### PR TITLE
Fix VisualizationServer to be compatible with recent versions of Tornado

### DIFF
--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -314,7 +314,6 @@ class ModularServer(tornado.web.Application):
 
     def launch(self, port=None):
         """ Run the app. """
-        startLoop = not tornado.ioloop.IOLoop.initialized()
         if port is not None:
             self.port = port
         url = 'http://127.0.0.1:{PORT}'.format(PORT=self.port)
@@ -322,5 +321,4 @@ class ModularServer(tornado.web.Application):
         self.listen(self.port)
         webbrowser.open(url)
         tornado.autoreload.start()
-        if startLoop:
-            tornado.ioloop.IOLoop.instance().start()
+        tornado.ioloop.IOLoop.current().start()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = [
     'networkx',
     'numpy',
     'pandas',
-    'tornado >= 4.2, < 5.0.0',
+    'tornado',
     'tqdm',
 ]
 


### PR DESCRIPTION
Since `IOLoop.initialized()` has been depreciated as of tornado 5.0, I changed `IOLoop.instance()` to `IOLoop.current()`- The latter already does check if an IOLoop is already running and returns it or otherwise create a new instance (which was the reason `IOLoop.initialized()` was used before)

Compatible with all recent versions of tornado