### PR TITLE
Scheduler keeps track of agents in dict

### DIFF
--- a/examples/WolfSheep/wolf_sheep/agents.py
+++ b/examples/WolfSheep/wolf_sheep/agents.py
@@ -14,8 +14,8 @@ class Sheep(RandomWalker):
 
     energy = None
 
-    def __init__(self, pos, model, moore, energy=None):
-        super().__init__(pos, model, moore=moore)
+    def __init__(self, unique_id, pos, model, moore, energy=None):
+        super().__init__(unique_id, pos, model, moore=moore)
         self.energy = energy
 
     def step(self):
@@ -47,7 +47,8 @@ class Sheep(RandomWalker):
             # Create a new sheep:
             if self.model.grass:
                 self.energy /= 2
-            lamb = Sheep(self.pos, self.model, self.moore, self.energy)
+            lamb = Sheep(self.model.next_id(), self.pos, self.model,
+                         self.moore, self.energy)
             self.model.grid.place_agent(lamb, self.pos)
             self.model.schedule.add(lamb)
 
@@ -59,8 +60,8 @@ class Wolf(RandomWalker):
 
     energy = None
 
-    def __init__(self, pos, model, moore, energy=None):
-        super().__init__(pos, model, moore=moore)
+    def __init__(self, unique_id, pos, model, moore, energy=None):
+        super().__init__(unique_id, pos, model, moore=moore)
         self.energy = energy
 
     def step(self):
@@ -87,7 +88,8 @@ class Wolf(RandomWalker):
             if random.random() < self.model.wolf_reproduce:
                 # Create a new wolf cub
                 self.energy /= 2
-                cub = Wolf(self.pos, self.model, self.moore, self.energy)
+                cub = Wolf(self.model.next_id(), self.pos, self.model,
+                           self.moore, self.energy)
                 self.model.grid.place_agent(cub, cub.pos)
                 self.model.schedule.add(cub)
 
@@ -97,7 +99,7 @@ class GrassPatch(Agent):
     A patch of grass that grows at a fixed rate and it is eaten by sheep
     '''
 
-    def __init__(self, pos, model, fully_grown, countdown):
+    def __init__(self, unique_id, pos, model, fully_grown, countdown):
         '''
         Creates a new patch of grass
 
@@ -105,9 +107,10 @@ class GrassPatch(Agent):
             grown: (boolean) Whether the patch of grass is fully grown or not
             countdown: Time for the patch of grass to be fully grown again
         '''
-        super().__init__(pos, model)
+        super().__init__(unique_id, model)
         self.fully_grown = fully_grown
         self.countdown = countdown
+        self.pos = pos
 
     def step(self):
         if not self.fully_grown:

--- a/examples/WolfSheep/wolf_sheep/model.py
+++ b/examples/WolfSheep/wolf_sheep/model.py
@@ -60,7 +60,7 @@ class WolfSheepPredation(Model):
                                  once it is eaten
             sheep_gain_from_food: Energy sheep gain from grass, if enabled.
         '''
-
+        super().__init__()
         # Set parameters
         self.height = height
         self.width = width
@@ -84,7 +84,7 @@ class WolfSheepPredation(Model):
             x = random.randrange(self.width)
             y = random.randrange(self.height)
             energy = random.randrange(2 * self.sheep_gain_from_food)
-            sheep = Sheep((x, y), self, True, energy)
+            sheep = Sheep(self.next_id(), (x, y), self, True, energy)
             self.grid.place_agent(sheep, (x, y))
             self.schedule.add(sheep)
 
@@ -93,7 +93,7 @@ class WolfSheepPredation(Model):
             x = random.randrange(self.width)
             y = random.randrange(self.height)
             energy = random.randrange(2 * self.wolf_gain_from_food)
-            wolf = Wolf((x, y), self, True, energy)
+            wolf = Wolf(self.next_id(), (x, y), self, True, energy)
             self.grid.place_agent(wolf, (x, y))
             self.schedule.add(wolf)
 
@@ -108,7 +108,8 @@ class WolfSheepPredation(Model):
                 else:
                     countdown = random.randrange(self.grass_regrowth_time)
 
