### PR TITLE
updated BatchRunner

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -182,7 +182,7 @@ class BatchRunner:
         for agent in model.schedule._agents.values():
             agent_record = {}
             for var, reporter in self.agent_reporters.items():
-                agent_record[var] = reporter(agent)
+                agent_record[var] = getattr(agent, reporter)
             agent_vars[agent.unique_id] = agent_record
         return agent_vars
 

--- a/tests/test_batchrunner.py
+++ b/tests/test_batchrunner.py
@@ -74,8 +74,8 @@ class TestBatchRunner(unittest.TestCase):
             "reported_fixed_value": lambda m: m.fixed_model_param
         }
         self.agent_reporters = {
-            "agent_id": lambda a: a.unique_id,
-            "agent_val": lambda a: a.val
+            "agent_id": "unique_id",
+            "agent_val": "val"
         }
         self.variable_params = {
             "variable_model_param": range(3),
@@ -161,6 +161,7 @@ class TestBatchRunner(unittest.TestCase):
         self.assertEqual(model_vars.shape, (self.model_runs, expected_cols))
         self.assertEqual(model_vars['reported_fixed_param'].iloc[0],
                 self.fixed_params['fixed_name'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -129,5 +129,6 @@ class TestDataCollector(unittest.TestCase):
         with self.assertRaises(Exception):
             table_df = data_collector.get_table_dataframe("not a real table")
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -438,5 +438,6 @@ class TestHexGridTorus(TestBaseGrid):
         neighborhood = self.grid.get_neighborhood((2, 4))
         assert len(neighborhood) == 6
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -412,5 +412,6 @@ class TestMultipleNetworkGrid(unittest.TestCase):
                                                       self.agents[1],
                                                       self.agents[2]]
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Program throwing error when passing in agent reporters. Error at line 185
line 185: agent_record[vars] = reporter(agent)    *error* could not read string
updated line 185 to
line 185:  agent[vars]=getattr(agent, reporter)

program ran without error, produced appropriate results from datacollector/batchrunner
