### PR TITLE
Addition of inner_radius parameter in vision for get_neighbor[...] functions

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -755,7 +755,7 @@ class ContinuousSpace:
 
         Args:
             pos: Coordinate tuple to convert.
-            
+
         """
         if not self.out_of_bounds(pos):
             return pos

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -146,6 +146,10 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+            inner_radius: If defined, the inner radius will be 
+                          substracted from the radius of neighborhood
+                          to get (also in number of cells).
+                          Otherwise, the full radius is considered.
 
         Returns:
             A list of coordinate tuples representing the neighborhood. For
@@ -194,6 +198,10 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+            inner_radius: If defined, the inner radius will be 
+                          substracted from the radius of neighborhood
+                          to get (also in number of cells).
+                          Otherwise, the full radius is considered.
 
         Returns:
             A list of coordinate tuples representing the neighborhood;
@@ -217,6 +225,10 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+            inner_radius: If defined, the inner radius will be 
+                          substracted from the radius of neighborhood
+                          to get (also in number of cells).
+                          Otherwise, the full radius is considered.
 
         Returns:
             An iterator of non-None objects in the given neighborhood;
@@ -242,6 +254,10 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+            inner_radius: If defined, the inner radius will be 
+                          substracted from the radius of neighborhood
+                          to get (also in number of cells).
+                          Otherwise, the full radius is considered.
 
         Returns:
             A list of non-None objects in the given neighborhood;

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -2,10 +2,13 @@
 """
 Mesa Space Module
 =================
+
 Objects used to add a spatial component to a model.
+
 Grid: base grid, a simple list-of-lists.
 SingleGrid: grid which strictly enforces one object per cell.
 MultiGrid: extension to Grid where each cell is a set of objects.
+
 """
 # Instruction for PyLint to suppress variable name errors, since we have a
 # good reason to use one-character variable names for x and y.
@@ -20,6 +23,7 @@ def accept_tuple_argument(wrapped_function):
     """ Decorator to allow grid methods that take a list of (x, y) coord tuples
     to also handle a single position, by automatically wrapping tuple in
     single-item list rather than forcing user to do it.
+
     """
 
     def wrapper(*args):
@@ -33,13 +37,16 @@ def accept_tuple_argument(wrapped_function):
 
 class Grid:
     """ Base class for a square grid.
+
     Grid cells are indexed by [x][y], where [0][0] is assumed to be the
     bottom-left and [width-1][height-1] is the top-right. If a grid is
     toroidal, the top and bottom, and left and right, edges wrap to each other
+
     Properties:
         width, height: The grid's width and height.
         torus: Boolean which determines whether to treat the grid as a torus.
         grid: Internal list-of-lists which holds the grid cells themselves.
+
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.
         get_neighborhood: Returns the cells surrounding a given cell.
@@ -60,13 +67,16 @@ class Grid:
         identified in cell_list.
         remove_agent: Removes an agent from the grid.
         is_cell_empty: Returns a bool of the contents of a cell.
+
     """
 
     def __init__(self, width, height, torus):
         """ Create a new grid.
+
         Args:
             width, height: The width and height of the grid
             torus: Boolean whether the grid wraps or not.
+
         """
         self.height = height
         self.width = width
@@ -105,10 +115,12 @@ class Grid:
 
     def neighbor_iter(self, pos, moore=True):
         """ Iterate over position neighbors.
+
         Args:
             pos: (x,y) coords tuple for the position to get the neighbors of.
             moore: Boolean for whether to use Moore neighborhood (including
                    diagonals) or Von Neumann (only up/down/left/right).
+
         """
         neighborhood = self.iter_neighborhood(pos, moore=moore)
         return self.iter_cell_list_contents(neighborhood)
@@ -117,6 +129,7 @@ class Grid:
                           include_center=False, radius=1, inner_radius=0):
         """ Return an iterator over cell coordinates that are in the
         neighborhood of a certain point.
+
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -126,11 +139,13 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             A list of coordinate tuples representing the neighborhood. For
             example with radius 1, it will return list with number of elements
             equals at most 9 (8) if Moore, 5 (4) if Von Neumann (if not
             including the center).
+
         """
         x, y = pos
         coordinates = set()
@@ -162,6 +177,7 @@ class Grid:
                          include_center=False, radius=1, inner_radius=0):
         """ Return a list of cells that are in the neighborhood of a
         certain point.
+
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -171,16 +187,19 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             A list of coordinate tuples representing the neighborhood;
             With radius 1, at most 9 if Moore, 5 if Von Neumann (8 and 4
             if not including the center).
