### PR TITLE
Update test_examples.py

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -64,4 +64,5 @@ class TestExamples(unittest.TestCase):
                     server.server.render_model()
                 Model = getattr(mod, classcase(example))
                 model = Model()
-                (model.step() for _ in range(100))
+                for _ in range(10):
+                    model.step()


### PR DESCRIPTION
changed unused generator expression to actually run the models.

Originally 100 steps were proposed, but this increased runtime dramatically from abound 10 seconds to 90 seconds on my local machine. I think this would be quite an anoying wait time to test since the intend was only to see if the models actually run. So I changed it to 10 steps (resulting in 20 seconds test time locally). 