### PR TITLE
add version numbers for tornado in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 from codecs import open
 
 requires = [
-    'tornado',
+    'tornado >= 4.2, < 5.0.0',
     'numpy',
     'pandas',
     'tqdm',


### PR DESCRIPTION
this change to setup.py specifies the version of tornado should be less that 5. 

This keeps an IOLoop error from occurring in the color_patches examples with the tornado 5 changes.