### PR TITLE
Fixed move_agent method

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -220,9 +220,8 @@ class Grid(object):
                    stored in a 'pos' tuple.
             pos: Tuple of new position to move the agent to.
         '''
-
-        self._place_agent(pos, agent)
         self._remove_agent(agent.pos, agent)
+        self._place_agent(pos, agent)
         agent.pos = pos
 
     def place_agent(self, agent, pos):


### PR DESCRIPTION
Order of operations reversed: agent is removed first and then it is placed. This closes #114 