### PR TITLE
Fixes issue #548, flockers visualization not showing up

### DIFF
--- a/examples/boid-flockers/boidflockers/SimpleContinuousModule.py
+++ b/examples/boid-flockers/boidflockers/SimpleContinuousModule.py
@@ -2,7 +2,7 @@ from mesa.visualization.ModularVisualization import VisualizationElement
 
 
 class SimpleCanvas(VisualizationElement):
-    local_includes = ["flockers/simple_continuous_canvas.js"]
+    local_includes = ["boidflockers/simple_continuous_canvas.js"]
     portrayal_method = None
     canvas_height = 500
     canvas_width = 500


### PR DESCRIPTION
The `local_includes `variable need to point to the correct filename