### PR TITLE
Fix deprecation warning in lifespan tests. Closes #531

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -81,9 +81,8 @@ class TestAgentLifespan(unittest.TestCase):
         assert self.df.steps.max() == 1
 
     def test_agent_lifetime(self):
-        lifetimes = self.df.groupby(["AgentID"]).Step.agg({"Step":
-                                                           lambda x: len(x)})
-        assert lifetimes.Step.max() == 2
+        lifetimes = self.df.groupby(["AgentID"]).Step.agg(len)
+        assert lifetimes.max() == 2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Take 2

Minor change to the test to remove the deprecated functionality (using dicts in calling .agg). Should be stable regardless what pandas ends up doing with the .agg.