### PR TITLE
Added Mesa Packages pages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,12 +76,16 @@ If you would like to add a feature, please reach out via `ticket`_ or the `email
 .. _`Github` : https://github.com/projectmesa/mesa/
 
 
-Sharing you Agent Based Model Packages
+MESA Packages
 --------------------------------------
+
+`See a list of packages users have shared from their MESA ABMs <https://github.com/projectmesa/mesa/wiki>`_
 
 If you have an agent behavior, landscape feature, analysis tool or other module fellow reserchers can benefit from when building their ABM, please share!
 
 Learn more at  :ref:`Mesa-Packages`
+
+
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,15 +76,23 @@ If you would like to add a feature, please reach out via `ticket`_ or the `email
 .. _`Github` : https://github.com/projectmesa/mesa/
 
 
+Sharing you Agent Based Model Packages
+--------------------------------------
+
+If you have an agent behavior, landscape feature, analysis tool or other module fellow reserchers can benefit from when building their ABM, please share!
+
+Learn more at  :ref:`Mesa-Packages`
+
 .. toctree::
    :hidden:
-   :maxdepth: 1
+   :maxdepth: 6
 
    Mesa Overview <overview>
    tutorials/intro_tutorial
    tutorials/adv_tutorial
    Best Practices <best-practices>
    API Documentation <apis/api_main.rst>
+   Mesa Packages <packages/package_main.rst>
 
 Indices and tables
 ==================

--- a/docs/packages/Package Development/package development main.rst
+++ b/docs/packages/Package Development/package development main.rst
@@ -3,20 +3,18 @@
 Package Development: A "How-to Guide" for Developing Packages for Others to Use
 ================================================================================
 
-The purpose of this page is to get your mesa package sharing as quickly as possible. The authoritative guide for python package development is through the `Python 
-Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting you package on the Python Package Index.
+The purpose of this page is to get your mesa package sharing as quickly as possible. 
 
 This "How-to Guide" uses GitHub to walk you through the process. However, other repositories will be able to provide similar services.
 
-
-Package Development Checklist (basic): Sharing your modules in seven steps
+Package Development Checklist (basic): Sharing your package in seven steps
 ----------------------------------------------------------------------------
 
-**1. Take your module(s) from your ABM and make sure it is callable from Mesa in a simple, easy to understand way**
+**1. Take your package from your ABM and make sure it is callable from Mesa in a simple, easy to understand way**
    
 **2. Think about the structure of your package**
 
-We recommend `Hitchhiker's Guide to Python <http://docs.python-guide.org/en/latest/writing/structure/>`_
+   Not sure what this means, see a discussion on package struture at `Hitchhiker's Guide to Python <http://docs.python-guide.org/en/latest/writing/structure/>`_
 
 **3. Using GitHub, create a new repository**
 
@@ -49,11 +47,14 @@ We recommend `Hitchhiker's Guide to Python <http://docs.python-guide.org/en/late
 
       Don't forgot to follow a good `structure <http://docs.python-guide.org/en/latest/writing/structure/>`_
 
-**7. Add a page to Mesa Packages WIKI page**
+**7. Let people know about your package on the MESA wiki page**
 
-      - `Build your package page <https://github.com/projectmesa/mesa/wiki>`_  
-      - Edit the Mesa Packages wiki page to add your package name
+      - `MESA Wiki Page <https://github.com/projectmesa/mesa/wiki>`_  
    
+You want to do even more. The authoritative guide for python package development is through the `Python Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting you package on the Python Package Index.
+
+
+
 .. toctree::
    :hidden:
    :maxdepth: 1

--- a/docs/packages/Package Development/package development main.rst
+++ b/docs/packages/Package Development/package development main.rst
@@ -51,7 +51,7 @@ Package Development Checklist (basic): Sharing your package in seven steps
 
       - `MESA Wiki Page <https://github.com/projectmesa/mesa/wiki>`_  
    
-You want to do even more. The authoritative guide for python package development is through the `Python Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting you package on the Python Package Index.
+You want to do even more. The authoritative guide for python package development is through the `Python Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting your package on the Python Package Index.
 
 
 

