### PR TITLE
introduce a requirements.txt for the tutorial.

### DIFF
--- a/docs/intro-tutorial.rst
+++ b/docs/intro-tutorial.rst
@@ -36,7 +36,12 @@ To install Mesa, simply:
 
     $ pip install mesa
 
-When you do that, it will install Mesa itself, as well as any dependencies that aren't in your setup yet.
+When you do that, it will install Mesa itself, as well as any dependencies that aren't in your setup yet. Additional dependencies required by this tutorial can be found in the **examples/Tutorial-Boltzmann_Wealth_Model/requirements.txt** file, which can be installed by running:
+
+.. code-block:: bash
+
+    $ pip install -r requirements.txt
+
 
 
 Building a sample model

--- a/examples/Tutorial-Boltzmann_Wealth_Model/Readme.md
+++ b/examples/Tutorial-Boltzmann_Wealth_Model/Readme.md
@@ -8,4 +8,4 @@ This model is a tutorial contained in a Jupyter notebook
 
 ### To run this example
 
-You will need to open the file as a Jupyter (aka iPython) notebook with an iPython 3 kernel
+You will need to open the file as a Jupyter (aka iPython) notebook with an iPython 3 kernel. Required dependencies are listed in the provided `requirements.txt` file which can be installed by running `pip install -r requirements.txt`

--- a/examples/Tutorial-Boltzmann_Wealth_Model/requirements.txt
+++ b/examples/Tutorial-Boltzmann_Wealth_Model/requirements.txt
@@ -1,0 +1,4 @@
+jupyter
+matplotlib
+mesa
+numpy


### PR DESCRIPTION
The tutorial contains dependencies which the mesa project does not
explicitly require itself (such as matplotlib). Even though most users
of the mesa library will have a full scientific python environment it's
good to call this out explicitly.

I've added a requirements.txt to list every dependency needed to run
the tutorial example, including mesa itself.

The tutorial documentation is also updated to include steps for
installing the dependencies using the requirements.txt