### PR TITLE
set pytest version >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
     'dev': [
         'coverage',
         'flake8',
-        'pytest',
+        'pytest >= 3.6',
         'pytest-cov',
         'sphinx',
     ],


### PR DESCRIPTION
As I stated in #619, the reason the build failed seems to be Travis is using an old version of pytest, which is not supported for the tested version of python (3.4, 3.5, 3.6) any more. I modified pytest to pytest >= 3.6 and now passes all travis build jobs.