### PR TITLE
networkx node list comes from 'G.nodes' rather than 'G.node'

### DIFF
--- a/examples/virus_on_network/virus_on_network/server.py
+++ b/examples/virus_on_network/virus_on_network/server.py
@@ -28,7 +28,7 @@ def network_portrayal(G):
         return 2
 
     def get_agents(source, target):
-        return G.node[source]['agent'][0], G.node[target]['agent'][0]
+        return G.nodes[source]['agent'][0], G.nodes[target]['agent'][0]
 
     portrayal = dict()
     portrayal['nodes'] = [{'size': 6,


### PR DESCRIPTION
This fixes what appears to be a small typo bug in the virus_on_network example, where the node list was being called incorrectly.