### PR TITLE
Remove figure from advanced tutorial showing the empty visualization

### DIFF
--- a/docs/tutorials/adv_tutorial.rst
+++ b/docs/tutorials/adv_tutorial.rst
@@ -131,17 +131,9 @@ open automatically, try pointing it at http://127.0.0.1:8521 manually.
 If this doesn't show you the visualization, something may have gone
 wrong with the server launch.)
 
-You should see something like the figure below: the model title, an
-empty space where the grid will be, and a control panel off to the
-right.
-
-.. figure:: files/viz_empty.png
-   :alt: Empty Visualization
-
-   Empty Visualization
-
-Click the 'reset' button on the control panel, and you should see the
-grid fill up with red circles, representing agents.
+You should see something like the figure below: the model title, a grid
+filled with red circles representing agents, and a set of buttons to the
+right for running and resetting the model.
 
 .. figure:: files/viz_redcircles.png
    :alt: Redcircles Visualization


### PR DESCRIPTION
This fixes the 3rd concern in #698 . This is my first PR, so please inform me if I've missed any other steps. Thank you!