### PR TITLE
Batchrunner fixes: properly initialize models with correct parameters during subsequent runs.

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -195,7 +195,12 @@ class BatchRunner:
         rest_cols = set(df.columns) - set(index_cols)
         ordered = df[index_cols + list(sorted(rest_cols))]
         ordered.sort_values(by='Run', inplace=True)
+        print(ordered)
         if self._include_fixed:
             for param in self.fixed_parameters.keys():
-                ordered[param] = self.fixed_parameters[param]
+                val = self.fixed_parameters[param]
+
+                # avoid error when val is an iterable
+                vallist = [val for i in range(ordered.shape[0])]
+                ordered[param] = vallist
         return ordered

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -195,7 +195,7 @@ class BatchRunner:
         rest_cols = set(df.columns) - set(index_cols)
         ordered = df[index_cols + list(sorted(rest_cols))]
         ordered.sort_values(by='Run', inplace=True)
-        print(ordered)
+
         if self._include_fixed:
             for param in self.fixed_parameters.keys():
                 val = self.fixed_parameters[param]

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -119,9 +119,10 @@ class BatchRunner:
             for param_values in product(*param_ranges):
                 kwargs = dict(zip(param_names, param_values))
                 kwargs.update(self.fixed_parameters)
-                model = self.model_cls(**kwargs)
 
                 for _ in range(self.iterations):
+                    kwargscopy = copy.deepcopy(kwargs)
+                    model = self.model_cls(**kwargscopy)
                     self.run_model(model)
                     # Collect and store results:
                     model_key = param_values + (next(run_count),)


### PR DESCRIPTION
- Moved model initialization into the iterations loop to ensure that
models are also properly initialized when starting a new iteration.

- The deepcopy ensures that on model initialization the kwargs are always
the original ones specified by the user.
The current solution (before this code change) allows parameters to be
overwritten during a model run.  This causes subsequent model runs to
be initialized with the wrong parameters.  This happens for example when
one of the parameters is warehouse stock.  If the first model modifies the
amount of stock in the warehouse, then the second model run would be
initialized with that modified value.