### PR TITLE
minor tweak to grid position list methods, resolve #177

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -23,6 +23,7 @@ RANDOM = -1
 X = 0
 Y = 1
 
+
 def accept_tuple_argument(wrapped_function):
     '''
     Decorator to allow grid methods that take a list of (x, y) position tuples
@@ -35,6 +36,7 @@ def accept_tuple_argument(wrapped_function):
         else:
             return wrapped_function(*args)
     return wrapper
+
 
 class Grid(object):
     '''

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -23,6 +23,18 @@ RANDOM = -1
 X = 0
 Y = 1
 
+def accept_tuple_argument(wrapped_function):
+    '''
+    Decorator to allow grid methods that take a list of (x, y) position tuples
+    to also handle a single position, by automatically wrapping tuple in
+    single-item list rather than forcing user to do it.
+    '''
+    def wrapper(*args):
+        if isinstance(args[1], tuple) and len(args[1]) == 2:
+            return wrapped_function(args[0], [args[1]])
+        else:
+            return wrapped_function(*args)
+    return wrapper
 
 class Grid(object):
     '''
@@ -238,10 +250,11 @@ class Grid(object):
         x, y = pos
         return x < 0 or x >= self.width or y < 0 or y >= self.height
 
+    @accept_tuple_argument
     def iter_cell_list_contents(self, cell_list):
         '''
         Args:
-            cell_list: Array-like of (x, y) tuples
+            cell_list: Array-like of (x, y) tuples, or single tuple.
 
         Returns:
             A iterator of the contents of the cells identified in cell_list
@@ -249,10 +262,11 @@ class Grid(object):
         return (
             self[y][x] for x, y in cell_list if not self.is_cell_empty((x, y)))
 
+    @accept_tuple_argument
     def get_cell_list_contents(self, cell_list):
         '''
         Args:
-            cell_list: Array-like of (x, y) tuples
+            cell_list: Array-like of (x, y) tuples, or single tuple.
 
         Returns:
             A list of the contents of the cells identified in cell_list
@@ -418,10 +432,11 @@ class MultiGrid(Grid):
         x, y = pos
         self.grid[y][x].remove(agent)
 
+    @accept_tuple_argument
     def iter_cell_list_contents(self, cell_list):
         '''
         Args:
-            cell_list: Array-like of (x, y) tuples
+            cell_list: Array-like of (x, y) tuples, or single tuple.
 
         Returns:
             A iterator of the contents of the cells identified in cell_list

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -83,7 +83,7 @@ class TestBaseGrid(unittest.TestCase):
     def test_listfree_iter_cell_agent_reporting(self):
         '''
         Ensure that if an agent is in a cell, iter_cell_list_contents
-        accuratelyreports that fact, even when single position is not
+        accurately reports that fact, even when single position is not
         wrapped in a list.
         '''
         for agent in self.agents:

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -73,8 +73,8 @@ class TestBaseGrid(unittest.TestCase):
 
     def test_iter_cell_agent_reporting(self):
         '''
-        Ensure that if an agent is in a cell, iter_cell_list_contents accurately
-        reports that fact.
+        Ensure that if an agent is in a cell, iter_cell_list_contents
+        accurately reports that fact.
         '''
         for agent in self.agents:
             x, y = agent.pos
@@ -82,13 +82,13 @@ class TestBaseGrid(unittest.TestCase):
 
     def test_listfree_iter_cell_agent_reporting(self):
         '''
-        Ensure that if an agent is in a cell, iter_cell_list_contents accurately
-        reports that fact, even when single position is not wrapped in a list.
+        Ensure that if an agent is in a cell, iter_cell_list_contents
+        accuratelyreports that fact, even when single position is not
+        wrapped in a list.
         '''
         for agent in self.agents:
             x, y = agent.pos
             assert agent in self.grid.iter_cell_list_contents((x, y))
-
 
     def test_neighbors(self):
         '''

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -53,6 +53,43 @@ class TestBaseGrid(unittest.TestCase):
             x, y = agent.pos
             assert self.grid[y][x] == agent
 
+    def test_cell_agent_reporting(self):
+        '''
+        Ensure that if an agent is in a cell, get_cell_list_contents accurately
+        reports that fact.
+        '''
+        for agent in self.agents:
+            x, y = agent.pos
+            assert agent in self.grid.get_cell_list_contents([(x, y)])
+
+    def test_listfree_cell_agent_reporting(self):
+        '''
+        Ensure that if an agent is in a cell, get_cell_list_contents accurately
+        reports that fact, even when single position is not wrapped in a list.
+        '''
+        for agent in self.agents:
+            x, y = agent.pos
+            assert agent in self.grid.get_cell_list_contents((x, y))
+
+    def test_iter_cell_agent_reporting(self):
+        '''
+        Ensure that if an agent is in a cell, iter_cell_list_contents accurately
+        reports that fact.
+        '''
+        for agent in self.agents:
+            x, y = agent.pos
+            assert agent in self.grid.iter_cell_list_contents([(x, y)])
+
+    def test_listfree_iter_cell_agent_reporting(self):
+        '''
+        Ensure that if an agent is in a cell, iter_cell_list_contents accurately
+        reports that fact, even when single position is not wrapped in a list.
+        '''
+        for agent in self.agents:
+            x, y = agent.pos
+            assert agent in self.grid.iter_cell_list_contents((x, y))
+
+
     def test_neighbors(self):
         '''
         Test the base neighborhood methods on the non-toroid.


### PR DESCRIPTION
Handling #177 --- applying a decorator to `get_cell_list_contents` as well as `iter_cell_list_contents` to allow them to accept a tuple rather than a list of tuples when passed a single position. 

Accompanied by: docstring updates for those methods, and 4 tests (two for original functionality, two for new functionality).  