### PR TITLE
Minor text cleanups - Readme related

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,3 @@
-.. Mesa documentation master file, created by
-   sphinx-quickstart on Sun Jan  4 23:34:09 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-
 Mesa: Agent-based modeling in Python 3+
 =========================================
 
@@ -13,21 +7,19 @@ Mesa: Agent-based modeling in Python 3+
 .. image:: https://coveralls.io/repos/projectmesa/mesa/badge.svg
     :target: https://coveralls.io/r/projectmesa/mesa
 
-`Mesa`_ is an Apache2 licensed agent-based modeling (or ABM) framework in Python 3+.
+`Mesa`_ is an Apache2 licensed agent-based modeling (or ABM) framework in Python.
 
-It allows users to quickly create agent-based models using built-in core components (such as spatial grids and agent schedulers) or customized implementations; visualize them using a browser-based interface; and analyze their results using Python's data analysis tools. It's goal is to be the Python 3-based alternative to NetLogo, Repast, or MASON.
+It allows users to quickly create agent-based models using built-in core components (such as spatial grids and agent schedulers) or customized implementations; visualize them using a browser-based interface; and analyze their results using Python's data analysis tools. Its goal is to be the Python 3-based alternative to NetLogo, Repast, or MASON.
 
 
 .. image:: https://cloud.githubusercontent.com/assets/166734/8611697/ce61ad08-268a-11e5-880b-4776dd738e0e.png
    :width: 100%
    :scale: 100%
-   :alt: A screenshot of the Shelling Model in Mesa
+   :alt: A screenshot of the Schelling Model in Mesa
 
 *Above: A Mesa implementation of the Schelling segregation model,
 being visualized in a browser window and analyzed in an IPython
 notebook.*
-
-
 
 .. _`Mesa` : https://github.com/projectmesa/mesa/
 
@@ -35,7 +27,7 @@ notebook.*
 Features
 ------------
 
-* Modular compoments
+* Modular components
 * Browser-based visualization
 * Built-in tools for analysis
 
@@ -48,7 +40,7 @@ Getting started quickly:
 
     $ pip install mesa
 
-For more help on using Mesa, checkout the following resources:
+For more help on using Mesa, check out the following resources:
 
 * `Intro to Mesa Tutorial`_
 * `Docs`_
@@ -63,7 +55,7 @@ For more help on using Mesa, checkout the following resources:
 Contributing back to Mesa
 ----------------------------
 
-If you run into an issues, please file a `ticket`_ for us to discuss. If possible, follow up with a pull request.
+If you run into an issue, please file a `ticket`_ for us to discuss. If possible, follow up with a pull request.
 
 If you would like to add a feature, please reach out via `ticket`_ or the `email list`_ for discussion. A feature is most likely to be added if you build it!
 
@@ -74,6 +66,7 @@ If you would like to add a feature, please reach out via `ticket`_ or the `email
 .. _`email list` : https://groups.google.com/d/forum/projectmesa
 .. _`Contributors guide` : https://github.com/projectmesa/mesa/blob/master/CONTRIBUTING.rst
 .. _`Github` : https://github.com/projectmesa/mesa/
+
 
 
 **Table of Contents**

--- a/setup.py
+++ b/setup.py
@@ -13,16 +13,6 @@ requires = [
 with open('README.rst', 'r', encoding='utf-8') as f:
     readme = f.read()
 
-# TODO: Rewrite Readme and pull that it instead.
-description = """
-    Mesa is an agent-based modeling (or ABM) framework in Python. It allows
-    users to quickly create agent-based models using built-in core components
-    (such as spatial grids and agent schedulers) or customized
-    implementations; visualize them using a browser-based interface; and
-    analyze their results using Python's data analysis tools. It's goal is
-    to be the Python 3-based alternative to NetLogo, Repast, or MASON.
-"""
-
 setup(
     name='Mesa',
     version='0.6.2',


### PR DESCRIPTION
This includes two minor text clean ups. 

1. Setup.py now pulls in Readme, so text string was ditched. 
2. Readme is also used as main text on the index page in the docs.