### PR TITLE
Fixes issue #263. Provides support for text overlay on Circle and Rectangle shapes.

### DIFF
--- a/examples/WolfSheep/Readme.md
+++ b/examples/WolfSheep/Readme.md
@@ -9,6 +9,7 @@ If wolves and sheep have enough energy, they reproduce, creating a new wolf or s
 The model is tests and demonstrates several Mesa concepts and features:
  - MultiGrid
  - Multiple agent types (wolves, sheep, grass)
+ - Overlay arbitrary text (wolf's energy) on agent's shapes while drawing on CanvasGrid
  - Agents inheriting a behavior (random movement) from an abstract parent
  - Writing a model composed of multiple files.
  - Dynamically adding and removing agents from the schedule

--- a/examples/WolfSheep/wolf_sheep/server.py
+++ b/examples/WolfSheep/wolf_sheep/server.py
@@ -20,6 +20,9 @@ def wolf_sheep_portrayal(agent):
         portrayal["Color"] = "#AA0000"
         portrayal["r"] = 0.5
         portrayal["Layer"] = 2
+        portrayal["text"] = round(agent.energy, 1)
+        portrayal["text_color"] = "Yellow" 
+        
 
     elif type(agent) is GrassPatch:
         if agent.fully_grown:

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -56,7 +56,8 @@ Server -> Client:
     {
     "type": "viz_state",
     "data": [{0:[ {"Shape": "circle", "x": 0, "y": 0, "r": 0.5,
-                "Color": "#AAAAAA", "Filled": "true", "Layer": 0}]},
+                "Color": "#AAAAAA", "Filled": "true", "Layer": 0,
+                "text": 'A', "text_color": "white" }]},
             "Shape Count: 1"]
     }
 

--- a/mesa/visualization/modules/CanvasGridVisualization.py
+++ b/mesa/visualization/modules/CanvasGridVisualization.py
@@ -35,6 +35,11 @@ class CanvasGrid(VisualizationElement):
                   filled or not.
         "Layer": Layer number of 0 or above; higher-numbered layers are drawn
                  above lower-numbered layers.
+        "text": The text to be inscribed inside the Shape. Normally useful for
+                showing the unique_id of the agent.
+        "text_color": The color to draw the inscribed text. Should be given in
+                      conjunction of "text" property.
+
 
     Attributes:
         portrayal_method: Function which generates portrayals from objects, as

--- a/mesa/visualization/templates/GridDraw.js
+++ b/mesa/visualization/templates/GridDraw.js
@@ -92,10 +92,10 @@ var GridVisualization = function(height, width, gridHeight, gridWidth, context) 
                 
                 // This part draws the text inside the Circle
                 if (text !== undefined) {
-                        context.fillStyle = text_color 
-                        context.textAlign = 'center'
-                        context.textBaseline= 'middle'
-                        context.fillText(text, cx, cy)
+                        context.fillStyle = text_color;
+                        context.textAlign = 'center';
+                        context.textBaseline= 'middle';
+                        context.fillText(text, cx, cy);
                 }
 
 	};
@@ -127,12 +127,12 @@ var GridVisualization = function(height, width, gridHeight, gridWidth, context) 
 
                 // This part draws the text inside the Rectangle
                 if (text !== undefined) {
-        		var cx = (x + 0.5) * cellWidth;
-                  	var cy = (y + 0.5) * cellHeight;
-                        context.fillStyle = text_color 
-                        context.textAlign = 'center'
-                        context.textBaseline= 'middle'
-                        context.fillText(text, cx, cy)
+                        var cx = (x + 0.5) * cellWidth;
+                        var cy = (y + 0.5) * cellHeight;
+                        context.fillStyle = text_color;
+                        context.textAlign = 'center';
+                        context.textBaseline= 'middle';
+                        context.fillText(text, cx, cy);
                 }
 	};
 

