### PR TITLE
Fix broken link to templates list in advanced tutorial.

### DIFF
--- a/docs/tutorials/adv_tutorial.rst
+++ b/docs/tutorials/adv_tutorial.rst
@@ -439,7 +439,7 @@ inherit from, and create the new visualization class.
 There are a few things going on here. ``package_includes`` is a list of
 JavaScript files that are part of Mesa itself that the visualization
 element relies on. You can see the included files in
-`mesa/visualization/templates/ <https://github.com/projectmesa/mesa/tree/tutorial_update/mesa/visualization/templates>`__.
+`mesa/visualization/templates/ <https://github.com/projectmesa/mesa/tree/master/mesa/visualization/templates>`__.
 Similarly, ``local_includes`` is a list of JavaScript files in the same
 directory as the class code itself. Note that both of these are class
 variables, not object variables -- they hold for all particular objects.


### PR DESCRIPTION
Small fix, followed tutorial and noticed the link was not working.

Closes  #830 