+
         """
         return list(self.iter_neighborhood(pos, moore, include_center, radius, inner_radius=0))
 
     def iter_neighbors(self, pos, moore,
                        include_center=False, radius=1, inner_radius=0):
         """ Return an iterator over neighbors to a certain point.
+
         Args:
             pos: Coordinates for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -191,10 +210,12 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             An iterator of non-None objects in the given neighborhood;
             at most 9 if Moore, 5 if Von-Neumann
             (8 and 4 if not including the center).
+
         """
         neighborhood = self.iter_neighborhood(
             pos, moore, include_center, radius, inner_radius=0)
@@ -203,6 +224,7 @@ class Grid:
     def get_neighbors(self, pos, moore,
                       include_center=False, radius=1, inner_radius=0):
         """ Return a list of neighbors to a certain point.
+
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -213,10 +235,12 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             A list of non-None objects in the given neighborhood;
             at most 9 if Moore, 5 if Von-Neumann
             (8 and 4 if not including the center).
+
         """
         return list(self.iter_neighbors(
             pos, moore, include_center, radius, inner_radius=0))
@@ -244,8 +268,10 @@ class Grid:
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
+
         Returns:
             An iterator of the contents of the cells identified in cell_list
+
         """
         return (
             self[x][y] for x, y in cell_list if not self.is_cell_empty((x, y)))
@@ -255,18 +281,22 @@ class Grid:
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
+
         Returns:
             A list of the contents of the cells identified in cell_list
+
         """
         return list(self.iter_cell_list_contents(cell_list))
 
     def move_agent(self, agent, pos):
         """
         Move an agent from its current position to a new position.
+
         Args:
             agent: Agent object to move. Assumed to have its current location
                    stored in a 'pos' tuple.
             pos: Tuple of new position to move the agent to.
+
         """
         pos = self.torus_adj(pos)
         self._remove_agent(agent.pos, agent)
@@ -339,9 +369,11 @@ class SingleGrid(Grid):
 
     def __init__(self, width, height, torus):
         """ Create a new single-item grid.
+
         Args:
             width, height: The width and width of the grid
             torus: Boolean whether the grid wraps or not.
+
         """
         super().__init__(width, height, torus)
 
@@ -353,6 +385,7 @@ class SingleGrid(Grid):
         If x or y are positive, they are used, but if "random",
         we get a random position.
         Ensure this random position is not occupied (in Grid).
+
         """
         if x == "random" or y == "random":
             if len(self.empties) == 0:
@@ -372,14 +405,20 @@ class SingleGrid(Grid):
 
 class MultiGrid(Grid):
     """ Grid where each cell can contain more than one object.
+
     Grid cells are indexed by [x][y], where [0][0] is assumed to be at
     bottom-left and [width-1][height-1] is the top-right. If a grid is
     toroidal, the top and bottom, and left and right, edges wrap to each other.
+
     Each grid cell holds a set object.
+
     Properties:
         width, height: The grid's width and height.
+
         torus: Boolean which determines whether to treat the grid as a torus.
+
         grid: Internal list-of-lists which holds the grid cells themselves.
+
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.
     """
@@ -407,8 +446,10 @@ class MultiGrid(Grid):
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
+
         Returns:
             A iterator of the contents of the cells identified in cell_list
+
         """
         return itertools.chain.from_iterable(
             self[x][y] for x, y in cell_list if not self.is_cell_empty((x, y)))
@@ -416,33 +457,40 @@ class MultiGrid(Grid):
 
 class HexGrid(Grid):
     """ Hexagonal Grid: Extends Grid to handle hexagonal neighbors.
+
     Functions according to odd-q rules.
     See http://www.redblobgames.com/grids/hexagons/#coordinates for more.
+
     Properties:
         width, height: The grid's width and height.
         torus: Boolean which determines whether to treat the grid as a torus.
+
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.
         get_neighborhood: Returns the cells surrounding a given cell.
         neighbor_iter: Iterates over position neightbors.
         iter_neighborhood: Returns an iterator over cell coordinates that are
             in the neighborhood of a certain point.
+
     """
 
     def iter_neighborhood(self, pos,
                           include_center=False, radius=1):
         """ Return an iterator over cell coordinates that are in the
         neighborhood of a certain point.
+
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             A list of coordinate tuples representing the neighborhood. For
             example with radius 1, it will return list with number of elements
             equals at most 9 (8) if Moore, 5 (4) if Von Neumann (if not
             including the center).
