### PR TITLE
Add information on image as agent portrayal shape

### DIFF
--- a/mesa/visualization/modules/CanvasGridVisualization.py
+++ b/mesa/visualization/modules/CanvasGridVisualization.py
@@ -22,7 +22,7 @@ class CanvasGrid(VisualizationElement):
 
     A portrayal as a dictionary with the following structure:
         "x", "y": Coordinates for the cell in which the object is placed.
-        "Shape": Can be either "circle", "rect" or "arrowHead"
+        "Shape": Can be either "circle", "rect", "arrowHead" or a custom image.
             For Circles:
                 "r": The radius, defined as a fraction of cell size. r=1 will
                      fill the entire cell.
@@ -30,9 +30,13 @@ class CanvasGrid(VisualizationElement):
                 "w", "h": The width and height of the rectangle, which are in
                           fractions of cell width and height.
             For arrowHead:
-            "scale": Proportion scaling as a fraction of cell size.
-            "heading_x": represents x direction unit vector.
-            "heading_y": represents y direction unit vector.
+                "scale": Proportion scaling as a fraction of cell size.
+                "heading_x": represents x direction unit vector.
+                "heading_y": represents y direction unit vector.
+             For an image:
+                The image must be placed in the same directory from which the
+                server is runned. An image has the attributes "x", "y",
+                "scale", "text" and "text_color".
         "Color": The color to draw the shape in; needs to be a valid HTML
                  color, e.g."Red" or "#AA08F8"
         "Filled": either "true" or "false", and determines whether the shape is


### PR DESCRIPTION
At first I was wondering if it was possible to fill the grid with a custom image, but this was not clearly stated. Just recently I found out that it was already implemented! It is a shame not to use this feature. Could you consider also adding it to CanvasGridVisualization.py?