-                patch = GrassPatch((x, y), self, fully_grown, countdown)
+                patch = GrassPatch(self.next_id(), (x, y), self,
+                                   fully_grown, countdown)
                 self.grid.place_agent(patch, (x, y))
                 self.schedule.add(patch)
 

--- a/examples/WolfSheep/wolf_sheep/random_walk.py
+++ b/examples/WolfSheep/wolf_sheep/random_walk.py
@@ -21,7 +21,7 @@ class RandomWalker(Agent):
     y = None
     moore = True
 
-    def __init__(self, pos, model, moore=True):
+    def __init__(self, unique_id, pos, model, moore=True):
         '''
         grid: The MultiGrid object in which the agent lives.
         x: The agent's current x coordinate
@@ -29,7 +29,7 @@ class RandomWalker(Agent):
         moore: If True, may move in all 8 directions.
                 Otherwise, only up, down, left, right.
         '''
-        super().__init__(pos, model)
+        super().__init__(unique_id, model)
         self.pos = pos
         self.moore = moore
 

--- a/examples/WolfSheep/wolf_sheep/schedule.py
+++ b/examples/WolfSheep/wolf_sheep/schedule.py
@@ -14,11 +14,11 @@ class RandomActivationByBreed(RandomActivation):
 
     Assumes that all agents have a step() method.
     '''
-    agents_by_breed = defaultdict(list)
+    agents_by_breed = defaultdict(dict)
 
     def __init__(self, model):
         super().__init__(model)
-        self.agents_by_breed = defaultdict(list)
+        self.agents_by_breed = defaultdict(dict)
 
     def add(self, agent):
         '''
@@ -28,21 +28,19 @@ class RandomActivationByBreed(RandomActivation):
             agent: An Agent to be added to the schedule.
         '''
 
-        self.agents.append(agent)
+        self.agents[agent.unique_id] = agent
         agent_class = type(agent)
-        self.agents_by_breed[agent_class].append(agent)
+        self.agents_by_breed[agent_class][agent.unique_id] = agent
 
     def remove(self, agent):
         '''
         Remove all instances of a given agent from the schedule.
         '''
 
-        while agent in self.agents:
-            self.agents.remove(agent)
+        del self.agents[agent.unique_id]
 
         agent_class = type(agent)
-        while agent in self.agents_by_breed[agent_class]:
-            self.agents_by_breed[agent_class].remove(agent)
+        del self.agents_by_breed[agent_class][agent.unique_id]
 
     def step(self, by_breed=True):
         '''