+
         """
 
         def torus_adj_2d(pos):
@@ -455,6 +503,7 @@ class HexGrid(Grid):
 
             """
             Both: (0,-), (0,+)
+
             Even: (-,+), (-,0), (+,+), (+,0)
             Odd:  (-,0), (-,-), (+,0), (+,-)
             """
@@ -492,8 +541,10 @@ class HexGrid(Grid):
 
     def neighbor_iter(self, pos):
         """ Iterate over position neighbors.
+
         Args:
             pos: (x,y) coords tuple for the position to get the neighbors of.
+
         """
         neighborhood = self.iter_neighborhood(pos)
         return self.iter_cell_list_contents(neighborhood)
@@ -502,28 +553,34 @@ class HexGrid(Grid):
                          include_center=False, radius=1):
         """ Return a list of cells that are in the neighborhood of a
         certain point.
+
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             A list of coordinate tuples representing the neighborhood;
             With radius 1
+
         """
         return list(self.iter_neighborhood(pos, include_center, radius))
 
     def iter_neighbors(self, pos,
                        include_center=False, radius=1):
         """ Return an iterator over neighbors to a certain point.
+
         Args:
             pos: Coordinates for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             An iterator of non-None objects in the given neighborhood
+
         """
         neighborhood = self.iter_neighborhood(
             pos, include_center, radius)
@@ -532,14 +589,17 @@ class HexGrid(Grid):
     def get_neighbors(self, pos,
                       include_center=False, radius=1):
         """ Return a list of neighbors to a certain point.
+
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
+
         Returns:
             A list of non-None objects in the given neighborhood
+
         """
         return list(self.iter_neighbors(
             pos, include_center, radius))
@@ -547,20 +607,24 @@ class HexGrid(Grid):
 
 class ContinuousSpace:
     """ Continuous space where each agent can have an arbitrary position.
+
     Assumes that all agents are point objects, and have a pos property storing
     their position as an (x, y) tuple. This class uses a numpy array internally
     to store agent objects, to speed up neighborhood lookups.
+
     """
     _grid = None
 
     def __init__(self, x_max, y_max, torus, x_min=0, y_min=0):
         """ Create a new continuous space.
+
         Args:
             x_max, y_max: Maximum x and y coordinates for the space.
             torus: Boolean for whether the edges loop around.
             x_min, y_min: (default 0) If provided, set the minimum x and y
                           coordinates for the space. Below them, values loop to
                           the other edge (if torus=True) or raise an exception.
+
         """
         self.x_min = x_min
         self.x_max = x_max
@@ -578,9 +642,11 @@ class ContinuousSpace:
 
     def place_agent(self, agent, pos):
         """ Place a new agent in the space.
+
         Args:
             agent: Agent object to place.
             pos: Coordinate tuple for where to place the agent.
+
         """
         pos = self.torus_adj(pos)
         if self._agent_points is None:
@@ -593,9 +659,11 @@ class ContinuousSpace:
 
     def move_agent(self, agent, pos):
         """ Move an agent from its current position to a new position.
+
         Args:
             agent: The agent object to move.
             pos: Coordinate tuple to move the agent to.
+
         """
         pos = self.torus_adj(pos)
         idx = self._agent_to_index[agent]
@@ -605,6 +673,7 @@ class ContinuousSpace:
 
     def remove_agent(self, agent):
         """ Remove an agent from the simulation.
+
         Args:
             agent: The agent object to remove
             """
@@ -625,6 +694,7 @@ class ContinuousSpace:
 
     def get_neighbors(self, pos, radius, include_center=True):
         """ Get all objects within a certain radius.
+
         Args:
             pos: (x,y) coordinate tuple to center the search at.
             radius: Get all the objects within this distance of the center.
@@ -632,6 +702,7 @@ class ContinuousSpace:
                             coordinates. i.e. if you are searching for the
                             neighbors of a given agent, True will include that
                             agent in the results.
+
         """
         deltas = np.abs(self._agent_points - np.array(pos))
         if self.torus:
@@ -644,6 +715,7 @@ class ContinuousSpace:
 
     def get_heading(self, pos_1, pos_2):
         """ Get the heading angle between two points, accounting for toroidal space.
+
         Args:
             pos_1, pos_2: Coordinate tuples for both points.
         """
@@ -659,8 +731,10 @@ class ContinuousSpace:
 
     def get_distance(self, pos_1, pos_2):
         """ Get the distance between two point, accounting for toroidal space.
+
         Args:
             pos_1, pos_2: Coordinate tuples for both points.
