### PR TITLE
Issue #749 networkx incompatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from codecs import open
 requires = [
     'click',
     'cookiecutter',
-    'networkx',
+    'networkx < 2.4',
     'numpy',
     'pandas',
     'tornado',


### PR DESCRIPTION
The 17th of October release of networkx broke the tests on master:
https://networkx.github.io/documentation/stable/index.html

This is a quick fix, pinning the library to a lower version.

It seems that despite Pipenv libraries must be pinned anyway. Possibly the import of all the libraries must be reviewed.