--- a/docs/packages/Package Development/package development main.rst
+++ b/docs/packages/Package Development/package development main.rst
@@ -1,0 +1,69 @@
+.. _package-development:
+
+Package Development: A "How-to Guide" for Developing Packages for Others to Use
+================================================================================
+
+The purpose of this page is to get your mesa package sharing as quickly as possible. The authoritative guide for python package development is through the `Python 
+Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting you package on the Python Package Index.
+
+This "How-to Guide" uses GitHub to walk you through the process. However, other repositories will be able to provide similar services.
+
+
+Package Development Checklist (basic): Sharing your modules in seven steps
+----------------------------------------------------------------------------
+
+**1. Take your module(s) from your ABM and make sure it is callable from Mesa in a simple, easy to understand way**
+   
+**2. Think about the structure of your package**
+
+We recommend `Hitchhiker's Guide to Python <http://docs.python-guide.org/en/latest/writing/structure/>`_
+
+**3. Using GitHub, create a new repository**
+
+   A. Name your repository
+   B. Select a license (not sure-- click the blue 'i' next to the i for a great run down of licenses) 
+   C. Create a readme.md file (this contains a description of the package) see an example: `Bilateral Shapley <https://github.com/tpike3/bilateralshapley/blob/master/README.md>`_
+
+      
+**4. COMMIT a requirements.txt to the repository**
+
+   - This can be created automatically from your python environment using the command: 
+         
+.. code:: bash
+          
+               pip freeze > requirements.txt
+
+
+               #if using Anaconda install pip first
+               conda install pip
+
+. 
+   - For more information on environments see the user guide: :ref:`user-guide` 
+
+**5. COMMIT a setup.py file**
+
+      Python Package Authority Setup `Example <https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+      or start with a set up file from a package you like
+
+**6. COMMIT the module(s) or folder(s) to the git hub repository**
+
+      Don't forgot to follow a good `structure <http://docs.python-guide.org/en/latest/writing/structure/>`_
+
+**7. Add a page to Mesa Packages WIKI page**
+
+      - `Build your package page <https://github.com/projectmesa/mesa/wiki>`_  
+      - Edit the Mesa Packages wiki page to add your package name
+   
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   Package Template  <package template.rst>	
+   
+
+
+   
+
+
+   
+   