+
         """
         x1, y1 = pos_1
         x2, y2 = pos_2
@@ -674,11 +748,14 @@ class ContinuousSpace:
 
     def torus_adj(self, pos):
         """ Adjust coordinates to handle torus looping.
+
         If the coordinate is out-of-bounds and the space is toroidal, return
         the corresponding point within the space. If the space is not toroidal,
         raise an exception.
+
         Args:
             pos: Coordinate tuple to convert.
+            
         """
         if not self.out_of_bounds(pos):
             return pos

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -250,7 +250,7 @@ class Grid:
 
         """
         return list(self.iter_neighbors(
-            pos, moore, include_center, radius, inner_radius=0))
+            pos, moore, include_center, radius))
 
     def torus_adj(self, pos: Coordinate) -> Coordinate:
         """ Convert coordinate, handling torus looping. """

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -2,13 +2,10 @@
 """
 Mesa Space Module
 =================
-
 Objects used to add a spatial component to a model.
-
 Grid: base grid, a simple list-of-lists.
 SingleGrid: grid which strictly enforces one object per cell.
 MultiGrid: extension to Grid where each cell is a set of objects.
-
 """
 # Instruction for PyLint to suppress variable name errors, since we have a
 # good reason to use one-character variable names for x and y.
@@ -18,17 +15,11 @@ import itertools
 
 import numpy as np
 
-from typing import Iterable, Iterator, List, Optional, Set, Tuple, Union
-from .agent import Agent
-Coordinate = Tuple[int, int]
-GridContent = Union[Optional[Agent], Set[Agent]]
-
 
 def accept_tuple_argument(wrapped_function):
     """ Decorator to allow grid methods that take a list of (x, y) coord tuples
     to also handle a single position, by automatically wrapping tuple in
     single-item list rather than forcing user to do it.
-
     """
 
     def wrapper(*args):
@@ -42,16 +33,13 @@ def accept_tuple_argument(wrapped_function):
 
 class Grid:
     """ Base class for a square grid.
-
     Grid cells are indexed by [x][y], where [0][0] is assumed to be the
     bottom-left and [width-1][height-1] is the top-right. If a grid is
     toroidal, the top and bottom, and left and right, edges wrap to each other
-
     Properties:
         width, height: The grid's width and height.
         torus: Boolean which determines whether to treat the grid as a torus.
         grid: Internal list-of-lists which holds the grid cells themselves.
-
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.
         get_neighborhood: Returns the cells surrounding a given cell.
@@ -72,25 +60,22 @@ class Grid:
         identified in cell_list.
         remove_agent: Removes an agent from the grid.
         is_cell_empty: Returns a bool of the contents of a cell.
-
     """
 
-    def __init__(self, width: int, height: int, torus: bool) -> None:
+    def __init__(self, width, height, torus):
         """ Create a new grid.
-
         Args:
             width, height: The width and height of the grid
             torus: Boolean whether the grid wraps or not.
-
         """
         self.height = height
         self.width = width
         self.torus = torus
 
-        self.grid = []  # type: List[List[GridContent]]
+        self.grid = []
 
         for x in range(self.width):
-            col = []  # type: List[GridContent]
+            col = []
             for y in range(self.height):
                 col.append(self.default_val())
             self.grid.append(col)
@@ -100,43 +85,38 @@ class Grid:
             *(range(self.width), range(self.height))))
 
     @staticmethod
-    def default_val() -> None:
+    def default_val():
         """ Default value for new cell elements. """
         return None
 
-    def __getitem__(self, index: int) -> List[GridContent]:
+    def __getitem__(self, index):
         return self.grid[index]
 
-    def __iter__(self) -> Iterator[GridContent]:
-        """
-        create an iterator that chains the
-        rows of grid together as if one list:
-        """
+    def __iter__(self):
+        # create an iterator that chains the
+        #  rows of grid together as if one list:
         return itertools.chain(*self.grid)
 
-    def coord_iter(self) -> Iterator[Tuple[GridContent, int, int]]:
+    def coord_iter(self):
         """ An iterator that returns coordinates as well as cell contents. """
         for row in range(self.width):
             for col in range(self.height):
                 yield self.grid[row][col], row, col  # agent, x, y
 
-    def neighbor_iter(self, pos: Coordinate, moore: bool = True) -> Iterator[GridContent]:
+    def neighbor_iter(self, pos, moore=True):
         """ Iterate over position neighbors.
-
         Args:
             pos: (x,y) coords tuple for the position to get the neighbors of.
             moore: Boolean for whether to use Moore neighborhood (including
                    diagonals) or Von Neumann (only up/down/left/right).
-
         """
         neighborhood = self.iter_neighborhood(pos, moore=moore)
         return self.iter_cell_list_contents(neighborhood)
 
