### PR TITLE
Travis: Explicitly set the dist to be Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 os:
@@ -5,7 +6,6 @@ os:
 cache:
   pip: true
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   # - "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
 python:
   - "3.5"
   - "3.6"
-  # - "nightly"
+  - "3.7"
+  - "nightly"
 install:
   - pip install coveralls
   - pip install .[dev]


### PR DESCRIPTION
Trusty has reached EOL. While in https://changelog.travis-ci.com/ there is an indication to set Xenial as the default, it still hasn't happened completely yet.

> Right now, 5% of the repositories building that do not explicitly specify an Operating System, os: key, or an Ubuntu Linux distribution, via the dist: key are now being routed to Ubuntu Xenial 16.04 instead of Ubuntu Trusty 14.04.

So better set it explicitly.