### PR TITLE
updating pipenv link

### DIFF
--- a/docs/tutorials/intro_tutorial.rst
+++ b/docs/tutorials/intro_tutorial.rst
@@ -48,7 +48,7 @@ Let's get started.
 Installation
 ~~~~~~~~~~~~
 
-To start, install Mesa. We recommend using a `pipenv <https://docs.pipenv.org/en/latest/>`_,
+To start, install Mesa. We recommend using a `pipenv <https://pipenv.readthedocs.io/en/latest/>`_,
 which combines the `virtual
 environment <https://virtualenvwrapper.readthedocs.org/en/stable/>`_
 along with the `dotenv <https://github.com/theskumar/python-dotenv>`_ projects


### PR DESCRIPTION
Updating the link to `pipenv` docs in the intro tutorial, as mentioned in #771.