-    def iter_neighborhood(self, pos: Coordinate, moore: bool,
-                          include_center: bool = False, radius: int = 1) -> Iterator[Coordinate]:
+    def iter_neighborhood(self, pos, moore,
+                          include_center=False, radius=1, inner_radius=0):
         """ Return an iterator over cell coordinates that are in the
         neighborhood of a certain point.
-
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -146,19 +126,19 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             A list of coordinate tuples representing the neighborhood. For
             example with radius 1, it will return list with number of elements
             equals at most 9 (8) if Moore, 5 (4) if Von Neumann (if not
             including the center).
-
         """
         x, y = pos
-        coordinates = set()  # type: Set[Coordinate]
+        coordinates = set()
         for dy in range(-radius, radius + 1):
             for dx in range(-radius, radius + 1):
                 if dx == 0 and dy == 0 and not include_center:
+                    continue
+                if abs(dx) < inner_radius and abs(dy) < inner_radius:
                     continue
                 # Skip coordinates that are outside manhattan distance
                 if not moore and abs(dx) + abs(dy) > radius:
@@ -178,11 +158,10 @@ class Grid:
                     coordinates.add(coords)
                     yield coords
 
-    def get_neighborhood(self, pos: Coordinate, moore: bool,
-                         include_center: bool = False, radius: int = 1) -> List[Coordinate]:
+    def get_neighborhood(self, pos, moore,
+                         include_center=False, radius=1, inner_radius=0):
         """ Return a list of cells that are in the neighborhood of a
         certain point.
-
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -192,19 +171,16 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             A list of coordinate tuples representing the neighborhood;
             With radius 1, at most 9 if Moore, 5 if Von Neumann (8 and 4
             if not including the center).
-
         """
-        return list(self.iter_neighborhood(pos, moore, include_center, radius))
+        return list(self.iter_neighborhood(pos, moore, include_center, radius, inner_radius=0))
 
-    def iter_neighbors(self, pos: Coordinate, moore: bool,
-                       include_center: bool = False, radius: int = 1) -> Iterator[GridContent]:
+    def iter_neighbors(self, pos, moore,
+                       include_center=False, radius=1, inner_radius=0):
         """ Return an iterator over neighbors to a certain point.
-
         Args:
             pos: Coordinates for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -215,21 +191,18 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             An iterator of non-None objects in the given neighborhood;
             at most 9 if Moore, 5 if Von-Neumann
             (8 and 4 if not including the center).
-
         """
         neighborhood = self.iter_neighborhood(
-            pos, moore, include_center, radius)
+            pos, moore, include_center, radius, inner_radius=0)
         return self.iter_cell_list_contents(neighborhood)
 
-    def get_neighbors(self, pos: Coordinate, moore: bool,
-                      include_center: bool = False, radius: int = 1) -> List[Coordinate]:
+    def get_neighbors(self, pos, moore,
+                      include_center=False, radius=1, inner_radius=0):
         """ Return a list of neighbors to a certain point.
-
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             moore: If True, return Moore neighborhood
@@ -240,17 +213,15 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             A list of non-None objects in the given neighborhood;
             at most 9 if Moore, 5 if Von-Neumann
             (8 and 4 if not including the center).
-
         """
         return list(self.iter_neighbors(
-            pos, moore, include_center, radius))
+            pos, moore, include_center, radius, inner_radius=0))
 
-    def torus_adj(self, pos: Coordinate) -> Coordinate:
+    def torus_adj(self, pos):
         """ Convert coordinate, handling torus looping. """
         if not self.out_of_bounds(pos):
             return pos
@@ -260,7 +231,7 @@ class Grid:
             x, y = pos[0] % self.width, pos[1] % self.height
         return x, y
 
-    def out_of_bounds(self, pos: Coordinate) -> bool:
+    def out_of_bounds(self, pos):
         """
         Determines whether position is off the grid, returns the out of
         bounds coordinate.
@@ -269,74 +240,68 @@ class Grid:
         return x < 0 or x >= self.width or y < 0 or y >= self.height
 
     @accept_tuple_argument
-    def iter_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> Iterator[GridContent]:
+    def iter_cell_list_contents(self, cell_list):
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
-
         Returns:
             An iterator of the contents of the cells identified in cell_list
-
         """
         return (
             self[x][y] for x, y in cell_list if not self.is_cell_empty((x, y)))
 
     @accept_tuple_argument
