### PR TITLE
intro tutorial: Clarify a function that is not defined in the class

### DIFF
--- a/docs/tutorials/intro_tutorial.rst
+++ b/docs/tutorials/intro_tutorial.rst
@@ -672,7 +672,7 @@ measure of wealth inequality.
                 self.grid.place_agent(a, (x, y))
 
             self.datacollector = DataCollector(
-                model_reporters={"Gini": compute_gini},
+                model_reporters={"Gini": compute_gini},  # `compute_gini` defined above
                 agent_reporters={"Wealth": "wealth"})
 
         def step(self):


### PR DESCRIPTION
This fixes #704.
The only case when the mistake happens is when someone is extracting only the class definition from the tutorial. Otherwise, this would be fine elsewhere in the .ipynb, examples/ files, `compute_gini()` when no partial copying is needed.

This is an in-place comment that would become visible in case the NameError (function not defined error) happens.