### PR TITLE
fixed typo in BarChartModule line 100

### DIFF
--- a/mesa/visualization/templates/js/BarChartModule.js
+++ b/mesa/visualization/templates/js/BarChartModule.js
@@ -97,7 +97,7 @@ var BarChartModule = function(fields, canvas_width, canvas_height, sorting, sort
         if(sorting != "none"){
             if(sorting == "ascending"){
                 data.sort((a, b) => b[sortingKey] - a[sortingKey]);
-            } else if (sorting == "decending") {
+            } else if (sorting == "descending") {
                 data.sort((a, b) => a[sortingKey] - b[sortingKey]);
             }
         }


### PR DESCRIPTION
Hello, in line 100 of BarChartModule.js there is a typo in the word 'decending'

See ticket: #746 