### PR TITLE
add versioning to tornado in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 from codecs import open
 
 requires = [
-    'tornado',
+    'tornado >= 4.2, < 5.0.0',
     'numpy',
     'pandas',
     'tqdm',


### PR DESCRIPTION
this sets the versioning for the tornado library in issue #523 to fix the `pip install -e` setup from an initial checkout.