### PR TITLE
Reset visualization when websocket connection is opened

### DIFF
--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -36,7 +36,10 @@
 
 		// WebSocket Stuff
 		var ws = new WebSocket("ws://127.0.0.1:{{ port }}/ws"); // Open the websocket connection
-		ws.onopen = function() {console.log("Connection opened!"); };
+                ws.onopen = function() {
+                    console.log("Connection opened!");
+                    reset();
+                };
 
 		/**
 		Parse an incoming message


### PR DESCRIPTION
This is a UX enhancement to reset the visualization when the websocket connection is opened.

Demo:
build mesa: `python setup.py build`
try one of the examples, e.g. color_patches
```bash
cd examples/ColorPatches
python color_patches.py
```