--- a/docs/packages/Package Development/package template.rst
+++ b/docs/packages/Package Development/package template.rst
@@ -1,0 +1,176 @@
+
+.. _package-template:
+
+Package Template
+=================
+
+   **THIS IS JUST AN EXAMPLE------ADJUST, ADD OR DELETE AS YOU SEE FIT**
+
+   Critical parts of the API are (1) describe the theory your instantiating and (2) cite your sources
+
+   Flow diagrams are always encouraged
+
+Provide an overview of your package?
+------------------------------------
+
+What is the theory, what is some background on when and how it was developed? What field does it fall in? ANy greate sucess or known uses?  
+
+Uses
+~~~~~
+Generically, how is it used--how does it influence agent behavior or the environment  
+
+Dependencies
+~~~~~~~~~~~~
+List other python libraries and version your package may depend on (or delete)
+
+Implementation
+--------------
+
+show 
+
+.. code:: python
+
+    from <packagefilename> import <main class>
+
+    <object> = <initiaition method>(parameter1, parameter2, parameter3)
+
+    # provide some examples
+    print (<object>.example1)
+
+    # example2
+    print (<object>.example2)
+
+    
+
+
+Required Parameters 
+~~~~~~~~~~~~~~~~~~~~
+Describe parameters your package requires---connection to Mesa as needed (add or delete as needed)
+
+**Parameter1:** requires list of agent objects 
+    
+            self.schedule.agents from mesa module is an easy choice 
+
+**Parameter2:** requires string
+
+             agent attribute defined in agent instantiation
+
+**Parameter3:** requires string
+
+             agent attribute defined in agent instantiation
+
+Default Parameters 
+~~~~~~~~~~~~~~~~~~~~
+Describe Default Parameters
+
+**default_parameter1:**  default = 1.5, requires float
+
+             add any illuminating details
+
+**defauly_parameter2:**  default = "unique_id", requires string
+
+             uses mesa unique_id attribute as default, module treats this value as a string
+
+**verbose:**  default = True, True or False input
+
+             if True module will print out lots of details about the package in progress
+
+Example Implementation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If practicable provide an exmaple implmentation which produces a toy model
+
+.. code:: python
+
+    from mesa import Model
+    from mesa.time import RandomActivation
+    from mesa import Agent
+    from <packagefilename> import <main class>
+    import numpy as np
+
+
+    class TestAgent(Agent):
+        '''Initialize agents with values for paraemeter1 and parameter2'''
+        def __init__(self, unique_id, model, maxparameter1, maxparameter2):
+            # use Mesa agent module
+            super().__init__(unique_id, model)
+            # parameter1 attribute of each agent
+            self.parameter1 = np.random.uniform(1, maxparameter1)
+            # parameter2 value of each agent 
+            self.parameter2 = np.random.uniform(1, maxparameter2)
+            
+
+
+    class TestModel(Model):
+        '''Initialize model'''
+        def __init__(self, N, maxparameter1, maxparameter2):
+            self.numagents = N
+            self.schedule = RandomActivation(self)
+            for i in range(self.numagents):
+                a = TestAgent(i, self, maxparameter1, maxparameter2)
+                self.schedule.add(a)
+                
+        
+        '''Call the bsv module'''        
+        def execution(self):
+            testnet = main(self.schedule.agents, "parameter1", "parameter2", verbose = False)
+            return testnet    
+
+
+    test = TestModel(500, 20, 100, 100)
+    test = test.execution()
+    print ("Numer of Groups: ", len(test.result))
+    print ("Group list: ", test.result)
+
+
+Detailed Description of Module
+------------------------------
+Provide a detailed description of your model
+
+Description
+~~~~~~~~~~~
+
+    This implementation of the Super awesome theory has three methods. 
+
+    **Method 1: self.method1(self.net)**
+
+    Each agent computes the super awesome (see flow diagram) and chooses to do X or Y bases on their local situation
+
+    **Method 2: self.method2(self.net)**
+
+    The super awesome is calcuated and printed out
+    
+
+    **Key Points**
+
+    Some things to consider or understand about your implementation   
+
+    **Module Flow Diagram**
+
+            Provide folder path and image name for a flow daigram or any other picutres you may want to add
+            .. image:: images/folder/flowdiagram.jpg
+
+Weaknesses and Choices
+~~~~~~~~~~~~~~~~~~~~~~
+
+    Every instantiation of a theory has problems and requires the programmer to make choices....discuss these
+
+
+Appearance in Journals and Conferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Not yet!
+
+
+
+Happy Modeling!
+----------------
+
+This document is a work in progress. If you see any errors, exclusions
+or have any problems please contact
+`us <https://github.com/projectmesa/mesa/issues>`__.
+
+``virtual environment``:
+http://docs.python-guide.org/en/latest/dev/virtualenvs/
+
+***sources you documentation cites!!!!!!**

--- a/docs/packages/User Guide/user guide main.rst
+++ b/docs/packages/User Guide/user guide main.rst
@@ -3,19 +3,19 @@
 User Guide
 ===================
 
-**A "How-to Guide" for using a package from Mesa Packages**
+**MESA does not endorse or verify any of the code shared through MESA packages**
 
-This is based on packages loaded into GitHub
+Use a Package in two Steps
+--------------------------
 
-Use a Package in 2 Steps
-------------------------
+This "How-To" Guide is based on packages loaded into GitHub
 
 1. Create a virtual environment for the ABM you are building. 
 	- `Why a virtual environment <https://realpython.com/blog/python/python-virtual-environments-a-primer/#why-the-need-for-virtual-environments>`_ 
 	- `How to create a python virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/#make-sure-you-ve-got-python-pip>`_
  	- `Creating a virtual environment with Anaconda <https://conda.io/docs/user-guide/tasks/manage-environments.html>`_
 
