### PR TITLE
Remove localhost hardcoding + allow secure sockets

### DIFF
--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -43,7 +43,15 @@ var fpsControl = $('#fps').slider({
 var sidebar = $("#sidebar");
 
 // WebSocket Stuff
-var ws = new WebSocket("ws://127.0.0.1:" + port + "/ws"); // Open the websocket connection
+// Support TLS-specific URLs, when appropriate
+if (window.location.protocol == "https:") {
+    var ws_scheme = "wss://";
+} else {
+    var ws_scheme = "ws://"
+};
+
+
+var ws = new WebSocket(ws_scheme + location.host + "/ws"); // Open the websocket connection
 ws.onopen = function() {
     console.log("Connection opened!");
     send({"type": "get_params"}); // Request model parameters when websocket is ready

--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -43,15 +43,10 @@ var fpsControl = $('#fps').slider({
 var sidebar = $("#sidebar");
 
 // WebSocket Stuff
-// Support TLS-specific URLs, when appropriate
-if (window.location.protocol == "https:") {
-    var ws_scheme = "wss://";
-} else {
-    var ws_scheme = "ws://"
-};
+// Open the websocket connection; support TLS-specific URLs when appropriate
+var ws = new WebSocket((window.location.protocol == "https:" ? "wss://" : "ws://") + 
+    location.host + "/ws");
 
-
-var ws = new WebSocket(ws_scheme + location.host + "/ws"); // Open the websocket connection
 ws.onopen = function() {
     console.log("Connection opened!");
     send({"type": "get_params"}); // Request model parameters when websocket is ready


### PR DESCRIPTION
When I deployed a pet model to Heroku, it failed to open a socket. This happened for two reasons:

1. My browser defaults to a secure connection with Heroku, which would block any connection made over `ws://` rather than `wss://`,
2. `runcontrol.js` assumes that the Tornado server is only served on 127.0.0.1 and requires an explicit port specification.

Consequently, even though the web app starts, the canvas doesn't show because the socket cannot be opened.

I took a hint from [Heroku's help page](https://devcenter.heroku.com/articles/python-websockets#front-end) and tried making this PR's edit on the fly via Chrome debugger. This successfully connected to the socket and restored the visualization functionality both on localhost and on the deployed Heroku instance.