### PR TITLE
Modified loop over agents in schedule step method

### DIFF
--- a/mesa/time.py
+++ b/mesa/time.py
@@ -72,7 +72,7 @@ class BaseScheduler:
 
     def step(self):
         """ Execute the step of all the agents, one at a time. """
-        for agent in self.agents:
+        for agent in self.agents[:]:
             agent.step()
         self.steps += 1
         self.time += 1
@@ -98,7 +98,7 @@ class RandomActivation(BaseScheduler):
 
         """
         random.shuffle(self.agents)
-        for agent in self.agents:
+        for agent in self.agents[:]:
             agent.step()
         self.steps += 1
         self.time += 1
@@ -114,9 +114,9 @@ class SimultaneousActivation(BaseScheduler):
     """
     def step(self):
         """ Step all agents, then advance them. """
-        for agent in self.agents:
+        for agent in self.agents[:]:
             agent.step()
-        for agent in self.agents:
+        for agent in self.agents[:]:
             agent.advance()
         self.steps += 1
         self.time += 1
@@ -164,7 +164,7 @@ class StagedActivation(BaseScheduler):
         if self.shuffle:
             random.shuffle(self.agents)
         for stage in self.stage_list:
-            for agent in self.agents:
+            for agent in self.agents[:]:
                 getattr(agent, stage)()  # Run stage
             if self.shuffle_between_stages:
                 random.shuffle(self.agents)


### PR DESCRIPTION
This addresses both #352 and #302, basically the same issue
If agents are deleted while looping over agents list in the model schedule,
looping becomes unpredictable and agents step methods for some agents may not be called for a given model step
A simple solution seems to be to iterate over a shallow copy of the agent list by using [:]
A shallow copy constructs a new compound object and then (to the extent possible) inserts references into it to the objects found in the original. So the objects we get from iteration are referencing the originals, but the copied list is not modified if agents are removed

A dict implementation could still be a preferable solution in terms of performance ( see #305) , but this one should have less impact