### PR TITLE
implement "end" message in visualization

### DIFF
--- a/examples/forest_fire/forest_fire/model.py
+++ b/examples/forest_fire/forest_fire/model.py
@@ -5,7 +5,7 @@ from mesa.datacollection import DataCollector
 from mesa.space import Grid
 from mesa.time import RandomActivation
 
-from examples.ForestFire.forest_fire.agent import TreeCell
+from .agent import TreeCell
 
 
 class ForestFire(Model):

--- a/examples/forest_fire/run.py
+++ b/examples/forest_fire/run.py
@@ -1,3 +1,3 @@
-from examples.ForestFire.forest_fire.server import server
+from forest_fire.server import server
 
 server.launch()

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -167,9 +167,12 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
         msg = tornado.escape.json_decode(message)
 
         if msg["type"] == "get_step":
-            self.application.model.step()
-            self.write_message({"type": "viz_state",
-                    "data": self.application.render_model()})
+            if not self.application.ui_model.running:
+                self.write_message({"type": "end"})
+            else:
+                self.application.model.step()
+                self.write_message({"type": "viz_state",
+                        "data": self.application.render_model()})
 
         elif msg["type"] == "reset":
             self.application.reset_model()

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -167,7 +167,7 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
         msg = tornado.escape.json_decode(message)
 
         if msg["type"] == "get_step":
-            if not self.application.ui_model.running:
+            if not self.application.model.running:
                 self.write_message({"type": "end"})
             else:
                 self.application.model.step()

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -97,10 +97,8 @@
 		*/
 
 		var single_step = function() {
-			if (control.running) {
-				control.tick += 1;
-				send({"type": "get_step", "step": control.tick});
-			}
+			control.tick += 1;
+			send({"type": "get_step", "step": control.tick});
 		};
 		var step = function() {
 			if (!control.running) {single_step()}

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -62,6 +62,8 @@
 				case "end":
 					// We have reached the end of the model
 					control.running = false;
+					clearInterval(player);
+					runController.name("run");
 					break;
 				default:
 					// There shouldn't be any other message
@@ -95,8 +97,10 @@
 		*/
 
 		var single_step = function() {
-			control.tick += 1;
-			send({"type": "get_step", "step": control.tick});
+			if (control.running) {
+				control.tick += 1;
+				send({"type": "get_step", "step": control.tick});
+			}
 		};
 		var step = function() {
 			if (!control.running) {single_step()}


### PR DESCRIPTION
It looks like support for terminating simulations was designed but not finished in the visualization code.  This PR sends the "end" message from the Tornado server to the browser as a websocket message when `model.running` is false.  The client-side javascript was also updated to stop the simulation when the "end" message is received.

The Forest Fire example can be used to demonstrate this change.