### PR TITLE
Dockerizing Mesa - example Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@
 # $ docker exec -it mymesa_instance /bin/bash 
 
 # FOR SECURITY:
-# - Don't use random Docker images or libraries.
-# - Use Docker images and libraries packaged by the same people.  
-# - Otherwise, who knows what's in that image?!
+# - Don't use random Docker images, libraries, or napkins in the bin
+# - Use official Docker images, or images packaged by the same people that made the library.
+# - Otherwise, who knows what code is in that image?!
 
 # This example Dockerfile packages the wolf_sheep example model.
 
@@ -42,9 +42,6 @@
 
 # Use official python image from Docker team: https://hub.docker.com/_/python
 FROM python:stretch
-
-# Our "home" directory in the Docker image
-WORKDIR /opt/mesa
 
 # Expose our port:
 EXPOSE 8521/tcp
@@ -73,10 +70,15 @@ COPY examples /opt/mesa/examples
 # Run wolf_sheep so it does something by default
 COPY examples/wolf_sheep /opt/mesa/mymodel
 
+# Our "home" directory in the Docker image
+WORKDIR /opt/mesa/mymodel
+
 # NOTE: your model's dependencies are installed here
-RUN (cd mymodel && pipenv install)
+RUN pip install -r requirements.txt
+# pipenv LIES and does sufficiently process requirements.txt
+# and then takes forever to do it.
+# RUN pipenv install
 
 # Run python
 ENTRYPOINT ["/usr/local/bin/python3"]