-2. Install into your environment via pip and github
+2. Install the package(s) into your environment via pip and github
 
 .. code:: bash
 

--- a/docs/packages/User Guide/user guide main.rst
+++ b/docs/packages/User Guide/user guide main.rst
@@ -1,0 +1,26 @@
+.. _user-guide:
+
+User Guide
+===================
+
+**A "How-to Guide" for using a package from Mesa Packages**
+
+This is based on packages loaded into GitHub
+
+Use a Package in 2 Steps
+------------------------
+
+1. Create a virtual environment for the ABM you are building. 
+	- `Why a virtual environment <https://realpython.com/blog/python/python-virtual-environments-a-primer/#why-the-need-for-virtual-environments>`_ 
+	- `How to create a python virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/#make-sure-you-ve-got-python-pip>`_
+ 	- `Creating a virtual environment with Anaconda <https://conda.io/docs/user-guide/tasks/manage-environments.html>`_
+
+2. Install into your environment via pip and github
+
+.. code:: bash
+
+	pip install git+https://<enter your clone url from git here>
+
+
+   
+   

--- a/docs/packages/package_main.rst
+++ b/docs/packages/package_main.rst
@@ -17,7 +17,7 @@ The Mesa core functionality is just a subset of what we believe researchers crea
 
 The purpose of this guide is to support new programmers by providing detailed guides on "How to" build and share a package. Let's get started!
 
-	You want add to create your package but have never done it before -- start here: :ref:`package-development`
+	You want create and share your package but have never done it before -- start here: :ref:`package-development`
 
 	You want to incorporate a package from a MESA user but don't know how--- try this: :ref:`user-guide`
 

--- a/docs/packages/package_main.rst
+++ b/docs/packages/package_main.rst
@@ -1,0 +1,65 @@
+.. _Mesa-Packages: 
+
+Mesa Packages 
+==============
+
+*Supporting MESA Agent Based Modeling with Crowd Sourced Packages*  
+------------------------------------------------------------------
+
+	*Bottom up models are virtual laboratories where controlled experiments distinguish noise from signal in the systems organization....
+	This approach may change our whole notion of scientific theory, which until now has been based on the theories of physics. Theories of
+	complex systems may never be reducible to simple analytical equations, but are more likely to be sets of conceptually simple mechanisms
+	(e.g. Darwinian natural selection) that produce different dynamics and outcomes in different contexts.*
+
+	Volker Grimm et al, "Pattern Oriented Modeling of Agent Based Complex Systems: Lessons from Ecology" Science, New Series, Vol. 310, No. 5750
+	(Nov. 11, 2005), pp. 987-991
+
+
+Mesa Packages Purpose: 
+----------------------
+
+
+**MESA Packages is a repository to share packages for use in Agent Based Models (ABMs) in pursuit of "unifying algorithmic theories of the relation between adaptive behavior and system complexity."**
+
+	**(1) Provide code which can be integrated into MESA ABMs to enable greater exploration of complex phenomenon.**
+	
+	**(2) Support new programmers by providing detailed guides on "How to" build and share a package.**
+
+
+Mesa Packages Overview: 
+-----------------------
+
+Mesa Packages does not have the capacity to verify the coding, the accuracy or the effectiveness of underlying theory and its instantiation in the supplied package. To ensure supplied packages are understandable and usable please adhere to the usability and veracity guidelines. 
+
+	You want to use a package but have no idea how -- start here: :ref:`user-guide`
+
+	You want add your package but have never done it before -- start here:: :ref:`package-development`
+
+**Usability Guidelines:**
+	1. Package has explanatory documentation (see an example in :ref:`package-template`) 
+	2. Package has a requirements document listing dependencies
+	3. Package has a generic example code which any user can copy and paste to see the package work
+
+**Veracity Guidelines:**
+	1. Package cites its sources (citation style is not mandated)  
+	2. Package lists any peer-reviewed journals and conferences where it has been published, presented or cited.
+
+
+
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   User Guide <User Guide/user guide main.rst>
+   Package Development  <Package Development/package development main.rst>	
+   
+      
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/packages/package_main.rst
+++ b/docs/packages/package_main.rst
@@ -3,46 +3,26 @@
 Mesa Packages 
 ==============
 