@@ -67,13 +65,13 @@ class RandomActivationByBreed(RandomActivation):
         Args:
             breed: Class object of the breed to run.
         '''
-        agents = self.agents_by_breed[breed]
-        random.shuffle(agents)
-        for agent in agents:
-            agent.step()
+        agent_keys = list(self.agents_by_breed[breed].keys())
+        random.shuffle(agent_keys)
+        for agent_key in agent_keys:
+            self.agents_by_breed[breed][agent_key].step()
 
     def get_breed_count(self, breed_class):
         '''
         Returns the current number of agents of certain breed in the queue.
         '''
-        return len(self.agents_by_breed[breed_class])
+        return len(self.agents_by_breed[breed_class].values())

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -103,7 +103,7 @@ class BatchRunner:
     def collect_agent_vars(self, model):
         """ Run reporters and collect agent-level variables. """
         agent_vars = {}
-        for agent in model.schedule.agents:
+        for agent in model.schedule.agents.values():
             agent_record = {}
             for var, reporter in self.agent_reporters.items():
                 agent_record[var] = reporter(agent)

--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -139,7 +139,7 @@ class DataCollector:
         if self.agent_reporters:
             for var, reporter in self.agent_reporters.items():
                 agent_records = []
-                for agent in model.schedule.agents:
+                for agent in model.schedule.agents.values():
                     agent_records.append((agent.unique_id, reporter(agent)))
                 self.agent_vars[var].append(agent_records)
 

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -30,6 +30,7 @@ class Model:
         random.seed(seed)
         self.running = True
         self.schedule = None
+        self.current_id = 0
 
     def run_model(self):
         """ Run the model until the end condition is reached. Overload as
@@ -42,3 +43,8 @@ class Model:
     def step(self):
         """ A single step. Fill in here. """
         pass
+
+    def next_id(self):
+        """ Return the next unique ID for agents, increment current_id"""
+        self.current_id += 1
+        return self.current_id

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -99,7 +99,7 @@ class RandomActivation(BaseScheduler):
         """
         agent_keys = list(self.agents.keys())
         random.shuffle(agent_keys)
-        
+
         for agent_key in agent_keys:
             self.agents[agent_key].step()
         self.steps += 1

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -73,7 +73,7 @@ class BaseScheduler:
         """ Execute the step of all the agents, one at a time. """
         agent_keys = list(self.agents.keys())
         for agent_key in agent_keys:
-            self.agents[agent_key].step(self.model)
+            self.agents[agent_key].step()
         self.steps += 1
         self.time += 1
 
@@ -101,7 +101,7 @@ class RandomActivation(BaseScheduler):
         random.shuffle(agent_keys)
         
         for agent_key in agent_keys:
-            self.agents[agent_key].step(self.model)
+            self.agents[agent_key].step()
         self.steps += 1
         self.time += 1
 
@@ -118,9 +118,9 @@ class SimultaneousActivation(BaseScheduler):
         """ Step all agents, then advance them. """
         agent_keys = list(self.agents.keys())
         for agent_key in agent_keys:
-            self.agents[agent_key].step(self.model)
+            self.agents[agent_key].step()
         for agent_key in agent_keys:
-            self.agents[agent_key].advance(self.model)
+            self.agents[agent_key].advance()
         self.steps += 1
         self.time += 1
 

--- a/tests/test_batchrunner.py
+++ b/tests/test_batchrunner.py
@@ -92,3 +92,6 @@ class TestBatchRunner(unittest.TestCase):
             len(self.params['model_param']) * \
             self.iterations
         assert agent_vars.shape == (rows, 6)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -61,7 +61,7 @@ class TestDataCollector(unittest.TestCase):
         for i in range(7):
             self.model.step()
         # Write to table:
-        for agent in self.model.schedule.agents:
+        for agent in self.model.schedule.agents.values():
             agent.write_final_values()
 
     def test_model_vars(self):
@@ -117,3 +117,6 @@ class TestDataCollector(unittest.TestCase):
 
         with self.assertRaises(Exception):
             table_df = data_collector.get_table_dataframe("not a real table")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -317,3 +317,6 @@ class TestMultiGrid(unittest.TestCase):
 
         neighbors = self.grid.get_neighbors((1, 3), moore=False, radius=2)
         assert len(neighbors) == 11
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -54,18 +54,19 @@ class FiniteLifeAgent(Agent):
         super().__init__(unique_id, model)
         self.remaining_life = lifetime
         self.steps = 0
+        self.model = model
 
-    def step(self, model):
-        inactivated = self.inactivate(model)
+    def step(self):
+        inactivated = self.inactivate()
         if not inactivated:
             self.steps += 1 # keep track of how many ticks are seen
             if np.random.binomial(1,0.1) is not 0: # 10% chance of dying
-                model.schedule.remove(self)
+                self.model.schedule.remove(self)
             
-    def inactivate(self, model):
+    def inactivate(self):
         self.remaining_life -= 1
         if self.remaining_life < 0:
-            model.schedule.remove(self)
+            self.model.schedule.remove(self)
             return True
         return False
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,96 @@
+import unittest
+
+from mesa.time import RandomActivation
+from mesa.datacollection import DataCollector
+from mesa import *
+import numpy as np
+
+class LifeTimeModel(Model):
+    '''Simple model for running models with a finite life'''
+    def __init__(self, agent_lifetime = 1, n_agents = 10):
+        super().__init__()
+        
+        self.agent_lifetime = agent_lifetime
+        self.n_agents = n_agents
+
+        ## keep track of the the remaining life of an agent and
+        ## how many ticks it has seen
+        self.datacollector = DataCollector(
+            agent_reporters = {"remaining_life" : lambda a: a.remaining_life,
+                               "steps" : lambda a: a.steps})
+        
+        self.current_ID = 0
+        self.schedule = RandomActivation(self)
+        
+        for _ in range(n_agents):
+            self.schedule.add(FiniteLifeAgent(self.next_id(),
+                                              self.agent_lifetime,
+                                              self))
+
+    def step(self):
+        '''Add agents back to n_agents in each step'''
+        
+        self.datacollector.collect(self)
+        self.schedule.step()
+        
+        if len(self.schedule.agents) < self.n_agents:
+            for _ in range(self.n_agents - len(self.schedule.agents)):
+                self.schedule.add(FiniteLifeAgent(self.next_id(),
+                                                  self.agent_lifetime,
+                                                  self))
+
+    def run_model(self, step_count = 100):
+        for _ in range(step_count):
+            self.step()
+
+class FiniteLifeAgent(Agent):
+    
+    '''An agent that is supposed to live for a finite number of ticks.
+    Also has a 10% chance of dying in each tick.
+
+    '''
+    
+    def __init__(self, unique_id, lifetime, model):
+        super().__init__(unique_id, model)
+        self.remaining_life = lifetime
+        self.steps = 0
+
+    def step(self, model):
+        inactivated = self.inactivate(model)
+        if not inactivated:
+            self.steps += 1 # keep track of how many ticks are seen
+            if np.random.binomial(1,0.1) is not 0: # 10% chance of dying
+                model.schedule.remove(self)
+            
+    def inactivate(self, model):
+        self.remaining_life -= 1
+        if self.remaining_life < 0:
+            model.schedule.remove(self)
+            return True
+        return False
+
+
+class TestAgentLifespan(unittest.TestCase):
+    def setUp(self):
+        self.model = LifeTimeModel()
+        self.model.run_model()
+        self.df = self.model.datacollector.get_agent_vars_dataframe()
+        self.df = self.df.reset_index()
+        
+    def test_ticks_seen(self):
+        '''Each agent should be activated no more than one time'''
+        assert self.df.steps.max() == 1
+
+    def test_agent_lifetime(self):
+        lifetimes = self.df.groupby(["AgentID"]).Step.agg({"Step" : lambda x: len(x)})
+        print( lifetimes.Step.max() )
+        assert lifetimes.Step.max() == 2
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+        
+        
+
+    

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -2,26 +2,27 @@ import unittest
 
 from mesa.time import RandomActivation
 from mesa.datacollection import DataCollector
-from mesa import *
+from mesa import Model, Agent
 import numpy as np
+
 
 class LifeTimeModel(Model):
     '''Simple model for running models with a finite life'''
-    def __init__(self, agent_lifetime = 1, n_agents = 10):
+    def __init__(self, agent_lifetime=1, n_agents=10):
         super().__init__()
-        
+
         self.agent_lifetime = agent_lifetime
         self.n_agents = n_agents
 
-        ## keep track of the the remaining life of an agent and
-        ## how many ticks it has seen
+        # keep track of the the remaining life of an agent and
+        # how many ticks it has seen
         self.datacollector = DataCollector(
-            agent_reporters = {"remaining_life" : lambda a: a.remaining_life,
-                               "steps" : lambda a: a.steps})
-        
+            agent_reporters={"remaining_life": lambda a: a.remaining_life,
+                             "steps": lambda a: a.steps})
+
         self.current_ID = 0
         self.schedule = RandomActivation(self)
-        
+
         for _ in range(n_agents):
             self.schedule.add(FiniteLifeAgent(self.next_id(),
                                               self.agent_lifetime,
@@ -29,27 +30,24 @@ class LifeTimeModel(Model):
 
     def step(self):
         '''Add agents back to n_agents in each step'''
-        
         self.datacollector.collect(self)
         self.schedule.step()
-        
+
         if len(self.schedule.agents) < self.n_agents:
             for _ in range(self.n_agents - len(self.schedule.agents)):
                 self.schedule.add(FiniteLifeAgent(self.next_id(),
                                                   self.agent_lifetime,
                                                   self))
 
-    def run_model(self, step_count = 100):
+    def run_model(self, step_count=100):
         for _ in range(step_count):
             self.step()
 
+
 class FiniteLifeAgent(Agent):
-    
     '''An agent that is supposed to live for a finite number of ticks.
     Also has a 10% chance of dying in each tick.
