### PR TITLE
[PERF] Add neighborhood cache to grids and improve iter_cell_list_contents

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -247,7 +247,7 @@ class Grid:
             An iterator of non-None objects in the given neighborhood;
             at most 9 if Moore, 5 if Von-Neumann
             (8 and 4 if not including the center).
-
+g
         """
         neighborhood = self.get_neighborhood(pos, moore, include_center, radius)
         return self.iter_cell_list_contents(neighborhood)
@@ -258,8 +258,8 @@ class Grid:
         moore: bool,
         include_center: bool = False,
         radius: int = 1,
-    ) -> List[Coordinate]:
-        """Return a list of neighbors to a certain point.
+    ) -> List[GridContent]:
+        """ Return a list of neighbors to a certain point.
 
         Args:
             pos: Coordinate tuple for the neighborhood to get.
@@ -287,8 +287,7 @@ class Grid:
         elif not self.torus:
             raise Exception("Point out of bounds, and space non-toroidal.")
         else:
-            x, y = pos[0] % self.width, pos[1] % self.height
-        return x, y
+            return pos[0] % self.width, pos[1] % self.height
 
     def out_of_bounds(self, pos: Coordinate) -> bool:
         """

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -310,7 +310,10 @@ class Grid:
             An iterator of the contents of the cells identified in cell_list
 
         """
-        return (self[x][y] for x, y in cell_list if not self.is_cell_empty((x, y)))
+        for (x, y) in cell_list:
+            content = self.grid[x][y]
+            if not content == self.default_val():
+                yield content
 
     @accept_tuple_argument
     def get_cell_list_contents(

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -101,7 +101,7 @@ class Grid:
         self.empties = set(itertools.product(*(range(self.width), range(self.height))))
 
         # Neighborhood Cache
-        self._neighborhood_cache = dict()  # type: Dict[Any, List[Coordinate]]
+        self._neighborhood_cache: Dict[Any, List[Coordinate]] = dict()
 
     @staticmethod
     def default_val() -> None:
@@ -197,7 +197,7 @@ class Grid:
         neighborhood = self._neighborhood_cache.get(cache_key, None)
 
         if neighborhood is None:
-            coordinates = set()  # type: Set[Coordinate]
+            coordinates: Set[Coordinate] = set()
 
             x, y = pos
             for dy in range(-radius, radius + 1):
@@ -247,7 +247,6 @@ class Grid:
             An iterator of non-None objects in the given neighborhood;
             at most 9 if Moore, 5 if Von-Neumann
             (8 and 4 if not including the center).
-g
         """
         neighborhood = self.get_neighborhood(pos, moore, include_center, radius)
         return self.iter_cell_list_contents(neighborhood)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -310,10 +310,7 @@ class Grid:
             An iterator of the contents of the cells identified in cell_list
 
         """
-        for (x, y) in cell_list:
-            content = self.grid[x][y]
-            if not content == self.default_val():
-                yield content
+        return filter(None, (self.grid[x][y] for x, y in cell_list))
 
     @accept_tuple_argument
     def get_cell_list_contents(

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -135,7 +135,7 @@ class Grid:
                    diagonals) or Von Neumann (only up/down/left/right).
 
         """
-        neighborhood = self.iter_neighborhood(pos, moore=moore)
+        neighborhood = self.get_neighborhood(pos, moore=moore)
         return self.iter_cell_list_contents(neighborhood)
 
     def iter_neighborhood(
@@ -249,7 +249,7 @@ class Grid:
             (8 and 4 if not including the center).
 
         """
-        neighborhood = self.iter_neighborhood(pos, moore, include_center, radius)
+        neighborhood = self.get_neighborhood(pos, moore, include_center, radius)
         return self.iter_cell_list_contents(neighborhood)
 
     def get_neighbors(


### PR DESCRIPTION
This is a purely performance related issue. For a little more insights check #815, the take-away is that this potentially increases speed by a factor of at least 2. 

Two things are changed:
1. `get_neighborhood` now uses a cache to lookup already calculated neighborhoods, since they never change over the lifetime of a grid. Also the algorithm was slightly tweaked (with caching this doesn't matter but look out for it if you do a code review)

2. `iter_cell_list_contents` was modified. Currently it access the content of every cell twice: Once to check if the cell is empty and once to return the content. Content is now retrieved only once. 

`