### PR TITLE
time: Remove resolved TODO on random seed of random scheduler

### DIFF
--- a/mesa/time.py
+++ b/mesa/time.py
@@ -20,11 +20,6 @@ Key concepts:
     Time: Some models may simulate a continuous 'clock' instead of discrete
     steps. However, by default, the Time is equal to the number of steps the
     model has taken.
-
-
-TODO: Have the schedulers use the model's randomizer, to keep random number
-seeds consistent and allow for replication.
-
 """
 
 from collections import OrderedDict


### PR DESCRIPTION
While I was self-debating over whether it is necessary to have the random seed stored in the model object, I found this obsolete TODO.