### PR TITLE
NetworkGrid: Update to networkx 2.4 API

### DIFF
--- a/examples/virus_on_network/virus_on_network/server.py
+++ b/examples/virus_on_network/virus_on_network/server.py
@@ -28,7 +28,7 @@ def network_portrayal(G):
         return 2
 
     def get_agents(source, target):
-        return G.node[source]['agent'][0], G.node[target]['agent'][0]
+        return G.nodes[source]['agent'][0], G.nodes[target]['agent'][0]
 
     portrayal = dict()
     portrayal['nodes'] = [{'size': 6,

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -807,16 +807,16 @@ class NetworkGrid:
     def _place_agent(self, agent, node_id):
         """ Place the agent at the correct node. """
 
-        self.G.node[node_id]['agent'].append(agent)
+        self.G.nodes[node_id]['agent'].append(agent)
 
     def _remove_agent(self, agent, node_id):
         """ Remove an agent from a node. """
 
-        self.G.node[node_id]['agent'].remove(agent)
+        self.G.nodes[node_id]['agent'].remove(agent)
 
     def is_cell_empty(self, node_id):
         """ Returns a bool of the contents of a cell. """
-        return not self.G.node[node_id]['agent']
+        return not self.G.nodes[node_id]['agent']
 
     def get_cell_list_contents(self, cell_list):
         return list(self.iter_cell_list_contents(cell_list))
@@ -825,5 +825,5 @@ class NetworkGrid:
         return list(self.iter_cell_list_contents(self.G))
 
     def iter_cell_list_contents(self, cell_list):
-        list_of_lists = [self.G.node[node_id]['agent'] for node_id in cell_list if not self.is_cell_empty(node_id)]
+        list_of_lists = [self.G.nodes[node_id]['agent'] for node_id in cell_list if not self.is_cell_empty(node_id)]
         return [item for sublist in list_of_lists for item in sublist]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from codecs import open
 requires = [
     'click',
     'cookiecutter',
-    'networkx < 2.4',
+    'networkx',
     'numpy',
     'pandas',
     'tornado',

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -335,12 +335,12 @@ class TestSingleNetworkGrid(unittest.TestCase):
         _agent = self.agents[agent_number]
 
         assert _agent.pos == initial_pos
-        assert _agent in self.space.G.node[initial_pos]['agent']
-        assert _agent not in self.space.G.node[final_pos]['agent']
+        assert _agent in self.space.G.nodes[initial_pos]['agent']
+        assert _agent not in self.space.G.nodes[final_pos]['agent']
         self.space.move_agent(_agent, final_pos)
         assert _agent.pos == final_pos
-        assert _agent not in self.space.G.node[initial_pos]['agent']
-        assert _agent in self.space.G.node[final_pos]['agent']
+        assert _agent not in self.space.G.nodes[initial_pos]['agent']
+        assert _agent in self.space.G.nodes[final_pos]['agent']
 
     def test_is_cell_empty(self):
         assert not self.space.is_cell_empty(0)
@@ -393,18 +393,18 @@ class TestMultipleNetworkGrid(unittest.TestCase):
         _agent = self.agents[agent_number]
 
         assert _agent.pos == initial_pos
-        assert _agent in self.space.G.node[initial_pos]['agent']
-        assert _agent not in self.space.G.node[final_pos]['agent']
-        assert len(self.space.G.node[initial_pos]['agent']) == 2
-        assert len(self.space.G.node[final_pos]['agent']) == 1
+        assert _agent in self.space.G.nodes[initial_pos]['agent']
+        assert _agent not in self.space.G.nodes[final_pos]['agent']
+        assert len(self.space.G.nodes[initial_pos]['agent']) == 2
+        assert len(self.space.G.nodes[final_pos]['agent']) == 1
 
         self.space.move_agent(_agent, final_pos)
 
         assert _agent.pos == final_pos
-        assert _agent not in self.space.G.node[initial_pos]['agent']
-        assert _agent in self.space.G.node[final_pos]['agent']
-        assert len(self.space.G.node[initial_pos]['agent']) == 1
-        assert len(self.space.G.node[final_pos]['agent']) == 2
+        assert _agent not in self.space.G.nodes[initial_pos]['agent']
+        assert _agent in self.space.G.nodes[final_pos]['agent']
+        assert len(self.space.G.nodes[initial_pos]['agent']) == 1
+        assert len(self.space.G.nodes[final_pos]['agent']) == 2
 
     def test_is_cell_empty(self):
         assert not self.space.is_cell_empty(0)


### PR DESCRIPTION
This fixes #749 
This is based on networkx 2.4 announcement changelog:
> G.node –> use G.nodes

