### PR TITLE
On-demand model stepping rather than an endless buffer

### DIFF
--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -82,7 +82,6 @@
 		*/
 		var reset = function() {
 			control.tick = 0;
-			control.running = true;
 			send({"type": "reset"});
 
 			// Reset all the visualizations
@@ -94,26 +93,32 @@
 		/**
 		Send a message to the server get the next visualization state.
 		*/
+
+		var single_step = function() {
+			control.tick += 1;
+			send({"type": "get_step", "step": control.tick});
+		};
 		var step = function() {
-			if(control.running) {
-				control.tick += 1;
-				send({"type": "get_step", "step": control.tick});
-			}
+			if (!control.running) {single_step()}
+			else {run()};
 		};
 		/**
 		Call the step function at fixed intervals, until getting an end message from the server.
 		*/
 		var run = function() {
-			player = setInterval(function() {
-				if (!control.running) clearInterval(player);
-				step();
-			}, 1000/control.fps);
-		};
-		/**
-		Pause the run() function, but leave all other variables as they are.
-		*/
-		var pause = function() {
-			clearInterval(player);
+			if (control.running) {
+				control.running = false;
+				runController.name("run");
+				if (player) {
+					clearInterval(player);
+					player = null;
+				}
+			}
+			else {
+				control.running = true;
+				runController.name("stop");
+				player = setInterval(single_step, 1000/control.fps);
+			}
 		};
 	</script>
 	
@@ -136,15 +141,17 @@
 	// Create the buttons
 	gui.add(this, "reset"); 
 	gui.add(this, "step");
-	gui.add(this, "run");
-	gui.add(this, "pause");
+	var runController = gui.add(this, "run");
 
 	/**
-	Called when the user releases the fps slider; pause the model and rerun, to reset the fps
+	Called when the user releases the fps slider; if already running, stop and
+    start again to reset the fps
 	*/
 	fps_control.onFinishChange(function(value) {
-		pause();
-		run();
+		if (control.running) {
+			run();
+			run();
+		}
 	});
 
 	// Element-specific scripts go here:


### PR DESCRIPTION
Also some tweaks to how the controls work - eg. the run button
starts and stops automatic stepping of the model, and the name
toggles between "run" and "stop" as you click it.

(This was originally #238, which I've closed; this version is slightly improved, rebased, and targeted at master instead of the old pyconsprints branch.)