-    def get_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> List[GridContent]:
+    def get_cell_list_contents(self, cell_list):
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
-
         Returns:
             A list of the contents of the cells identified in cell_list
-
         """
         return list(self.iter_cell_list_contents(cell_list))
 
-    def move_agent(self, agent: Agent, pos: Coordinate) -> None:
+    def move_agent(self, agent, pos):
         """
         Move an agent from its current position to a new position.
-
         Args:
             agent: Agent object to move. Assumed to have its current location
                    stored in a 'pos' tuple.
             pos: Tuple of new position to move the agent to.
-
         """
         pos = self.torus_adj(pos)
         self._remove_agent(agent.pos, agent)
         self._place_agent(pos, agent)
         agent.pos = pos
 
-    def place_agent(self, agent: Agent, pos: Coordinate) -> None:
+    def place_agent(self, agent, pos):
         """ Position an agent on the grid, and set its pos variable. """
         self._place_agent(pos, agent)
         agent.pos = pos
 
-    def _place_agent(self, pos: Coordinate, agent: Agent) -> None:
+    def _place_agent(self, pos, agent):
         """ Place the agent at the correct location. """
         x, y = pos
         self.grid[x][y] = agent
         self.empties.discard(pos)
 
-    def remove_agent(self, agent: Agent) -> None:
+    def remove_agent(self, agent):
         """ Remove the agent from the grid and set its pos variable to None. """
         pos = agent.pos
         self._remove_agent(pos, agent)
         agent.pos = None
 
-    def _remove_agent(self, pos: Coordinate, agent: Agent) -> None:
+    def _remove_agent(self, pos, agent):
         """ Remove the agent from the given location. """
         x, y = pos
         self.grid[x][y] = None
         self.empties.add(pos)
 
-    def is_cell_empty(self, pos: Coordinate) -> bool:
+    def is_cell_empty(self, pos):
         """ Returns a bool of the contents of a cell. """
         x, y = pos
         return self.grid[x][y] == self.default_val()
 
-    def move_to_empty(self, agent: Agent) -> None:
+    def move_to_empty(self, agent):
         """ Moves agent to a random empty cell, vacating agent's old cell. """
         pos = agent.pos
         if len(self.empties) == 0:
@@ -346,7 +311,7 @@ class Grid:
         agent.pos = new_pos
         self._remove_agent(pos, agent)
 
-    def find_empty(self) -> Optional[Coordinate]:
+    def find_empty(self):
         """ Pick a random empty cell. """
         from warnings import warn
         import random
@@ -363,22 +328,20 @@ class Grid:
         else:
             return None
 
-    def exists_empty_cells(self) -> bool:
+    def exists_empty_cells(self):
         """ Return True if any cells empty else False. """
         return len(self.empties) > 0
 
 
 class SingleGrid(Grid):
     """ Grid where each cell contains exactly at most one object. """
-    empties = set()  # type: Set[Coordinate]
+    empties = set()
 
-    def __init__(self, width: int, height: int, torus: bool) -> None:
+    def __init__(self, width, height, torus):
         """ Create a new single-item grid.
-
         Args:
             width, height: The width and width of the grid
             torus: Boolean whether the grid wraps or not.
-
         """
         super().__init__(width, height, torus)
 
@@ -390,7 +353,6 @@ class SingleGrid(Grid):
         If x or y are positive, they are used, but if "random",
         we get a random position.
         Ensure this random position is not occupied (in Grid).
-
         """
         if x == "random" or y == "random":
             if len(self.empties) == 0:
@@ -401,7 +363,7 @@ class SingleGrid(Grid):
         agent.pos = coords
         self._place_agent(coords, agent)
 
-    def _place_agent(self, pos: Coordinate, agent: Agent) -> None:
+    def _place_agent(self, pos, agent):
         if self.is_cell_empty(pos):
             super()._place_agent(pos, agent)
         else:
@@ -410,20 +372,14 @@ class SingleGrid(Grid):
 
 class MultiGrid(Grid):
     """ Grid where each cell can contain more than one object.
-
     Grid cells are indexed by [x][y], where [0][0] is assumed to be at
     bottom-left and [width-1][height-1] is the top-right. If a grid is
     toroidal, the top and bottom, and left and right, edges wrap to each other.
-
     Each grid cell holds a set object.
-
     Properties:
         width, height: The grid's width and height.
-
         torus: Boolean which determines whether to treat the grid as a torus.
-
         grid: Internal list-of-lists which holds the grid cells themselves.
