### PR TITLE
Restructured runcontrol.js

### DIFF
--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -173,6 +173,10 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
     def open(self):
         if self.application.verbose:
             print("Socket opened!")
+        self.write_message({
+            "type": "model_params",
+            "params": self.application.user_params
+        })
 
     def check_origin(self, origin):
         return True
@@ -213,12 +217,6 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
                     self.application.model_kwargs[param].value = value
                 else:
                     self.application.model_kwargs[param] = value
-
-        elif msg["type"] == "get_params":
-            self.write_message({
-                "type": "model_params",
-                "params": self.application.user_params
-            })
 
         else:
             if self.application.verbose:

--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /* runcontrol.js
  Users can reset() the model, advance it by one step(), or start() it. reset() and
  step() send a message to the server, which then sends back the appropriate data.
@@ -33,14 +31,14 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
     this.finished = finished;
 
     /** Start the model and keep it running until stopped */
-    this.start = function() {
+    this.start = function start() {
         this.running = true;
         this.step();
         startModelButton.firstElementChild.innerText = "Stop";
     }
 
     /** Stop the model */
-    this.stop = function() {
+    this.stop = function stop() {
         this.running = false;
         startModelButton.firstElementChild.innerText = "Start";
     }
@@ -50,14 +48,14 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
      *
      * If the model is in a running state this function will be called repeatedly
      * after the visualization elements are rendered. */
-    this.step = function() {
+    this.step = function step() {
         this.tick += 1;
         stepDisplay.innerText = this.tick;
         send({ type: "get_step", step: this.tick });
     }
 
     /** Reset the model and visualization state but keep its running state */
-    this.reset = function() {
+    this.reset = function reset() {
         this.tick = 0;
         stepDisplay.innerText = this.tick;
         // Reset all the visualizations
@@ -66,22 +64,34 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
             this.finished = false;
             startModelButton.firstElementChild.innerText = "Start";
         }
+        clearTimeout(this.timeout)
         send({ type: "reset" });
     }
 
     /** Stops the model and put it into a finished state */
-    this.done = function() {
+    this.done = function done() {
         this.stop();
         this.finished = true;
         startModelButton.firstElementChild.innerText = "Done";
     }
 
     /**
+     * Render visualisation elements with new data.
+     * @param {any[]} data Model state data passed to the visualization elements
+     */
+    this.render = function render(data) {
+        vizElements.forEach((element, index) => element.render(data[index]))
+        if (this.running) {
+            this.timeout = setTimeout(() => this.step(), 1000 / this.fps);
+        }
+
+    /**
      * Update the frames per second
      * @param {number} val - The new value of frames per second
      */
-    this.updateFPS = function(val) {
+    this.updateFPS = function (val) {
         this.fps = Number(val);
+    }
     }
 }
 
@@ -136,13 +146,7 @@ ws.onmessage = function (message) {
     switch (msg["type"]) {
         case "viz_state":
             // Update visualization state
-            let vizData = msg["data"]
-            for (let i in vizElements) {
-                vizElements[i].render(vizData[i]);
-            }
-            if (controller.running) {
-                setTimeout(() => controller.step(), 1000 / controller.fps);
-            }
+            controller.render(msg["data"])
             break;
         case "end":
             // We have reached the end of the model
@@ -152,11 +156,6 @@ ws.onmessage = function (message) {
             // Create GUI elements for each model parameter and reset everything
             initGUI(msg["params"]);
             controller.reset();
-            break;
-        case "elements":
-            console.log("what?")
-            // Create visualization elements
-            msg["elements"].forEach(element => eval(element));
             break;
         default:
             // There shouldn't be any other message
@@ -184,203 +183,167 @@ const send = function (message) {
  * @param {object} model_params - Create the GUI from these model parameters
  */
 const initGUI = function (model_params) {
-    const addParamInput = function (param, option) {
-        switch (option["param_type"]) {
-            case "checkbox":
-                addBooleanInput(param, option);
-                break;
 
-            case "slider":
-                addSliderInput(param, option);
-                break;
+    const sidebar = $("#sidebar");
 
-            case "choice":
-                addChoiceInput(param, option);
-                break;
-
-            case "number":
-                addNumberInput(param, option); // Behaves the same as just a simple number
-                break;
-
-            case "static_text":
-                addTextBox(param, option);
-                break;
-        }
+    var onSubmitCallback = function(param_name, value) {
+        send({"type": "submit_params", "param": param_name, "value": value});
     };
 
-    for (let option in model_params) {
-        const type = typeof model_params[option];
-        const param_str = String(option);
-
-        switch (type) {
-            case "boolean":
-                addBooleanInput(param_str, {
-                    value: model_params[option],
-                    name: param_str
-                });
-                break;
-            case "number":
-                addNumberInput(param_str, {
-                    value: model_params[option],
-                    name: param_str
-                });
-                break;
-            case "object":
-                addParamInput(param_str, model_params[option]); // catch-all for params that use Option class
-                break;
-        }
-    }
-};
-
-/*
- * Input parameter definitions
- */
-
-const onSubmitCallback = function (param_name, value) {
-    send({ type: "submit_params", param: param_name, value: value });
-};
-
-const addBooleanInput = function (param, obj) {
-    var domID = param + "_id";
-    sidebar.insertAdjacentHTML(
-        "beforeend",
-        [
+    var addBooleanInput = function(param, obj) {
+        var domID = param + '_id';
+        sidebar.append([
             "<div class='input-group input-group-lg'>",
-            "<p><label for='" +
-            domID +
-            "' class='label label-primary'>" +
-            obj.name +
-            "</label></p>",
+            "<p><label for='" + domID + "' class='label label-primary'>" + obj.name + "</label></p>",
             "<input class='model-parameter' id='" + domID + "' type='checkbox'/>",
             "</div>"
-        ].join("")
-    );
-    $("#" + domID).bootstrapSwitch({
-        state: obj.value,
-        size: "small",
-        onSwitchChange: function (e, state) {
-            onSubmitCallback(param, state);
-        }
-    });
-};
+        ].join(''));
+        $('#' + domID).bootstrapSwitch({
+            'state': obj.value,
+            'size': 'small',
+            'onSwitchChange': function(e, state) {
+                onSubmitCallback(param, state);
+            }
+        });
+    };
 
-const addNumberInput = function (param, obj) {
-    var domID = param + "_id";
-    sidebar.insertAdjacentHTML(
-        "beforeend",
-        [
+    var addNumberInput = function(param, obj) {
+        var domID = param + '_id';
+        sidebar.append([
             "<div class='input-group input-group-lg'>",
-            "<p><label for='" +
-            domID +
-            "' class='label label-primary'>" +
-            obj.name +
-            "</label></p>",
+            "<p><label for='" + domID + "' class='label label-primary'>" + obj.name + "</label></p>",
             "<input class='model-parameter' id='" + domID + "' type='number'/>",
             "</div>"
-        ].join("")
-    );
-    var numberInput = $("#" + domID);
-    numberInput.val(obj.value);
-    numberInput.on("change", function () {
-        onSubmitCallback(param, Number($(this).val()));
-    });
-};
+        ].join(''));
+        var numberInput = $('#' + domID);
+        numberInput.val(obj.value);
+        numberInput.on('change', function() {
+            onSubmitCallback(param, Number($(this).val()));
+        })
+    };
 
-const addSliderInput = function (param, obj) {
-    var domID = param + "_id";
-    var tooltipID = domID + "_tooltip";
-    sidebar.insertAdjacentHTML(
-        "beforeend",
-        [
+    var addSliderInput = function(param, obj) {
+        var domID = param + '_id';
+        var tooltipID = domID + "_tooltip";
+        sidebar.append([
             "<div class='input-group input-group-lg'>",
             "<p>",
-            "<a id='" +
-            tooltipID +
-            "' data-toggle='tooltip' data-placement='top' class='label label-primary'>",
+            "<a id='" + tooltipID + "' data-toggle='tooltip' data-placement='top' class='label label-primary'>",
             obj.name,
             "</a>",
             "</p>",
             "<input id='" + domID + "' type='text' />",
             "</div>"
-        ].join("")
-    );
+        ].join(''));
 
-    // Enable tooltip label
-    if (obj.description !== null) {
-        $(tooltipID).tooltip({
-            title: obj.description,
-            placement: "right"
+        // Enable tooltip label
+        if (obj.description !== null) {
+            $(tooltipID).tooltip({
+                title: obj.description,
+                placement: 'right'
+            });
+        }
+
+        // Setup slider
+        var sliderInput = $("#" + domID);
+        sliderInput.slider({
+            min: obj.min_value,
+            max: obj.max_value,
+            value: obj.value,
+            step: obj.step,
+            ticks: [obj.min_value, obj.max_value],
+            ticks_labels: [obj.min_value, obj.max_value],
+            ticks_positions: [0, 100]
         });
-    }
+        sliderInput.on('change', function() {
+            onSubmitCallback(param, Number($(this).val()));
+        })
+    };
 
-    // Setup slider
-    var sliderInput = $("#" + domID);
-    sliderInput.slider({
-        min: obj.min_value,
-        max: obj.max_value,
-        value: obj.value,
-        step: obj.step,
-        ticks: [obj.min_value, obj.max_value],
-        ticks_labels: [obj.min_value, obj.max_value],
-        ticks_positions: [0, 100]
-    });
-    sliderInput.on("change", function () {
-        onSubmitCallback(param, Number($(this).val()));
-    });
-};
+    var addChoiceInput = function(param, obj) {
+        var domID = param + '_id';
+        var span = "<span class='caret'></span>";
+        var template = [
+            "<p><label for='" + domID + "' class='label label-primary'>" + obj.name + "</label></p>",
+            "<div class='dropdown'>",
+            "<button id='" + domID + "' class='btn btn-default dropdown-toggle' type='button' data-toggle='dropdown'>" +
+            obj.value + " " + span,
+            "</button>",
+            "<ul class='dropdown-menu' role='menu' aria-labelledby='" + domID + "'>"
+        ];
+        var choiceIdentifiers = [];
+        for (var i = 0; i < obj.choices.length; i++) {
+            var choiceID = domID + '_choice_' + i;
+            choiceIdentifiers.push(choiceID);
+            template.push(
+                "<li role='presentation'><a class='pick-choice' id='" + choiceID + "' role='menuitem' tabindex='-1' href='#'>",
+                obj.choices[i],
+                "</a></li>"
+            );
+        }
 
-const addChoiceInput = function (param, obj) {
-    var domID = param + "_id";
-    var span = "<span class='caret'></span>";
-    var template = [
-        "<p><label for='" +
-        domID +
-        "' class='label label-primary'>" +
-        obj.name +
-        "</label></p>",
-        "<div class='dropdown'>",
-        "<button id='" +
-        domID +
-        "' class='btn btn-default dropdown-toggle' type='button' data-toggle='dropdown'>" +
-        obj.value +
-        " " +
-        span,
-        "</button>",
-        "<ul class='dropdown-menu' role='menu' aria-labelledby='" + domID + "'>"
-    ];
-    var choiceIdentifiers = [];
-    for (var i = 0; i < obj.choices.length; i++) {
-        var choiceID = domID + "_choice_" + i;
-        choiceIdentifiers.push(choiceID);
-        template.push(
-            "<li role='presentation'><a class='pick-choice' id='" +
-            choiceID +
-            "' role='menuitem' tabindex='-1' href='#'>",
-            obj.choices[i],
-            "</a></li>"
-        );
-    }
+        // Close the dropdown options
+        template.push("</ul>", "</div>");
 
-    // Close the dropdown options
-    template.push("</ul>", "</div>");
-
-    // Finally render the dropdown and activate choice listeners
-    sidebar.insertAdjacentHTML("beforeend", template.join(""));
-    choiceIdentifiers.forEach(function (id, idx) {
-        $("#" + id).on("click", function () {
-            var value = obj.choices[idx];
-            $("#" + domID).html(value + " " + span);
-            onSubmitCallback(param, value);
+        // Finally render the dropdown and activate choice listeners
+        sidebar.append(template.join(''));
+        choiceIdentifiers.forEach(function (id,idx) {
+            $('#' + id).on('click', function () {
+                var value = obj.choices[idx];
+                $('#' + domID).html(value + ' ' + span);
+                onSubmitCallback(param, value);
+            });
         });
-    });
-};
+    };
 
-const addTextBox = function (param, obj) {
-    var well = $('<div class="well">' + obj.value + "</div>")[0];
-    sidebar.insertAdjacentHTML("beforeend", well);
-};
+    var addTextBox = function(param, obj) {
+        var well = $('<div class="well">' + obj.value + '</div>')[0];
+        sidebar.append(well);
+    };
 
+    var addParamInput = function(param, option) {
+        switch (option['param_type']) {
+            case 'checkbox':
+                addBooleanInput(param, option);
+                break;
+
+            case 'slider':
+                addSliderInput(param, option);
+                break;
+
+            case 'choice':
+                addChoiceInput(param, option);
+                break;
+
+            case 'number':
+                addNumberInput(param, option);   // Behaves the same as just a simple number
+                break;
+
+            case 'static_text':
+                addTextBox(param, option);
+                break;
+        }
+    };
+
+    for (var option in model_params) {
+
+        var type = typeof(model_params[option]);
+        var param_str = String(option);
+
+        switch (type) {
+            case "boolean":
+                addBooleanInput(param_str, {'value': model_params[option], 'name': param_str});
+                break;
+            case "number":
+                addNumberInput(param_str, {'value': model_params[option], 'name': param_str});
+                break;
+            case "object":
+                addParamInput(param_str, model_params[option]);    // catch-all for params that use Option class
+                break;
+        }
+    }
+};
 
 // Backward-Compatibility aliases
 const control = controller;
-const elements = vizElements
+const elements = vizElements;

--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -84,6 +84,7 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
         if (this.running) {
             this.timeout = setTimeout(() => this.step(), 1000 / this.fps);
         }
+    }
 
     /**
      * Update the frames per second
@@ -91,7 +92,6 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
      */
     this.updateFPS = function (val) {
         this.fps = Number(val);
-    }
     }
 }
 
@@ -186,11 +186,11 @@ const initGUI = function (model_params) {
 
     const sidebar = $("#sidebar");
 
-    var onSubmitCallback = function(param_name, value) {
-        send({"type": "submit_params", "param": param_name, "value": value});
+    var onSubmitCallback = function (param_name, value) {
+        send({ "type": "submit_params", "param": param_name, "value": value });
     };
 
-    var addBooleanInput = function(param, obj) {
+    var addBooleanInput = function (param, obj) {
         var domID = param + '_id';
         sidebar.append([
             "<div class='input-group input-group-lg'>",
@@ -201,13 +201,13 @@ const initGUI = function (model_params) {
         $('#' + domID).bootstrapSwitch({
             'state': obj.value,
             'size': 'small',
-            'onSwitchChange': function(e, state) {
+            'onSwitchChange': function (e, state) {
                 onSubmitCallback(param, state);
             }
         });
     };
 
-    var addNumberInput = function(param, obj) {
+    var addNumberInput = function (param, obj) {
         var domID = param + '_id';
         sidebar.append([
             "<div class='input-group input-group-lg'>",
@@ -217,12 +217,12 @@ const initGUI = function (model_params) {
         ].join(''));
         var numberInput = $('#' + domID);
         numberInput.val(obj.value);
-        numberInput.on('change', function() {
+        numberInput.on('change', function () {
             onSubmitCallback(param, Number($(this).val()));
         })
     };
 
-    var addSliderInput = function(param, obj) {
+    var addSliderInput = function (param, obj) {
         var domID = param + '_id';
         var tooltipID = domID + "_tooltip";
         sidebar.append([
@@ -255,12 +255,12 @@ const initGUI = function (model_params) {
             ticks_labels: [obj.min_value, obj.max_value],
             ticks_positions: [0, 100]
         });
-        sliderInput.on('change', function() {
+        sliderInput.on('change', function () {
             onSubmitCallback(param, Number($(this).val()));
         })
     };
 
-    var addChoiceInput = function(param, obj) {
+    var addChoiceInput = function (param, obj) {
         var domID = param + '_id';
         var span = "<span class='caret'></span>";
         var template = [
@@ -287,7 +287,7 @@ const initGUI = function (model_params) {
 
         // Finally render the dropdown and activate choice listeners
         sidebar.append(template.join(''));
-        choiceIdentifiers.forEach(function (id,idx) {
+        choiceIdentifiers.forEach(function (id, idx) {
             $('#' + id).on('click', function () {
                 var value = obj.choices[idx];
                 $('#' + domID).html(value + ' ' + span);
@@ -296,12 +296,12 @@ const initGUI = function (model_params) {
         });
     };
 
-    var addTextBox = function(param, obj) {
+    var addTextBox = function (param, obj) {
         var well = $('<div class="well">' + obj.value + '</div>')[0];
         sidebar.append(well);
     };
 
-    var addParamInput = function(param, option) {
+    var addParamInput = function (param, option) {
         switch (option['param_type']) {
             case 'checkbox':
                 addBooleanInput(param, option);
@@ -327,15 +327,15 @@ const initGUI = function (model_params) {
 
     for (var option in model_params) {
 
-        var type = typeof(model_params[option]);
+        var type = typeof (model_params[option]);
         var param_str = String(option);
 
         switch (type) {
             case "boolean":
-                addBooleanInput(param_str, {'value': model_params[option], 'name': param_str});
+                addBooleanInput(param_str, { 'value': model_params[option], 'name': param_str });
                 break;
             case "number":
-                addNumberInput(param_str, {'value': model_params[option], 'name': param_str});
+                addNumberInput(param_str, { 'value': model_params[option], 'name': param_str });
                 break;
             case "object":
                 addParamInput(param_str, model_params[option]);    // catch-all for params that use Option class

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -48,6 +48,7 @@
                 <div class="input-group input-group-lg">
                     <label class="label label-primary" for="fps" style="margin-right: 15px">Frames Per Second</label>
                     <input id="fps" data-slider-id='fps' type="text" />
+                    <p>Current Step: <span id="currentStep">0</span></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Since my previous PR #632  for restructuring the front-end was hanging around for quite some time without a review, here is yet another attempt to clear things up. 

While the previous PR has split up `runcontrol.js` into several modules, I here simply restructured the file. I think this way it is even easier to understand what is going on and overall a much better solution (because the previous split wasn't very clean).

This PR really shouldn't change anything about what is done in `runcontrol.js`, but rather how it is done. A code review should therefore primarily test if the visualizations for the examples remain unchanged and do not throw any errors. The only change is the addition of a step/tick display below the FPS slider. 

The core aspects:
 * The ModelController is now the primary actor for start(), step() and reset(). Any time-related user interaction goes through this. 
* The WebSocket `onmessage` function now just delegates the task to the controller (or `initGUI` for the initial set-up)
* No changes were made to the `initGUI` function