### PR TITLE
Fixes #493: Tornado not ready for 5+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jupyter==1.0.0
 
 coverage==4.1
 nose==1.3.7
-tornado
+tornado==4.5.3
 flake8==2.5.2
 tqdm
 networkx==2.1


### PR DESCRIPTION
Apparently Tornado 5 is not ready for prime time. So, for now, we are downgrading explicitly to the highest v4. 

If you want to read about other's issues with Tornado, see... 
https://github.com/ContinuumIO/anaconda-issues/issues/8789
https://github.com/jupyter/notebook/issues/3407 