### PR TITLE
fix boundaries of ContinousSpace

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -592,5 +592,5 @@ class ContinuousSpace:
     def out_of_bounds(self, pos):
         """ Check if a point is out of bounds. """
         x, y = pos
-        return (x < self.x_min or x > self.x_max or
-                y < self.y_min or y > self.y_max)
+        return (x < self.x_min or x >= self.x_max or
+                y < self.y_min or y >= self.y_max)

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -4,7 +4,7 @@ from mesa.space import ContinuousSpace
 from test_grid import MockAgent
 
 TEST_AGENTS = [(-20, -20), (-20, -20.05), (65, 18)]
-
+OUTSIDE_POSITIONS = [(70, 10), (30, 20), (100, 10)]
 
 class TestSpaceToroidal(unittest.TestCase):
     '''
@@ -54,6 +54,25 @@ class TestSpaceToroidal(unittest.TestCase):
         neighbors_3 = self.space.get_neighbors((-30, -30), 10)
         assert len(neighbors_3) == 1
 
+    def test_bounds(self):
+        '''
+        Test positions outside of boundary
+        '''
+        boundary_agents = []
+        for i, pos in enumerate(OUTSIDE_POSITIONS):
+            a = MockAgent(len(self.agents) + i, None)
+            boundary_agents.append(a)
+            self.space.place_agent(a, pos)
+
+        for a, pos in zip(boundary_agents, OUTSIDE_POSITIONS):
+            adj_pos = self.space.torus_adj(pos)
+            assert a.pos == adj_pos
+
+        a = self.agents[0]
+        for pos in OUTSIDE_POSITIONS:
+            assert self.space.out_of_bounds(pos)
+            self.space.move_agent(a, pos)
+
 
 class TestSpaceNonToroidal(unittest.TestCase):
     '''
@@ -100,3 +119,18 @@ class TestSpaceNonToroidal(unittest.TestCase):
 
         neighbors_3 = self.space.get_neighbors((-30, -30), 10)
         assert len(neighbors_3) == 0
+
+    def test_bounds(self):
+        '''
+        Test positions outside of boundary
+        '''
+        for i, pos in enumerate(OUTSIDE_POSITIONS):
+            a = MockAgent(len(self.agents) + i, None)
+            with self.assertRaises(Exception):
+                self.space.place_agent(a, pos)
+
+        a = self.agents[0]
+        for pos in OUTSIDE_POSITIONS:
+            assert self.space.out_of_bounds(pos)
+            with self.assertRaises(Exception):
+                self.space.move_agent(a, pos)

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -6,6 +6,7 @@ from test_grid import MockAgent
 TEST_AGENTS = [(-20, -20), (-20, -20.05), (65, 18)]
 OUTSIDE_POSITIONS = [(70, 10), (30, 20), (100, 10)]
 
+
 class TestSpaceToroidal(unittest.TestCase):
     '''
     Testing a toroidal continuous space.


### PR DESCRIPTION
An IndexOutOfBounds Exception was thrown when an agent was placed at either the x_max or y_max in a ContinuousSpace.  My simple fix was to have the `out_of_bounds` function use a >= comparison instead of >.  I also added some tests of these boundaries in test_space.py
