### PR TITLE
Faster agent attribute collection

### DIFF
--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -92,8 +92,8 @@ class DataCollector:
                 self._new_model_reporter(name, reporter)
 
         if agent_reporters is not None:
-                for name, reporter in agent_reporters.items():
-                    self._new_agent_reporter(name, reporter)
+            for name, reporter in agent_reporters.items():
+                self._new_agent_reporter(name, reporter)
 
         if tables is not None:
             for name, columns in tables.items():
@@ -146,7 +146,9 @@ class DataCollector:
         """
         if all([rep.__name__ == 'attr_collector' for rep in reporters]):
             # Fast path if all reporters are attribute collecters
-            report = attrgetter(*[rep.attribute_name for rep in reporters])
+            def report(agent):
+                f = attrgetter(*[rep.attribute_name for rep in reporters])
+                return (agent.unique_id, ) + f(agent)
         else:
             def report(agent):
                 return (agent.unique_id, ) + tuple(

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -90,10 +90,9 @@ class TestDataCollector(unittest.TestCase):
         data_collector = self.model.datacollector
         assert len(data_collector._agent_records) == 7
         for step, records in data_collector._agent_records.items():
-            records = list(records)
             assert len(records) == 10
             for values in records:
-                assert len(values) == 3
+                assert len(values) == 4
 
     def test_table_rows(self):
         '''

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -83,16 +83,17 @@ class TestDataCollector(unittest.TestCase):
         for element in data_collector.model_vars["model_value"]:
             assert element == 100
 
-    def test_agent_vars(self):
+    def test_agent_records(self):
         '''
         Test agent-level variable collection.
         '''
         data_collector = self.model.datacollector
-        assert len(data_collector.agent_vars) == 7
-        for step, records in data_collector.agent_vars.items():
+        assert len(data_collector._agent_records) == 7
+        for step, records in data_collector._agent_records.items():
+            records = list(records)
             assert len(records) == 10
-            for values in records.values():
-                assert len(values) == 2
+            for values in records:
+                assert len(values) == 3
 
     def test_table_rows(self):
         '''

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -88,13 +88,11 @@ class TestDataCollector(unittest.TestCase):
         Test agent-level variable collection.
         '''
         data_collector = self.model.datacollector
-        assert len(data_collector.agent_vars["value"]) == 7
-        assert len(data_collector.agent_vars["value2"]) == 7
-        for var in ["value", "value2"]:
-            for step in data_collector.agent_vars[var]:
-                assert len(step) == 10
-                for record in step:
-                    assert len(record) == 2
+        assert len(data_collector.agent_vars) == 7
+        for step, records in data_collector.agent_vars.items():
+            assert len(records) == 10
+            for values in records.values():
+                assert len(values) == 2
 
     def test_table_rows(self):
         '''


### PR DESCRIPTION
Addresses #575 

This implementation adds a fast-track for collecting agent attributes if all reporters are string-based (no custom or lambda functions). If no string-based reporters are present or for a mixture of reporters it defaults to a only slightly improved version of the current implementation.

I also changed the structure of the class variable agent_vars, to store less data, it specifically stores the agent.unique_id only once and not for every reporter. This breaks code that relies on that variable, although none of the examples do. 

One idea to encourage the use of string-based reporters for agent reporters would be to include a warning if an agent reporter is not string-based and tell users that they could benefit from switching to string-based reporters (or even that support for non string-based reporters will be dropped in a much later version of mesa). 

Hope you like it