-
     '''
-    
     def __init__(self, unique_id, lifetime, model):
         super().__init__(unique_id, model)
         self.remaining_life = lifetime
@@ -59,10 +57,10 @@ class FiniteLifeAgent(Agent):
     def step(self):
         inactivated = self.inactivate()
         if not inactivated:
-            self.steps += 1 # keep track of how many ticks are seen
-            if np.random.binomial(1,0.1) is not 0: # 10% chance of dying
+            self.steps += 1  # keep track of how many ticks are seen
+            if np.random.binomial(1, 0.1) is not 0:  # 10% chance of dying
                 self.model.schedule.remove(self)
-            
+
     def inactivate(self):
         self.remaining_life -= 1
         if self.remaining_life < 0:
@@ -77,21 +75,15 @@ class TestAgentLifespan(unittest.TestCase):
         self.model.run_model()
         self.df = self.model.datacollector.get_agent_vars_dataframe()
         self.df = self.df.reset_index()
-        
+
     def test_ticks_seen(self):
         '''Each agent should be activated no more than one time'''
         assert self.df.steps.max() == 1
 
     def test_agent_lifetime(self):
-        lifetimes = self.df.groupby(["AgentID"]).Step.agg({"Step" : lambda x: len(x)})
-        print( lifetimes.Step.max() )
+        lifetimes = self.df.groupby(["AgentID"]).Step.agg({"Step":
+                                                           lambda x: len(x)})
         assert lifetimes.Step.max() == 2
-
 
 if __name__ == '__main__':
     unittest.main()
-
-        
-        
-
-    

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -100,3 +100,6 @@ class TestSpaceNonToroidal(unittest.TestCase):
 
         neighbors_3 = self.space.get_neighbors((-30, -30), 10)
         assert len(neighbors_3) == 0
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -88,7 +88,8 @@ class TestStagedActivation(TestCase):
         '''
         model = MockModel(shuffle=False)
         model.step()