-# NOTE: replace with your own parameter
-CMD ["/opt/mesa/mymodel/run.py"]
+CMD ["run.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ WORKDIR /opt/mesa/mymodel
 # NOTE: your model's dependencies are installed here
 RUN pip install -r requirements.txt
 # pipenv LIES and does sufficiently process requirements.txt
-# and then takes forever to do it.
+# and takes forever to do it.
 # RUN pipenv install
 
 # Run python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,82 @@
-FROM phusion/baseimage:0.11
-# developer Dockerfile for mesa development, installs from local git checkout
-LABEL maintainer="Allen Lee <allen.lee@asu.edu>"
+# The Mesa project publishes "official" code to:
+# - Pip: https://pypi.org/project/Mesa
+# - Docker Hub: Not yet!
 
-ENV PYTHONUNBUFFERED=1 \
-    LANG=C.UTF-8 \
-    LC_ALL=C.UTF-8
+# There is no official Mesa Docker image.  Use this example to build your own.
 
+# You can build and run this Docker image with these commands:
+# $ docker build . -t mymesa_image
+# $ docker rm -f mymesa_instance
+# $ docker run --name mymesa_instance -p 8521:8521/tcp -it mymesa_image 
+# View at http://127.0.0.1:8521
+
+# "bash" the instance like this:
+# $ docker exec -it mymesa_instance /bin/bash 
+
+# FOR SECURITY:
+# - Don't use random Docker images or libraries.
+# - Use Docker images and libraries packaged by the same people.  
+# - Otherwise, who knows what's in that image?!
+
+# This example Dockerfile packages the wolf_sheep example model.
+
+# To use your own model, place your code in /opt/mesa/mymodel. 
+# You have two options:
+
+# OPTION A) COPY files into Docker image
+
+# From your other codebase, do these steps:
+# 1) Copy this Dockerfile into your model codebase
+# 2) Replace `COPY examples/boid-flockers /opt/mesa/mymodel`
+#       with `COPY [dir w/ your run.py] /opt/mesa/mymodel`
+# 3) Follow steps to build and run above
+
+# OPTION B) Mount a volume using docker-compose or kubernetes
+
+# `docker-compose.yml` in this repo shows an example of this 
+# models mounted in volumes must have their dependencies managed outside docker
+
+
+# Example Dockerfile for wolf_sheep model
+# Steps in this file are ordered least likly to change (top) to most likely to change (bottom)
+
+# Use official python image from Docker team: https://hub.docker.com/_/python
+FROM python:stretch
+
+# Our "home" directory in the Docker image
 WORKDIR /opt/mesa
 
-COPY . /opt/mesa
+# Expose our port:
+EXPOSE 8521/tcp
 
-RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \
-    && apt-get install -y --no-install-recommends \
-    build-essential \
-    python3-dev \
-    python3-pip \
-    python3-setuptools \
-    python3-wheel \
-    && rm -rf /var/lib/apt/lists/*
+# Update OS
+RUN apt-get update && apt-get upgrade -y 
 
-RUN pip3 install -e /opt/mesa
+# Don't buffer output: https://docs.python.org/3.7/using/cmdline.html?highlight=pythonunbuffered#envvar-PYTHONUNBUFFERED
+ENV PYTHONUNBUFFERED=1 
+# Cruft? Set locale to use UTF-8: http://www.iac.es/sieinvens/siepedia/pmwiki.php?n=Tutorials.LinuxLocale
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# Install pipenv
+RUN pip install --upgrade pipenv
+
+# As of now, we have:
+# - debian stretch OS w/ updates
+# - python3 from Docker team
+# - pipenv from Pip
+# - models can install mesa w/ pip or pipenv
+
+# NOTE: copy your model in here
+# Add examples for fun
+COPY examples /opt/mesa/examples
+# Run wolf_sheep so it does something by default
+COPY examples/wolf_sheep /opt/mesa/mymodel
+
+# NOTE: your model's dependencies are installed here
+RUN (cd mymodel && pipenv install)
+
+# Run python
+ENTRYPOINT ["/usr/local/bin/python3"]
+# NOTE: replace with your own parameter
+CMD ["/opt/mesa/mymodel/run.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ WORKDIR /opt/mesa/mymodel
 
 # NOTE: your model's dependencies are installed here
 RUN pip install -r requirements.txt
-# pipenv LIES and does sufficiently process requirements.txt
+# pipenv LIES and does not sufficiently process requirements.txt
 # and takes forever to do it.
 # RUN pipenv install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,20 +64,25 @@ RUN pip install --upgrade pipenv
 # - pipenv from Pip
 # - models can install mesa w/ pip or pipenv
 
-# NOTE: copy your model in here
 # Add examples for fun
 COPY examples /opt/mesa/examples
-# Run wolf_sheep so it does something by default
-COPY examples/wolf_sheep /opt/mesa/mymodel
 
 # Our "home" directory in the Docker image
 WORKDIR /opt/mesa/mymodel
 
-# NOTE: your model's dependencies are installed here
+# Copy requirements.txt w/o code.  This layer is cached so we don't have to push every build
+# NOTE: copy your model requirements.txt here
+COPY examples/wolf_sheep/requirements.txt .
+
+# Install dependencies
 RUN pip install -r requirements.txt
 # pipenv LIES and does not sufficiently process requirements.txt
 # and takes forever to do it.
 # RUN pipenv install
+
+# Copy rest of code so code changes only push the last layer
+# NOTE: copy your model in here
+COPY examples/wolf_sheep/ ./
 
 # Run python
 ENTRYPOINT ["/usr/local/bin/python3"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,25 +2,35 @@
 # - Pip: https://pypi.org/project/Mesa
 # - Docker Hub: not yet!  
 
-# Example showing running a model using mounted volumes.  
-# See Dockerfile
+# This example shows how to run a model using mounted volumes.  
+# See Dockerfile for details on why.
 
-# Build and run with these commands:
+# Build and run using these commands from this directory:
+
+# 1) build the image
+# $ docker build . -t mymesa_image
+
+# 2) Install docker-compose
 # $ pip install docker-compose
-# $ cd mesa
+
+# 3) Install example's dependencies. () creates new subshell so shell's working directory doesn't change
 # $ (cd examples/conways_game_of_life && pip3 install -r requirements.txt)
-# $ docker compose-up --attach mymesa_instance bash
+
+# 4) Start the image and mount the volume
+# $ docker-compose up
+
+# 5) browse to http://127.0.0.1:8521 to see results
 
 version: '3'
 services:
   mesa:
     # Built on your computer with `docker build . -t mymesa_image`
     image: mymesa_image
-    # Mount examples/conways to /opt/mesa/mymodel before starting image
+    # Mount host dir './examples/conways' 
+    #   to image dir '/opt/mesa/mymodel' before starting image
     volumes:
-      - /examples/conways_game_of_life:/opt/mesa/mymodel
-    # browse to http://127.0.0.1:8521 to see results
+      - ./examples/conways_game_of_life:/opt/mesa/mymodel
     ports:
       - "8521:8521"
-
+    
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,26 @@
+# The Mesa project publishes "official" code to:
+# - Pip: https://pypi.org/project/Mesa
+# - Docker Hub: not yet!  
+
+# Example showing running a model using mounted volumes.  
+# See Dockerfile
+
+# Build and run with these commands:
+# $ pip install docker-compose
+# $ cd mesa
+# $ (cd examples/conways_game_of_life && pip3 install -r requirements.txt)
+# $ docker compose-up --attach mymesa_instance bash
+
 version: '3'
 services:
-  install:
-    build: .
-    image: mesa:dev
-    command: pip3 install -e /opt/mesa
+  mesa:
+    # Built on your computer with `docker build . -t mymesa_image`
+    image: mymesa_image
+    # Mount examples/conways to /opt/mesa/mymodel before starting image
     volumes:
-      - .:/opt/mesa
-  dev:
-    image: mesa:dev
-    depends_on:
-      - install
-    volumes:
-      - .:/opt/mesa
+      - /examples/conways_game_of_life:/opt/mesa/mymodel
+    # browse to http://127.0.0.1:8521 to see results
     ports:
-      - "127.0.0.1:8521:8521"
+      - "8521:8521"
+
 


### PR DESCRIPTION
Hello, this commit on dockerizing Mesa was requested by @jackiekazil in https://github.com/projectmesa/mesa/issues/558

Because Mesa is packaged into a Pip library, there isn't anything magical the Dockerfile has to do other than:
- setup python3 
- setup dependency managers.  

Luckily [Docker already packages Python for us](https://hub.docker.com/_/python).

This `Dockerfile` shows how to package one of the examples - wolf_sheep.
The `docker-compose.yml` shows how to mount a custom model (vs packaging it).

See comments in `Dockerfile`, then `docker-compose.yml`

Michael
