### PR TITLE
Fix Schelling documentation

### DIFF
--- a/examples/Schelling/Readme.md
+++ b/examples/Schelling/Readme.md
@@ -3,29 +3,13 @@
 A simple implementation of a Schelling segregation model.
 
 
-Implemented here to test / demonstrate several Mesa concepts and features:
- - This version demonstrates the ASCII renderer.
-
+Implemented here to test / demonstrate several Mesa concepts and features.
 
 ### To run this example
 
-* Launch the model
-```python
-python Schelling.py
+* Launch the model with the browser visualization:
+```sh
+python SchellingModular.py
 ```
-* Visit your browser: http://127.0.0.1:8888/
+* Open your browser to: http://127.0.0.1:8888/
 * In your browser hit *reset*, then *run*
-
-
-To use with iPython, run this code from the command line, e.g.
-    $ ipython -i Schelling.py
-
-viz is the visualization wrapper around
-To print the current state of the model:
-    viz.render()
-
-To advance the model by one step and print the new state:
-    viz.step()
-
-To advance the model by e.g. 10 steps and print the new state:
-    viz.step_forward(10)

--- a/examples/Schelling/Schelling.py
+++ b/examples/Schelling/Schelling.py
@@ -3,21 +3,6 @@ Schelling Segregation Model
 =========================================
 
 A simple implementation of a Schelling segregation model.
-
-This version demonstrates the ASCII renderer.
-To use, run this code from the command line, e.g.
-    $ ipython -i Schelling.py
-
-viz is the visualization wrapper around
-To print the current state of the model:
-    viz.render()
-
-To advance the model by one step and print the new state:
-    viz.step()
-
-To advance the model by e.g. 10 steps and print the new state:
-    viz.step_forward(10)
-
 '''
 
 from __future__ import division  # For Python 2.x compatibility


### PR DESCRIPTION
The documentation for the Schelling example provided instructions which were no longer compatible with the code; trying to follow them would just lead to errors. I largely just removed the out-of-date instructions, leaving only one which works.