### PR TITLE
Schelling: Separate text-only viz into run_ascii.py

### DIFF
--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -21,7 +21,7 @@ Simple cellular automata of a fire spreading through a forest of cells on a grid
 ### PD_Grid
 Grid-based demographic prisoner's dilemma model, demonstrating how simple mimicing can lead to the emergence of widespread cooperation -- and how a model activation regime can change its outcome.
 
-### Schelling
+### Schelling (GUI and Text)
 Mesa implementation of the classic [Schelling segregation model](http://nifty.stanford.edu/2014/mccown-schelling-model-segregation/). 
 
 ### Shape Example

--- a/examples/Schelling/README.md
+++ b/examples/Schelling/README.md
@@ -26,9 +26,14 @@ Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and p
 
 To view and run some example model analyses, launch the IPython Notebook and open ``analysis.ipynb``. Visualizing the analysis also requires [matplotlib](http://matplotlib.org/).
 
+## How to Run without the GUI
+
+To run the model with the grid displayed as an ASCII text, run `python run_ascii.py` in this directory.
+
 ## Files
 
 * ``run.py``: Launches a model visualization server.
+* ``run_ascii.py``: Run the model in text mode.
 * ``schelling.py``: Contains the agent class, and the overall model class.
 * ``server.py``: Defines classes for visualizing the model in the browser via Mesa's modular server, and instantiates a visualization server.
 * ``analysis.ipynb``: Notebook demonstrating how to run experiments and parameter sweeps on the model.

--- a/examples/Schelling/run_ascii.py
+++ b/examples/Schelling/run_ascii.py
@@ -1,0 +1,51 @@
+from mesa.visualization.TextVisualization import (
+    TextData, TextGrid, TextVisualization
+)
+
+from model import Schelling
+
+
+class SchellingTextVisualization(TextVisualization):
+    '''
+    ASCII visualization for schelling model
+    '''
+
+    def __init__(self, model):
+        '''
+        Create new Schelling ASCII visualization.
+        '''
+        self.model = model
+
+        grid_viz = TextGrid(self.model.grid, self.ascii_agent)
+        happy_viz = TextData(self.model, 'happy')
+        self.elements = [grid_viz, happy_viz]
+
+    @staticmethod
+    def ascii_agent(a):
+        '''
+        Minority agents are X, Majority are O.
+        '''
+        if a.type == 0:
+            return 'O'
+        if a.type == 1:
+            return 'X'
+
+
+if __name__ == '__main__':
+    model_params = {
+        "height": 20,
+        "width": 20,
+        # Agent density, from 0.8 to 1.0
+        "density": 0.8,
+        # Fraction minority, from 0.2 to 1.0
+        "minority_pc": 0.2,
+        # Homophily, from 3 to 8
+        "homophily": 3
+    }
+
+    model = Schelling(**model_params)
+    viz = SchellingTextVisualization(model)
+    for i in range(10):
+        print("Step:", i)
+        viz.step()
+        print('---')

--- a/examples/Schelling/run_ascii.py
+++ b/examples/Schelling/run_ascii.py
@@ -16,12 +16,12 @@ class SchellingTextVisualization(TextVisualization):
         '''
         self.model = model
 
-        grid_viz = TextGrid(self.model.grid, self.ascii_agent)
+        grid_viz = TextGrid(self.model.grid, self.print_ascii_agent)
         happy_viz = TextData(self.model, 'happy')
         self.elements = [grid_viz, happy_viz]
 
     @staticmethod
-    def ascii_agent(a):
+    def print_ascii_agent(a):
         '''
         Minority agents are X, Majority are O.
         '''

--- a/examples/Schelling/server.py
+++ b/examples/Schelling/server.py
@@ -2,37 +2,7 @@ from mesa.visualization.ModularVisualization import ModularServer
 from mesa.visualization.modules import CanvasGrid, ChartModule, TextElement
 from mesa.visualization.UserParam import UserSettableParameter
 
-from mesa.visualization.TextVisualization import (
-    TextData, TextGrid, TextVisualization
-)
-
 from model import Schelling
-
-
-class SchellingTextVisualization(TextVisualization):
-    '''
-    ASCII visualization for schelling model
-    '''
-
-    def __init__(self, model):
-        '''
-        Create new Schelling ASCII visualization.
-        '''
-        self.model = model
-
-        grid_viz = TextGrid(self.model.grid, self.ascii_agent)
-        happy_viz = TextData(self.model, 'happy')
-        self.elements = [grid_viz, happy_viz]
-
-    @staticmethod
-    def ascii_agent(a):
-        '''
-        Minority agents are X, Majority are O.
-        '''
-        if a.type == 0:
-            return 'O'
-        if a.type == 1:
-            return 'X'
 
 
 class HappyElement(TextElement):


### PR DESCRIPTION
This partially addresses #693.

The text-specific viz is moved to run_ascii.py, and so it'd be less confusing to read `run.py`.