### PR TITLE
[BUGFIX] Torus adjustment in Grid class

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -162,8 +162,7 @@ class Grid:
                                        not (0 <= dy + y < self.height)):
                     continue
 
-                px = self.torus_adj(x + dx, self.width)
-                py = self.torus_adj(y + dy, self.height)
+                px, py = self.torus_adj((x + dx, y + dy))
 
                 # Skip if new coords out of bounds.
                 if(self.out_of_bounds((px, py))):
@@ -246,11 +245,15 @@ class Grid:
         return list(self.iter_neighbors(
             pos, moore, include_center, radius))
 
-    def torus_adj(self, coord, dim_len):
+    def torus_adj(self, pos):
         """ Convert coordinate, handling torus looping. """
-        if self.torus:
-            coord %= dim_len
-        return coord
+        if not self.out_of_bounds(pos):
+            return pos
+        elif not self.torus:
+            raise Exception("Point out of bounds, and space non-toroidal.")
+        else:
+            x, y = pos[0] % self.width, pos[1] % self.height
+        return x, y
 
     def out_of_bounds(self, pos):
         """
@@ -295,6 +298,7 @@ class Grid:
             pos: Tuple of new position to move the agent to.
 
         """
+        pos = self.torus_adj(pos)
         self._remove_agent(agent.pos, agent)
         self._place_agent(pos, agent)
         agent.pos = pos

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -147,6 +147,30 @@ class TestBaseGrid(unittest.TestCase):
         assert second[1] == 0
         assert second[2] == 1
 
+    def test_agent_move(self):
+        # get the agent at [0, 1]
+        agent = self.agents[0]
+        self.grid.move_agent(agent, (1, 1))
+        assert agent.pos == (1, 1)
+        # move it off the torus and check for the exception
+        if not self.torus:
+            with self.assertRaises(Exception):
+                self.grid.move_agent(agent, [-1, 1])
+            with self.assertRaises(Exception):
+                self.grid.move_agent(agent, [1, self.grid.height + 1])
+        else:
+            self.grid.move_agent(agent, [-1, 1])
+            assert agent.pos == (self.grid.width - 1, 1)
+            self.grid.move_agent(agent, [1, self.grid.height + 1])
+            assert agent.pos == (1, 1)
+
+    def test_agent_remove(self):
+        agent = self.agents[0]
+        x, y = agent.pos
+        self.grid.remove_agent(agent)
+        assert agent.pos is None
+        assert self.grid.grid[x][y] is None
+
 
 class TestBaseGridTorus(TestBaseGrid):
     '''


### PR DESCRIPTION
This is a PR in response to #420 

The `torus_adj` method was updated to have a similar signature to the one in `ContinuousGrid`. `move_agent` now does a position check for toroid. 