### PR TITLE
Update install command to be edible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ You can also use `pip` to install the github version:
 
 .. code-block:: bash
 
-    $ pip install git+https://github.com/projectmesa/mesa
+    $ pip install -e git+https://github.com/projectmesa/mesa
 
 Take a look at the `examples <https://github.com/projectmesa/mesa/tree/master/examples>`_ folder for sample models demonstrating Mesa features.
 


### PR DESCRIPTION
If you don't do the ``-e``, then cookie cutter doesn't work if you install from the github repo.