### PR TITLE
Updating coveragerc to not pull in everything.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,5 +5,5 @@ omit =
     develop-eggs/*
     eggs/*
     */site-packages/*
-       */python3.4/distutils/*
+    */python3.4/distutils/*
     tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,9 @@
 [report]
 omit =
     mesa/tests/*
+    bin/*
+    develop-eggs/*
+    eggs/*
+    */site-packages/*
+       */python3.4/distutils/*
+    tests/*


### PR DESCRIPTION
As discussed.... this is part 1 of #106 --- this updates coveragerc to not test everything so that our test stats return with more accurate numbers. 