--- a/mesa/visualization/templates/GridDraw.js
+++ b/mesa/visualization/templates/GridDraw.js
@@ -28,8 +28,8 @@ locations, represented by circles:
 	{"Shape": "rect", "x": 0, "y": 0, "w": 1, "h": 1, "Color": "#00aa00", "Filled": "true", "Layer": 0} 
    ],
  1: [
-	{"Shape": "circle", "x": 0, "y": 0, "r": 0.5, "Color": "#AAAAAA", "Filled": "true", "Layer": 1},
-	{"Shape": "circle", "x": 1, "y": 1, "r": 0.5, "Color": "#AAAAAA", "Filled": "true", "Layer": 1}
+	{"Shape": "circle", "x": 0, "y": 0, "r": 0.5, "Color": "#AAAAAA", "Filled": "true", "Layer": 1, "text": 'A', "text_color": "white"},
+	{"Shape": "circle", "x": 1, "y": 1, "r": 0.5, "Color": "#AAAAAA", "Filled": "true", "Layer": 1, "text": 'B', "text_color": "white"}
    ]
 }
 
@@ -53,9 +53,9 @@ var GridVisualization = function(height, width, gridHeight, gridWidth, context) 
 		for (var i in portrayalLayer) {
 			var p = portrayalLayer[i];
 			if (p.Shape == "rect")
-				this.drawRectange(p.x, p.y, p.w, p.h, p.Color, p.Filled);
+				this.drawRectange(p.x, p.y, p.w, p.h, p.Color, p.Filled, p.text, p.text_color);
 			if (p.Shape == "circle")
-				this.drawCircle(p.x, p.y, p.r, p.Color, p.Filled);
+				this.drawCircle(p.x, p.y, p.r, p.Color, p.Filled, p.text, p.text_color);
 		}
 	};
 
@@ -70,8 +70,10 @@ var GridVisualization = function(height, width, gridHeight, gridWidth, context) 
 		r: Radius, as a multiple of cell size
 		color: Code for the fill color
 		fill: Boolean for whether or not to fill the circle.
-	*/
-	this.drawCircle = function(x, y, radius, color, fill) {
+                text: Inscribed text in rectangle.
+                text_color: Color of the inscribed text.
+        */
+	this.drawCircle = function(x, y, radius, color, fill, text, text_color) {
 		var cx = (x + 0.5) * cellWidth;
 		var cy = (y + 0.5) * cellHeight;
 		var r = radius * maxR;
@@ -87,6 +89,14 @@ var GridVisualization = function(height, width, gridHeight, gridWidth, context) 
 			context.fillStyle = color;
 			context.fill();
 		}
+                
+                // This part draws the text inside the Circle
+                if (text !== undefined) {
+                        context.fillStyle = text_color 
+                        context.textAlign = 'center'
+                        context.textBaseline= 'middle'
+                        context.fillText(text, cx, cy)
+                }
 
 	};
 
@@ -96,8 +106,10 @@ var GridVisualization = function(height, width, gridHeight, gridWidth, context) 
 		w, h: Width and height, [0, 1]
 		color: Color for the rectangle
 		fill: Boolean, whether to fill or not.
+                text: Inscribed text in rectangle.
+                text_color: Color of the inscribed text.
 	*/
-	this.drawRectange = function(x, y, w, h, color, fill) {
+	this.drawRectange = function(x, y, w, h, color, fill, text, text_color) {
 		context.beginPath();
 		var dx = w * cellWidth;
 		var dy = h * cellHeight;
@@ -112,15 +124,21 @@ var GridVisualization = function(height, width, gridHeight, gridWidth, context) 
 			context.fillRect(x0, y0, dx, dy);
 		else
 			context.strokeRect(x0, y0, dx, dy);
+
+                // This part draws the text inside the Rectangle
+                if (text !== undefined) {
+        		var cx = (x + 0.5) * cellWidth;
+                  	var cy = (y + 0.5) * cellHeight;
+                        context.fillStyle = text_color 
+                        context.textAlign = 'center'
+                        context.textBaseline= 'middle'
+                        context.fillText(text, cx, cy)
+                }
 	};
 
 	/**
-		Draw a rectangle in the specified grid cell.
-		x, y: Grid coords
-		w, h: Width and height, [0, 1]
-		color: Color for the rectangle
-		fill: Boolean, whether to fill or not.
-	*/
+		Draw Grid lines in the full gird
+        */
 
 	this.drawGridLines = function() {
 		context.beginPath();


### PR DESCRIPTION
Hi, 
Just check once before merging it. Can be tested with attributes "text" and "text_color" as shown below

```
            portrayal = {"Shape": "rect",
                         "Filled": "true",
                         "Layer": 0,
                         "Color": "lightsalmon",
                         "w": 1.0,
                         "h": 1.0,
                         "text": agent.uid,
                         "text_color": "black"}
```