### PR TITLE
Fix math problems in flockers; use numpy in space

### DIFF
--- a/examples/Flockers/flockers/model.py
+++ b/examples/Flockers/flockers/model.py
@@ -21,40 +21,50 @@ class BoidModel(Model):
     Flocker model class. Handles agent creation, placement and scheduling.
     '''
 
-    def __init__(self, N, width, height, speed, vision, separation):
+    def __init__(self,
+                 population=100,
+                 width=100,
+                 height=100,
+                 speed=1,
+                 vision=10,
+                 separation=2,
+                 cohere=0.025,
+                 separate=0.25,
+                 match=0.04):
         '''
         Create a new Flockers model.
 
         Args:
-            N: Number of Boids
+            population: Number of Boids
             width, height: Size of the space.
             speed: How fast should the Boids move.
             vision: How far around should each Boid look for its neighbors
-            separtion: What's the minimum distance each Boid will attempt to
-                       keep from any other
-        '''
-        self.N = N
+            separation: What's the minimum distance each Boid will attempt to
+                    keep from any other
+            cohere, separate, match: factors for the relative importance of
+                    the three drives.        '''
+        self.population = population
         self.vision = vision
         self.speed = speed
         self.separation = separation
         self.schedule = RandomActivation(self)
         self.space = ContinuousSpace(width, height, True,
                                      grid_width=10, grid_height=10)
+        self.factors = dict(cohere=cohere, separate=separate, match=match)
         self.make_agents()
         self.running = True
 
     def make_agents(self):
         '''
-        Create N agents, with random positions and starting headings.
+        Create self.population agents, with random positions and starting headings.
         '''
-        for i in range(self.N):
+        for i in range(self.population):
             x = random.random() * self.space.x_max
             y = random.random() * self.space.y_max
-            pos = (x, y)
-            heading = np.random.random(2) * 2 - np.array((1, 1))
-            heading /= np.linalg.norm(heading)
-            boid = Boid(i, self, pos, self.speed, heading, self.vision,
-                        self.separation)
+            pos = np.array((x, y))
+            velocity = np.random.random(2) * 2 - 1
+            boid = Boid(i, self, pos, self.speed, velocity, self.vision,
+                        self.separation, **self.factors)
             self.space.place_agent(boid, pos)
             self.schedule.add(boid)
 

--- a/examples/Flockers/flockers/server.py
+++ b/examples/Flockers/flockers/server.py
@@ -9,4 +9,4 @@ def boid_draw(agent):
 
 boid_canvas = SimpleCanvas(boid_draw, 500, 500)
 server = ModularServer(BoidModel, [boid_canvas], "Boids",
-                       100, 100, 100, 5, 10, 2)
+                       100, 100, 100, 1, 10, 2)

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -42,6 +42,15 @@ class TestSpaceToroidal(unittest.TestCase):
         pos_3 = (-30, -20)
         assert self.space.get_distance(pos_1, pos_3) == 10
 
+    def test_heading(self):
+        pos_1 = (-30, -30)
+        pos_2 = (70, 20)
+        self.assertEqual((0, 0), self.space.get_heading(pos_1, pos_2))
+
+        pos_1 = (65, -25)
+        pos_2 = (-25, -25)
+        self.assertEqual((10, 0), self.space.get_heading(pos_1, pos_2))
+
     def test_neighborhood_retrieval(self):
         '''
         Test neighborhood retrieval
@@ -107,6 +116,15 @@ class TestSpaceNonToroidal(unittest.TestCase):
         pos_2 = (70, 20)
         pos_3 = (-30, -20)
         assert self.space.get_distance(pos_2, pos_3) == 107.70329614269008
+
+    def test_heading(self):
+        pos_1 = (-30, -30)
+        pos_2 = (70, 20)
+        self.assertEqual((100, 50), self.space.get_heading(pos_1, pos_2))
+
+        pos_1 = (65, -25)
+        pos_2 = (-25, -25)
+        self.assertEqual((-90, 0), self.space.get_heading(pos_1, pos_2))
 
     def test_neighborhood_retrieval(self):
         '''


### PR DESCRIPTION
This changes how ContinuousSpace.get_distance works, making it us numpy arrays internally, and adds a get_heading method. The latter takes the toroidal nature of the space into account to have the Boids correctly match velocity and keep separation with their neighbors.

It also changes how the Boids calculate their new vectors - there were some errors there. In particular both match_heading and separate were (mostly) doing nothing, because they were using ints internally instead of floats. I also tried to make these methods easier to follow.