-
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.
     """
@@ -433,13 +389,13 @@ class MultiGrid(Grid):
         """ Default value for new cell elements. """
         return set()
 
-    def _place_agent(self, pos: Coordinate, agent: Agent) -> None:
+    def _place_agent(self, pos, agent):
         """ Place the agent at the correct location. """
         x, y = pos
         self.grid[x][y].add(agent)
         self.empties.discard(pos)
 
-    def _remove_agent(self, pos: Coordinate, agent: Agent) -> None:
+    def _remove_agent(self, pos, agent):
         """ Remove the agent from the given location. """
         x, y = pos
         self.grid[x][y].remove(agent)
@@ -451,10 +407,8 @@ class MultiGrid(Grid):
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
-
         Returns:
             A iterator of the contents of the cells identified in cell_list
-
         """
         return itertools.chain.from_iterable(
             self[x][y] for x, y in cell_list if not self.is_cell_empty((x, y)))
@@ -462,40 +416,33 @@ class MultiGrid(Grid):
 
 class HexGrid(Grid):
     """ Hexagonal Grid: Extends Grid to handle hexagonal neighbors.
-
     Functions according to odd-q rules.
     See http://www.redblobgames.com/grids/hexagons/#coordinates for more.
-
     Properties:
         width, height: The grid's width and height.
         torus: Boolean which determines whether to treat the grid as a torus.
-
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.
         get_neighborhood: Returns the cells surrounding a given cell.
         neighbor_iter: Iterates over position neightbors.
         iter_neighborhood: Returns an iterator over cell coordinates that are
             in the neighborhood of a certain point.
-
     """
 
     def iter_neighborhood(self, pos,
                           include_center=False, radius=1):
         """ Return an iterator over cell coordinates that are in the
         neighborhood of a certain point.
-
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             A list of coordinate tuples representing the neighborhood. For
             example with radius 1, it will return list with number of elements
             equals at most 9 (8) if Moore, 5 (4) if Von Neumann (if not
             including the center).
-
         """
 
         def torus_adj_2d(pos):
@@ -508,7 +455,6 @@ class HexGrid(Grid):
 
             """
             Both: (0,-), (0,+)
-
             Even: (-,+), (-,0), (+,+), (+,0)
             Odd:  (-,0), (-,-), (+,0), (+,-)
             """
@@ -546,10 +492,8 @@ class HexGrid(Grid):
 
     def neighbor_iter(self, pos):
         """ Iterate over position neighbors.
-
         Args:
             pos: (x,y) coords tuple for the position to get the neighbors of.
-
         """
         neighborhood = self.iter_neighborhood(pos)
         return self.iter_cell_list_contents(neighborhood)
@@ -558,34 +502,28 @@ class HexGrid(Grid):
                          include_center=False, radius=1):
         """ Return a list of cells that are in the neighborhood of a
         certain point.
-
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             A list of coordinate tuples representing the neighborhood;
             With radius 1
-
         """
         return list(self.iter_neighborhood(pos, include_center, radius))
 
     def iter_neighbors(self, pos,
                        include_center=False, radius=1):
         """ Return an iterator over neighbors to a certain point.
-
         Args:
             pos: Coordinates for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             An iterator of non-None objects in the given neighborhood
-
         """
         neighborhood = self.iter_neighborhood(
             pos, include_center, radius)
@@ -594,17 +532,14 @@ class HexGrid(Grid):
     def get_neighbors(self, pos,
                       include_center=False, radius=1):
         """ Return a list of neighbors to a certain point.
-
         Args:
             pos: Coordinate tuple for the neighborhood to get.
             include_center: If True, return the (x, y) cell as well.
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-
         Returns:
             A list of non-None objects in the given neighborhood
-
         """
         return list(self.iter_neighbors(
             pos, include_center, radius))
@@ -612,24 +547,20 @@ class HexGrid(Grid):
 
 class ContinuousSpace:
     """ Continuous space where each agent can have an arbitrary position.
-
     Assumes that all agents are point objects, and have a pos property storing
     their position as an (x, y) tuple. This class uses a numpy array internally
     to store agent objects, to speed up neighborhood lookups.
-
     """
     _grid = None
 
     def __init__(self, x_max, y_max, torus, x_min=0, y_min=0):
         """ Create a new continuous space.
-
         Args:
             x_max, y_max: Maximum x and y coordinates for the space.
             torus: Boolean for whether the edges loop around.
             x_min, y_min: (default 0) If provided, set the minimum x and y
                           coordinates for the space. Below them, values loop to
                           the other edge (if torus=True) or raise an exception.
-
         """
         self.x_min = x_min
         self.x_max = x_max
