### PR TITLE
BUG example relative path test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ target/
 # Spyder app workspace config file
 .spyderworkspace
 
-# PyCharm environment files
+# PyCharm and Visual Studio environment files
 .idea/
 .vscode/
 

--- a/examples/wolf_sheep/wolf_sheep/test_random_walk.py
+++ b/examples/wolf_sheep/wolf_sheep/test_random_walk.py
@@ -8,7 +8,7 @@ from mesa.space import MultiGrid
 from mesa.time import RandomActivation
 from mesa.visualization.TextVisualization import TextVisualization, TextGrid
 
-from random_walk import RandomWalker
+from .random_walk import RandomWalker
 
 
 class WalkerAgent(RandomWalker):


### PR DESCRIPTION
Hello,
Pytest was not passing due to a relative path import error in `examples/wolf_sheep/wolf_sheep/test_random_walk.py`
```
________________________________ ERROR collecting examples/wolf_sheep/wolf_sheep/test_random_walk.py _________________________________
ImportError while importing test module '/home/ludos/repos/mesa/examples/wolf_sheep/wolf_sheep/test_random_walk.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
examples/wolf_sheep/wolf_sheep/test_random_walk.py:11: in <module>
    from random_walk import RandomWalker
E   ModuleNotFoundError: No module named 'random_walk'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================== 1 error in 2.00 seconds =======================================================
```
This PR fixed the issue. Hope it helps.