### PR TITLE
Updating contribution to prevent future travis breaks

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,36 +19,52 @@ No contribution is too small. Although, contributions can be too big, so let's d
 - Fork the Mesa repository.
 - Create a new branch if you aren't contributing to an existing branch.
 - Edit the code.
-- Use `PEP8`_ and the `Google Style Guide`_ as the coding standards for Python
 - If implementing a new feature, include some documentation.
-- Make sure that you contribution will pass Travis build by having flake8 come back with no errors and make sure test coverage has not decreased.
-
-    - Install libraries to review: ``pip install flake8 nose``
-    - To run flake8: ``flake8 . --ignore=F403,E501,E123,E128 --exclude=docs,build``
-    - To see test coverage: ``nosetests --with-coverage --cover-package=mesa``
+- Make sure that your submission passes the `Travis build`_. See "Testing and Standards below".
 - Submit as a pull request.
 - Describe the change w/ ticket number(s) that the code fixes.
 
 .. _`email list` : https://groups.google.com/forum/#!forum/projectmesa
 .. _`an issue` : https://github.com/projectmesa/mesa/issues
-.. _`PEP8` : https://www.python.org/dev/peps/pep-0008
-.. _`Google Style Guide` : https://google.github.io/styleguide/pyguide.html
+.. _`Travis build` : https://travis-ci.org/projectmesa/mesa 
 
 
-Testing
+Testing and Code Standards
 --------
 
 .. image:: https://coveralls.io/repos/projectmesa/mesa/badge.svg
     :target: https://coveralls.io/r/projectmesa/mesa
-
-We are continually working to improve our testing. At the moment, we've been testing features by implementing them in simple models. This is useful since it also expands the library of sample models. We also have several traditional unit tests in the tests/ folder.
+    
+As part of our contribution process, we practice continuous integration and use Travis to help enforce best practices. 
 
 If you're changing previous Mesa features, please make sure of the following:
 
 - Your changes pass the current tests.
+- Your changes pass our style standards.
 - Your changes don't break the models or your changes include updated models.
 - Additional features or rewrites of current features are accompanied by tests.
 - New features are demonstrated in a model, so folks can understand more easily.
+
+To ensure that your submission will not break the build, you will need to install Flake8 and Nose. 
+
+.. code-block:: bash
+
+    pip install flake8 nose
+
+We test by implementing simple models and through traditional unit tests in the tests/ folder. The following only covers unit tests coverage. Ensure that your test coverage has not gone down. If it has and you need help, we will offer advice on how to structure tests for the contribution.
+
+.. code-block:: bash
+
+    nosetests --with-coverage --cover-package=mesa
+
+With respect to code standards, we follow `PEP8`_ and the `Google Style Guide`_. If the command below generates errors, fix all errors that are returned. 
+
+.. code-block:: bash
+
+    flake8 . --ignore=F403,E501,E123,E128 --exclude=docs,build
+
+.. _`PEP8` : https://www.python.org/dev/peps/pep-0008
+.. _`Google Style Guide` : https://google.github.io/styleguide/pyguide.html
 
 
 Licensing

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,9 +19,14 @@ No contribution is too small. Although, contributions can be too big, so let's d
 - Fork the Mesa repository.
 - Create a new branch if you aren't contributing to an existing branch.
 - Edit the code.
-- Use `PEP8`_ and the `Google Style Guide`_ as the coding standards for Python.
-- If implementing a new feature, include some documentation and ideally a working example or unit test as well.
-- Submit as pull requests.
+- Use `PEP8`_ and the `Google Style Guide`_ as the coding standards for Python
+- If implementing a new feature, include some documentation.
+- Make sure that you contribution will pass Travis build by having flake8 come back with no errors and make sure test coverage has not decreased.
+
+    - Install libraries to review: ``pip install flake8 nose``
+    - To run flake8: ``flake8 . --ignore=F403,E501,E123,E128 --exclude=docs,build``
+    - To see test coverage: ``nosetests --with-coverage --cover-package=mesa``
+- Submit as a pull request.
 - Describe the change w/ ticket number(s) that the code fixes.
 
 .. _`email list` : https://groups.google.com/forum/#!forum/projectmesa


### PR DESCRIPTION
Updating contribution to prevent future travis breaks -- this is because this seems like something that has come up a few times. Also, I promised someone at Scipy that I would explicitly do this.

To preview changes in prettier format than commits: 
https://github.com/projectmesa/mesa/blob/contribution-clarification/CONTRIBUTING.rst 
