### PR TITLE
Fixes #543

### DIFF
--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -156,9 +156,9 @@ var initGUI = function() {
 
         // Finally render the dropdown and activate choice listeners
         sidebar.append(template.join(''));
-        choiceIdentifiers.forEach(function (id) {
+        choiceIdentifiers.forEach(function (id,idx) {
             $('#' + id).on('click', function () {
-                var value = $(this).text();
+                var value = obj.choices[idx];
                 $('#' + domID).html(value + ' ' + span);
                 onSubmitCallback(param, value);
             });


### PR DESCRIPTION
Fixes #543 

When attaching the listeners, instead of using the jquery selector to obtain the value (which will necessarily return a string representation of the data), I propose obtaining the value directly from the obj variable. This will allow non-string datatypes to be returned as the value. 

I've mainly looked at using number data types (int and floats) as well as arrays. However, it seems like as long as there is a corresponding javascript data type, the fix should work. So dictionaries and boolean should work, but tuples will not.   

I'm not too sure how we would implement a test for this though. It would be good if someone could review this as well, I'm still new to js. 