### PR TITLE
Remove unused scipy dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - >
     conda create -q -n test-environment
     python=$TRAVIS_PYTHON_VERSION
-    coverage flake8 matplotlib nose numpy pandas pip scipy sympy tornado
+    coverage flake8 matplotlib nose numpy pandas pip tornado
   - source activate test-environment
   - pip install coveralls
   - pip install .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
-MOCK_MODULES = ['scipy', 'numpy', 'pandas']
+MOCK_MODULES = ['numpy', 'pandas']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # End of mock

--- a/docs/intro-tutorial.rst
+++ b/docs/intro-tutorial.rst
@@ -297,7 +297,7 @@ With that in mind, the agent's ``move`` method looks like this:
             model.grid.move_agent(self, new_position)
 
 
-Next, we need to get all the other agents present in a cell, and give one of them some money. We can get the contents of one or more cells using the grid's ``get_cell_list_contents`` method, or by accessing a cell directly. The method currently requires a list of cells (TODO: someone should probably fix that...), even if we only care about one cell.
+Next, we need to get all the other agents present in a cell, and give one of them some money. We can get the contents of one or more cells using the grid's ``get_cell_list_contents`` method, or by accessing a cell directly. The method accepts a list of cell coordinate tuples, or a single tuple if we only care about one cell.
 
 
 .. code-block:: python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 numpy
-scipy
 pandas==0.17.1
 ipython==4.1.1
-
 tornado==4.0.2
 flake8==2.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 numpy
 pandas==0.17.1
 ipython==4.1.1
+
+coverage==4.1
+nose==1.3.7
 tornado==4.0.2
 flake8==2.5.2


### PR DESCRIPTION
Also removes a dangling TODO in the intro tutorial that was solved with the `@accept_tuple_argument` decorator.