### PR TITLE
Made corrections so reads as distributed MESA packages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,12 +76,16 @@ If you would like to add a feature, please reach out via `ticket`_ or the `email
 .. _`Github` : https://github.com/projectmesa/mesa/
 
 
-Sharing you Agent Based Model Packages
+MESA Packages
 --------------------------------------
+
+`See a list of packages users have shared from their MESA ABMs <https://github.com/projectmesa/mesa/wiki>`_
 
 If you have an agent behavior, landscape feature, analysis tool or other module fellow reserchers can benefit from when building their ABM, please share!
 
 Learn more at  :ref:`Mesa-Packages`
+
+
 
 .. toctree::
    :hidden:

--- a/docs/packages/Package Development/package development main.rst
+++ b/docs/packages/Package Development/package development main.rst
@@ -3,20 +3,18 @@
 Package Development: A "How-to Guide" for Developing Packages for Others to Use
 ================================================================================
 
-The purpose of this page is to get your mesa package sharing as quickly as possible. The authoritative guide for python package development is through the `Python 
-Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting you package on the Python Package Index.
+The purpose of this page is to get your mesa package sharing as quickly as possible. 
 
 This "How-to Guide" uses GitHub to walk you through the process. However, other repositories will be able to provide similar services.
 
-
-Package Development Checklist (basic): Sharing your modules in seven steps
+Package Development Checklist (basic): Sharing your package in seven steps
 ----------------------------------------------------------------------------
 
-**1. Take your module(s) from your ABM and make sure it is callable from Mesa in a simple, easy to understand way**
+**1. Take your package from your ABM and make sure it is callable from Mesa in a simple, easy to understand way**
    
 **2. Think about the structure of your package**
 
-We recommend `Hitchhiker's Guide to Python <http://docs.python-guide.org/en/latest/writing/structure/>`_
+   Not sure what this means, see a discussion on package struture at `Hitchhiker's Guide to Python <http://docs.python-guide.org/en/latest/writing/structure/>`_
 
 **3. Using GitHub, create a new repository**
 
@@ -49,11 +47,14 @@ We recommend `Hitchhiker's Guide to Python <http://docs.python-guide.org/en/late
 
       Don't forgot to follow a good `structure <http://docs.python-guide.org/en/latest/writing/structure/>`_
 
-**7. Add a page to Mesa Packages WIKI page**
+**7. Let people know about your package on the MESA wiki page**
 
-      - `Build your package page <https://github.com/projectmesa/mesa/wiki>`_  
-      - Edit the Mesa Packages wiki page to add your package name
+      - `MESA Wiki Page <https://github.com/projectmesa/mesa/wiki>`_  
    
+You want to do even more. The authoritative guide for python package development is through the `Python Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting you package on the Python Package Index.
+
+
+
 .. toctree::
    :hidden:
    :maxdepth: 1

--- a/docs/packages/Package Development/package development main.rst
+++ b/docs/packages/Package Development/package development main.rst
@@ -51,7 +51,7 @@ Package Development Checklist (basic): Sharing your package in seven steps
 
       - `MESA Wiki Page <https://github.com/projectmesa/mesa/wiki>`_  
    
-You want to do even more. The authoritative guide for python package development is through the `Python Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting you package on the Python Package Index.
+You want to do even more. The authoritative guide for python package development is through the `Python Packaging User Guide <https://packaging.python.org/>`_. This will take you through the entire process necessary for getting your package on the Python Package Index.
 
 
 

--- a/docs/packages/User Guide/user guide main.rst
+++ b/docs/packages/User Guide/user guide main.rst
@@ -3,19 +3,19 @@
 User Guide
 ===================
 
-**A "How-to Guide" for using a package from Mesa Packages**
+**MESA does not endorse or verify any of the code shared through MESA packages**
 
-This is based on packages loaded into GitHub
+Use a Package in two Steps
+--------------------------
 
-Use a Package in 2 Steps
-------------------------
+This "How-To" Guide is based on packages loaded into GitHub
 
 1. Create a virtual environment for the ABM you are building. 
 	- `Why a virtual environment <https://realpython.com/blog/python/python-virtual-environments-a-primer/#why-the-need-for-virtual-environments>`_ 
 	- `How to create a python virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/#make-sure-you-ve-got-python-pip>`_
  	- `Creating a virtual environment with Anaconda <https://conda.io/docs/user-guide/tasks/manage-environments.html>`_
 
