### PR TITLE
Updating kernel version on forest fire model.

### DIFF
--- a/examples/ForestFire/Forest Fire Model.ipynb
+++ b/examples/ForestFire/Forest Fire Model.ipynb
@@ -568,21 +568,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [se]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "Python [se]"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When checking #288, I received an error with regards to which kernel jupyter uses when the notebook is running. The was resolved by setting the kernel to Python3.

To test this, the notebook should be runnable when you open it with not pop up prompts asking you which kernel to use. (This assumes that you have a Python3 kernel for jupyter to use.)