@@ -647,11 +578,9 @@ class ContinuousSpace:
 
     def place_agent(self, agent, pos):
         """ Place a new agent in the space.
-
         Args:
             agent: Agent object to place.
             pos: Coordinate tuple for where to place the agent.
-
         """
         pos = self.torus_adj(pos)
         if self._agent_points is None:
@@ -664,11 +593,9 @@ class ContinuousSpace:
 
     def move_agent(self, agent, pos):
         """ Move an agent from its current position to a new position.
-
         Args:
             agent: The agent object to move.
             pos: Coordinate tuple to move the agent to.
-
         """
         pos = self.torus_adj(pos)
         idx = self._agent_to_index[agent]
@@ -678,7 +605,6 @@ class ContinuousSpace:
 
     def remove_agent(self, agent):
         """ Remove an agent from the simulation.
-
         Args:
             agent: The agent object to remove
             """
@@ -699,7 +625,6 @@ class ContinuousSpace:
 
     def get_neighbors(self, pos, radius, include_center=True):
         """ Get all objects within a certain radius.
-
         Args:
             pos: (x,y) coordinate tuple to center the search at.
             radius: Get all the objects within this distance of the center.
@@ -707,7 +632,6 @@ class ContinuousSpace:
                             coordinates. i.e. if you are searching for the
                             neighbors of a given agent, True will include that
                             agent in the results.
-
         """
         deltas = np.abs(self._agent_points - np.array(pos))
         if self.torus:
@@ -720,7 +644,6 @@ class ContinuousSpace:
 
     def get_heading(self, pos_1, pos_2):
         """ Get the heading angle between two points, accounting for toroidal space.
-
         Args:
             pos_1, pos_2: Coordinate tuples for both points.
         """
@@ -736,10 +659,8 @@ class ContinuousSpace:
 
     def get_distance(self, pos_1, pos_2):
         """ Get the distance between two point, accounting for toroidal space.
-
         Args:
             pos_1, pos_2: Coordinate tuples for both points.
-
         """
         x1, y1 = pos_1
         x2, y2 = pos_2
@@ -753,14 +674,11 @@ class ContinuousSpace:
 
     def torus_adj(self, pos):
         """ Adjust coordinates to handle torus looping.
-
         If the coordinate is out-of-bounds and the space is toroidal, return
         the corresponding point within the space. If the space is not toroidal,
         raise an exception.
-
         Args:
             pos: Coordinate tuple to convert.
-
         """
         if not self.out_of_bounds(pos):
             return pos
@@ -777,8 +695,7 @@ class ContinuousSpace:
     def out_of_bounds(self, pos):
         """ Check if a point is out of bounds. """
         x, y = pos
-        return (x < self.x_min or x >= self.x_max or
-                y < self.y_min or y >= self.y_max)
+        return (x < self.x_min or x >= self.x_max or y < self.y_min or y >= self.y_max)
 
 
 class NetworkGrid:

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -146,7 +146,7 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-            inner_radius: If defined, the inner radius will be 
+            inner_radius: If defined, the inner radius will be
                           substracted from the radius of neighborhood
                           to get (also in number of cells).
                           Otherwise, the full radius is considered.
@@ -198,7 +198,7 @@ class Grid:
             include_center: If True, return the (x, y) cell as well.
                             Otherwise, return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-            inner_radius: If defined, the inner radius will be 
+            inner_radius: If defined, the inner radius will be
                           substracted from the radius of neighborhood
                           to get (also in number of cells).
                           Otherwise, the full radius is considered.
@@ -225,7 +225,7 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-            inner_radius: If defined, the inner radius will be 
+            inner_radius: If defined, the inner radius will be
                           substracted from the radius of neighborhood
                           to get (also in number of cells).
                           Otherwise, the full radius is considered.
@@ -254,7 +254,7 @@ class Grid:
                             Otherwise,
                             return surrounding cells only.
             radius: radius, in cells, of neighborhood to get.
-            inner_radius: If defined, the inner radius will be 
+            inner_radius: If defined, the inner radius will be
                           substracted from the radius of neighborhood
                           to get (also in number of cells).
                           Otherwise, the full radius is considered.


### PR DESCRIPTION
Sometimes when using a large radius, the code computes for unnecessary neighbors. For optimisation purposes, using`inner_radius` allows higher precision of the desired neighbors. This is done by only looking from a certain radius and up instead of from a given origin.