### PR TITLE
Removing last link to coveralls and replacing to codecoverage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,10 +2,10 @@ Mesa: Agent-based modeling in Python 3+
 =========================================
 
 .. image:: https://api.travis-ci.org/projectmesa/mesa.svg
-        :target: https://travis-ci.org/projectmesa/mesa
+    :target: https://travis-ci.org/projectmesa/mesa
 
-.. image:: https://coveralls.io/repos/projectmesa/mesa/badge.svg
-    :target: https://coveralls.io/r/projectmesa/mesa
+.. image:: https://codecov.io/gh/projectmesa/mesa/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/projectmesa/mesa
 
 `Mesa`_ is an Apache2 licensed agent-based modeling (or ABM) framework in Python.
 


### PR DESCRIPTION
Missed in the latest PR with the same issue.
This would set the correct badge in the website documentation - https://mesa.readthedocs.io and https://pypi.org/project/Mesa/ - that is currently out of date.