-        assert model.log == self.expected_output
+        model.step()
+        assert all([i==j for i,j in zip(model.log[:4], model.log[4:])])
 
     def test_shuffle(self):
         '''

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -22,7 +22,7 @@ class MockAgent(Agent):
         super().__init__(unique_id, model)
         self.steps = 0
         self.advances = 0
-    
+
     def stage_one(self):
         self.model.log.append(self.unique_id + "_1")
 
@@ -34,6 +34,7 @@ class MockAgent(Agent):
 
     def step(self):
         self.steps += 1
+
 
 class MockModel(Model):
 
@@ -89,7 +90,7 @@ class TestStagedActivation(TestCase):
         model = MockModel(shuffle=False)
         model.step()
         model.step()
-        assert all([i==j for i,j in zip(model.log[:4], model.log[4:])])
+        assert all([i == j for i, j in zip(model.log[:4], model.log[4:])])
 
     def test_shuffle(self):
         '''
@@ -166,8 +167,6 @@ class TestSimultaneousActivation(TestCase):
         '''
         Test the simultaneous activation step causes each agent to step
         '''
-
-        
         model = MockModel(activation=SIMULTANEOUS)
         model.step()
         # one step for each of 2 agents


### PR DESCRIPTION
@jackiekazil 

Hello! I think this would resolve #302 . I've changed the scheduler to handle a dict rather than a list. I added a `next_id()` method to Model to dispense `unique_id`s for agents. I've made WolfSheep and the tests compatible with the change, and added a test for whether the lifespan of agents with a finite life is what they should be. I haven't messed with the docs or other examples, but I could work on that if y'all'd like. 

Since this is my first pull request, please let me know if I've messed anything up!

best,
Colin
