### PR TITLE
Fixes #803 Advanced Tutorial #elements

### DIFF
--- a/docs/tutorials/adv_tutorial.ipynb
+++ b/docs/tutorials/adv_tutorial.ipynb
@@ -257,9 +257,9 @@
     "    // Create the tag:\n",
     "    var canvas_tag = \"<canvas width='\" + canvas_width + \"' height='\" + canvas_height + \"' \";\n",
     "    canvas_tag += \"style='border:1px dotted'></canvas>\";\n",
-    "    // Append it to body:\n",
+    "    // Append it to #elements:\n",
     "    var canvas = $(canvas_tag)[0];\n",
-    "    $(\"body\").append(canvas);\n",
+    "    $(\"#elements\").append(canvas);\n",
     "    // Create the context and the drawing controller:\n",
     "    var context = canvas.getContext(\"2d\");\n",
     "};\n",
@@ -269,14 +269,12 @@
     "\n",
     "```javascript\n",
     "var HistogramModule = function(bins, canvas_width, canvas_height) {\n",
-    "    // Create the elements\n",
-    "\n",
     "    // Create the tag:\n",
     "    var canvas_tag = \"<canvas width='\" + canvas_width + \"' height='\" + canvas_height + \"' \";\n",
     "    canvas_tag += \"style='border:1px dotted'></canvas>\";\n",
-    "    // Append it to body:\n",
+    "    // Append it to #elements:\n",
     "    var canvas = $(canvas_tag)[0];\n",
-    "    $(\"body\").append(canvas);\n",
+    "    $(\"#elements\").append(canvas);\n",
     "    // Create the context and the drawing controller:\n",
     "    var context = canvas.getContext(\"2d\");\n",
     "\n",
@@ -430,9 +428,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/tutorials/adv_tutorial.rst
+++ b/docs/tutorials/adv_tutorial.rst
@@ -310,9 +310,9 @@ context, which is required for doing anything with it.
         // Create the tag:
         var canvas_tag = "<canvas width='" + canvas_width + "' height='" + canvas_height + "' ";
         canvas_tag += "style='border:1px dotted'></canvas>";
-        // Append it to body:
+        // Append it to #elements:
         var canvas = $(canvas_tag)[0];
-        $("body").append(canvas);
+        $("#elements").append(canvas);
         // Create the context and the drawing controller:
         var context = canvas.getContext("2d");
     };
@@ -330,14 +330,12 @@ created, we can create the chart object.
 .. code:: javascript
 
     var HistogramModule = function(bins, canvas_width, canvas_height) {
-        // Create the elements
-
         // Create the tag:
         var canvas_tag = "<canvas width='" + canvas_width + "' height='" + canvas_height + "' ";
         canvas_tag += "style='border:1px dotted'></canvas>";
-        // Append it to body:
+        // Append it to #elements:
         var canvas = $(canvas_tag)[0];
-        $("body").append(canvas);
+        $("#elements").append(canvas);
         // Create the context and the drawing controller:
         var context = canvas.getContext("2d");
 


### PR DESCRIPTION
Fixes #803 by changing the docs to reflect that `canvas` should be added to the `#elements` div.