-*Supporting MESA Agent Based Modeling with Crowd Sourced Packages*  
-------------------------------------------------------------------
+		*Bottom up models are virtual laboratories where controlled experiments distinguish noise from signal in the systems organization....
+		This approach may change our whole notion of scientific theory, which until now has been based on the theories of physics. Theories of
+		complex systems may never be reducible to simple analytical equations, but are more likely to be sets of conceptually simple mechanisms
+		(e.g. Darwinian natural selection) that produce different dynamics and outcomes in different contexts.*
 
-	*Bottom up models are virtual laboratories where controlled experiments distinguish noise from signal in the systems organization....
-	This approach may change our whole notion of scientific theory, which until now has been based on the theories of physics. Theories of
-	complex systems may never be reducible to simple analytical equations, but are more likely to be sets of conceptually simple mechanisms
-	(e.g. Darwinian natural selection) that produce different dynamics and outcomes in different contexts.*
-
-	Volker Grimm et al, "Pattern Oriented Modeling of Agent Based Complex Systems: Lessons from Ecology" Science, New Series, Vol. 310, No. 5750
-	(Nov. 11, 2005), pp. 987-991
+		Volker Grimm et al, "Pattern Oriented Modeling of Agent Based Complex Systems: Lessons from Ecology" Science, New Series, Vol. 310, No. 5750
+		(Nov. 11, 2005), pp. 987-991
 
 
-Mesa Packages Purpose: 
-----------------------
 
+The Mesa core functionality is just a subset of what we believe researchers creating Agent Based Models (ABMs) will use. We designed Mesa to be extensible, so that individuals from various domains can build and maintain their own Mesa packages in pursuit of "unifying algorithmic theories of the relation between adaptive behavior and system complexity."
 
-**MESA Packages is a repository to share packages for use in Agent Based Models (ABMs) in pursuit of "unifying algorithmic theories of the relation between adaptive behavior and system complexity."**
+The purpose of this guide is to support new programmers by providing detailed guides on "How to" build and share a package. Let's get started!
 
-	**(1) Provide code which can be integrated into MESA ABMs to enable greater exploration of complex phenomenon.**
-	
-	**(2) Support new programmers by providing detailed guides on "How to" build and share a package.**
+	You want add to create your package but have never done it before -- start here: :ref:`package-development`
 
+	You want to incorporate a package from a MESA user but don't know how--- try this: :ref:`user-guide`
 
-Mesa Packages Overview: 
------------------------
+	`See links to shared Mesa packages <https://github.com/projectmesa/mesa/wiki>`_
 
-Mesa Packages does not have the capacity to verify the coding, the accuracy or the effectiveness of underlying theory and its instantiation in the supplied package. To ensure supplied packages are understandable and usable please adhere to the usability and veracity guidelines. 
-
-	You want to use a package but have no idea how -- start here: :ref:`user-guide`
-
-	You want add your package but have never done it before -- start here:: :ref:`package-development`
-
-**Usability Guidelines:**
-	1. Package has explanatory documentation (see an example in :ref:`package-template`) 
-	2. Package has a requirements document listing dependencies
-	3. Package has a generic example code which any user can copy and paste to see the package work
-
-**Veracity Guidelines:**
-	1. Package cites its sources (citation style is not mandated)  
-	2. Package lists any peer-reviewed journals and conferences where it has been published, presented or cited.
 
 
 


### PR DESCRIPTION
I added: 

1. a mesa packages section in index.rst
2. a mesa packages main page
3. a package development checklist  page (tried to do the most basic I could think of, then will create an expanded version which gets them to PyPI standards)
4. a package template page
5. a user guide for packages page

I have an example package ready to add to the wiki page, when/if this is merged. Otherwise, I will regroup and try again. 

 