### PR TITLE
ContinuousSpace: Fix get_distance calculation on toroidal boundary condition

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -572,12 +572,15 @@ class ContinuousSpace:
             pos_1, pos_2: Coordinate tuples for both points.
 
         """
-        pos_1 = np.array(pos_1)
-        pos_2 = np.array(pos_2)
+        x1, y1 = pos_1
+        x2, y2 = pos_2
+
+        dx = np.abs(x1 - x2)
+        dy = np.abs(y1 - y2)
         if self.torus:
-            pos_1 = (pos_1 - self.center) % self.size
-            pos_2 = (pos_2 - self.center) % self.size
-        return np.linalg.norm(pos_1 - pos_2)
+            dx = min(dx, self.width - dx)
+            dy = min(dy, self.height - dy)
+        return np.sqrt(dx * dx + dy * dy)
 
     def torus_adj(self, pos):
         """ Adjust coordinates to handle torus looping.

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -1,6 +1,7 @@
 import unittest
 
 import networkx as nx
+import numpy as np
 
 from mesa.space import ContinuousSpace
 from mesa.space import SingleGrid
@@ -48,6 +49,14 @@ class TestSpaceToroidal(unittest.TestCase):
 
         pos_3 = (-30, -20)
         assert self.space.get_distance(pos_1, pos_3) == 10
+
+        pos_4 = (20, -5)
+        pos_5 = (20, -15)
+        assert self.space.get_distance(pos_4, pos_5) == 10
+
+        pos_6 = (-30, -29)
+        pos_7 = (21, -5)
+        assert self.space.get_distance(pos_6, pos_7) == np.sqrt(49 ** 2 + 24 ** 2)
 
     def test_heading(self):
         pos_1 = (-30, -30)


### PR DESCRIPTION
cc: @simonchx, @clmerlos, @JamesArruda, @njvrzm 

This fixes the distance calculation back to before this commit change: https://github.com/projectmesa/mesa/commit/600c62b35dbac6de9300da471377b0e200b60da8#diff-84ac902399d236cac5d91bacaad69b2bL547, additionally, uses numpy for the arithmetic as suggested by @JamesArruda's implementation. This version of distance calculation passes the most number of test cases.

This fixes #410.