### PR TITLE
install: Minimize install footprint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from codecs import open
 requires = [
     'click',
     'cookiecutter',
-    'jupyter',
     'networkx',
     'numpy',
     'pandas',


### PR DESCRIPTION
1. ~`click`: only used in tests, hence should be put in dev~
2. `jupyter`: only appears in examples
3. `networkx`: only appears in test_space.py and examples (technically it is implicitly required in `NetworkGrid`, but again, not every users have to install `networkx` if they don't use `NetworkGrid` at all)

This should minimize the install footprint of any libraries that depend on Mesa.