-2. Install into your environment via pip and github
+2. Install the package(s) into your environment via pip and github
 
 .. code:: bash
 

--- a/docs/packages/package_main.rst
+++ b/docs/packages/package_main.rst
@@ -17,7 +17,7 @@ The Mesa core functionality is just a subset of what we believe researchers crea
 
 The purpose of this guide is to support new programmers by providing detailed guides on "How to" build and share a package. Let's get started!
 
-	You want add to create your package but have never done it before -- start here: :ref:`package-development`
+	You want create and share your package but have never done it before -- start here: :ref:`package-development`
 
 	You want to incorporate a package from a MESA user but don't know how--- try this: :ref:`user-guide`
 

--- a/docs/packages/package_main.rst
+++ b/docs/packages/package_main.rst
@@ -3,46 +3,26 @@
 Mesa Packages 
 ==============
 
-*Supporting MESA Agent Based Modeling with Crowd Sourced Packages*  
-------------------------------------------------------------------
+		*Bottom up models are virtual laboratories where controlled experiments distinguish noise from signal in the systems organization....
+		This approach may change our whole notion of scientific theory, which until now has been based on the theories of physics. Theories of
+		complex systems may never be reducible to simple analytical equations, but are more likely to be sets of conceptually simple mechanisms
+		(e.g. Darwinian natural selection) that produce different dynamics and outcomes in different contexts.*
 
-	*Bottom up models are virtual laboratories where controlled experiments distinguish noise from signal in the systems organization....
-	This approach may change our whole notion of scientific theory, which until now has been based on the theories of physics. Theories of
-	complex systems may never be reducible to simple analytical equations, but are more likely to be sets of conceptually simple mechanisms
-	(e.g. Darwinian natural selection) that produce different dynamics and outcomes in different contexts.*
-
-	Volker Grimm et al, "Pattern Oriented Modeling of Agent Based Complex Systems: Lessons from Ecology" Science, New Series, Vol. 310, No. 5750
-	(Nov. 11, 2005), pp. 987-991
+		Volker Grimm et al, "Pattern Oriented Modeling of Agent Based Complex Systems: Lessons from Ecology" Science, New Series, Vol. 310, No. 5750
+		(Nov. 11, 2005), pp. 987-991
 
 
-Mesa Packages Purpose: 
-----------------------
 
+The Mesa core functionality is just a subset of what we believe researchers creating Agent Based Models (ABMs) will use. We designed Mesa to be extensible, so that individuals from various domains can build and maintain their own Mesa packages in pursuit of "unifying algorithmic theories of the relation between adaptive behavior and system complexity."
 
-**MESA Packages is a repository to share packages for use in Agent Based Models (ABMs) in pursuit of "unifying algorithmic theories of the relation between adaptive behavior and system complexity."**
+The purpose of this guide is to support new programmers by providing detailed guides on "How to" build and share a package. Let's get started!
 
-	**(1) Provide code which can be integrated into MESA ABMs to enable greater exploration of complex phenomenon.**
-	
-	**(2) Support new programmers by providing detailed guides on "How to" build and share a package.**
+	You want add to create your package but have never done it before -- start here: :ref:`package-development`
 
+	You want to incorporate a package from a MESA user but don't know how--- try this: :ref:`user-guide`
 
-Mesa Packages Overview: 
------------------------
+	`See links to shared Mesa packages <https://github.com/projectmesa/mesa/wiki>`_
 
-Mesa Packages does not have the capacity to verify the coding, the accuracy or the effectiveness of underlying theory and its instantiation in the supplied package. To ensure supplied packages are understandable and usable please adhere to the usability and veracity guidelines. 
-
-	You want to use a package but have no idea how -- start here: :ref:`user-guide`
-
-	You want add your package but have never done it before -- start here:: :ref:`package-development`
-
-**Usability Guidelines:**
-	1. Package has explanatory documentation (see an example in :ref:`package-template`) 
-	2. Package has a requirements document listing dependencies
-	3. Package has a generic example code which any user can copy and paste to see the package work
-
-**Veracity Guidelines:**
-	1. Package cites its sources (citation style is not mandated)  
-	2. Package lists any peer-reviewed journals and conferences where it has been published, presented or cited.
 
 
 


### PR DESCRIPTION
Made the requested changes so it reads as shared packages from different github repositories instead of a consolidated repository. 

The one challenge I did see was where links to different packages can be stored. I linked to the MESA wiki main page, but at the least probably needs to be a subpage, or other dedicated location. 

Let me know if this meets the mail.

