### PR TITLE
space: more type annotations

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -5,16 +5,18 @@ Core Objects: Agent
 
 """
 # mypy
-from typing import Optional, Union
-from mesa.model import Model
-from mesa.space import Coordinate, FloatCoordinate
+from typing import Optional, Union, TYPE_CHECKING
 from random import Random
+
+if TYPE_CHECKING:
+    from mesa.model import Model
+    from mesa.space import Coordinate, FloatCoordinate
 
 
 class Agent:
     """ Base class for a model agent. """
 
-    def __init__(self, unique_id: int, model: Model) -> None:
+    def __init__(self, unique_id: int, model: "Model") -> None:
         """ Create a new agent. """
         self.unique_id = unique_id
         self.model = model

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -5,7 +5,9 @@ Core Objects: Agent
 
 """
 # mypy
+from typing import Optional, Union
 from mesa.model import Model
+from mesa.space import Coordinate, FloatCoordinate
 from random import Random
 
 
@@ -16,7 +18,7 @@ class Agent:
         """ Create a new agent. """
         self.unique_id = unique_id
         self.model = model
-        self.pos = None
+        self.pos: Optional[Union[Coordinate, FloatCoordinate, int]] = None
 
     def step(self) -> None:
         """ A single step of the agent. """

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -5,12 +5,12 @@ Core Objects: Agent
 
 """
 # mypy
-from typing import Optional, Union, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from random import Random
 
 if TYPE_CHECKING:
     from mesa.model import Model
-    from mesa.space import Coordinate, FloatCoordinate
+    from mesa.space import Position
 
 
 class Agent:
@@ -20,7 +20,7 @@ class Agent:
         """ Create a new agent. """
         self.unique_id = unique_id
         self.model = model
-        self.pos: Optional[Union[Coordinate, FloatCoordinate, int]] = None
+        self.pos = None  # type: Optional[Position]
 
     def step(self) -> None:
         """ A single step of the agent. """

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -427,7 +427,7 @@ class Grid(BaseGrid[GridContent]):
     def _remove_agent(self, pos: Coordinate, agent: Agent) -> None:
         """ Remove the agent from the given location. """
         x, y = pos
-        self.grid[x][y] = None
+        self.grid[x][y] = self.default_val()
         self.empties.add(pos)
 
 

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -137,9 +137,7 @@ class Grid:
             for col in range(self.height):
                 yield self.grid[row][col], row, col  # agent, x, y
 
-    def neighbor_iter(
-        self, pos: Coordinate, moore: bool = True
-    ) -> Iterator[GridContent]:
+    def neighbor_iter(self, pos: Coordinate, moore: bool = True) -> Iterator[Agent]:
         """Iterate over position neighbors.
 
         Args:
@@ -238,7 +236,7 @@ class Grid:
         moore: bool,
         include_center: bool = False,
         radius: int = 1,
-    ) -> Iterator[GridContent]:
+    ) -> Iterator[Agent]:
         """Return an iterator over neighbors to a certain point.
 
         Args:
@@ -267,7 +265,7 @@ class Grid:
         moore: bool,
         include_center: bool = False,
         radius: int = 1,
-    ) -> List[GridContent]:
+    ) -> List[Agent]:
         """Return a list of neighbors to a certain point.
 
         Args:
@@ -310,7 +308,7 @@ class Grid:
     @accept_tuple_argument
     def iter_cell_list_contents(
         self, cell_list: Iterable[Coordinate]
-    ) -> Iterator[GridContent]:
+    ) -> Iterator[Agent]:
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
@@ -319,12 +317,13 @@ class Grid:
             An iterator of the contents of the cells identified in cell_list
 
         """
-        return (self[x][y] for x, y in cell_list if not self.is_cell_empty((x, y)))
+        return cast(
+            Iterator[Agent],
+            (self[x][y] for x, y in cell_list if not self.is_cell_empty((x, y))),
+        )
 
     @accept_tuple_argument
-    def get_cell_list_contents(
-        self, cell_list: Iterable[Coordinate]
-    ) -> List[GridContent]:
+    def get_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> List[Agent]:
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
@@ -506,7 +505,7 @@ class MultiGrid(Grid):
     @accept_tuple_argument
     def iter_cell_list_contents(
         self, cell_list: Iterable[Coordinate]
-    ) -> Iterator[GridContent]:
+    ) -> Iterator[Agent]:
         """
         Args:
             cell_list: Array-like of (x, y) tuples, or single tuple.
@@ -603,7 +602,7 @@ class HexGrid(Grid):
         for i in coordinates:
             yield i
 
-    def neighbor_iter(self, pos: Coordinate) -> Iterator[GridContent]:
+    def neighbor_iter(self, pos: Coordinate) -> Iterator[Agent]:
         """Iterate over position neighbors.
 
         Args:
@@ -634,7 +633,7 @@ class HexGrid(Grid):
 
     def iter_neighbors(
         self, pos: Coordinate, include_center: bool = False, radius: int = 1
-    ) -> Iterator[GridContent]:
+    ) -> Iterator[Agent]:
         """Return an iterator over neighbors to a certain point.
 
         Args:
@@ -653,7 +652,7 @@ class HexGrid(Grid):
 
     def get_neighbors(
         self, pos: Coordinate, include_center: bool = False, radius: int = 1
-    ) -> List[GridContent]:
+    ) -> List[Agent]:
         """Return a list of neighbors to a certain point.
 
         Args:
@@ -767,7 +766,7 @@ class ContinuousSpace:
 
     def get_neighbors(
         self, pos: FloatCoordinate, radius: float, include_center: bool = True
-    ) -> List[GridContent]:
+    ) -> List[Agent]:
         """Get all objects within a certain radius.
 
         Args:
@@ -868,7 +867,7 @@ class NetworkGrid:
         self._place_agent(agent, node_id)
         agent.pos = node_id
 
-    def get_neighbors(self, node_id: int, include_center: bool = False) -> List[int]:
+    def get_neighbors(self, node_id: int, include_center: bool = False) -> List[Agent]:
         """ Get all adjacent nodes """
 
         neighbors = list(self.G.neighbors(node_id))
@@ -898,13 +897,13 @@ class NetworkGrid:
         """ Returns a bool of the contents of a cell. """
         return not self.G.nodes[node_id]["agent"]
 
-    def get_cell_list_contents(self, cell_list: List[int]) -> List[GridContent]:
+    def get_cell_list_contents(self, cell_list: List[int]) -> List[Agent]:
         return list(self.iter_cell_list_contents(cell_list))
 
     def get_all_cell_contents(self) -> List[GridContent]:
         return list(self.iter_cell_list_contents(self.G))
 
-    def iter_cell_list_contents(self, cell_list: List[int]) -> List[GridContent]:
+    def iter_cell_list_contents(self, cell_list: List[int]) -> List[Agent]:
         list_of_lists = [
             self.G.nodes[node_id]["agent"]
             for node_id in cell_list

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -346,8 +346,8 @@ class Grid:
 
         """
         pos = self.torus_adj(pos)
-        assert isinstance(agent.pos, Tuple[int, int])
-        self._remove_agent(agent.pos, agent)
+        old_pos = cast(Coordinate, agent.pos)
+        self._remove_agent(old_pos, agent)
         self._place_agent(pos, agent)
         agent.pos = pos
 
@@ -364,8 +364,7 @@ class Grid:
 
     def remove_agent(self, agent: Agent) -> None:
         """ Remove the agent from the grid and set its pos variable to None. """
-        pos = agent.pos
-        assert isinstance(pos, Tuple[int, int])
+        pos = cast(Coordinate, agent.pos)
         self._remove_agent(pos, agent)
         agent.pos = None
 
@@ -382,8 +381,7 @@ class Grid:
 
     def move_to_empty(self, agent: Agent) -> None:
         """ Moves agent to a random empty cell, vacating agent's old cell. """
-        pos = agent.pos
-        assert isinstance(pos, Tuple[int, int])
+        pos = cast(Coordinate, agent.pos)
         if len(self.empties) == 0:
             raise Exception("ERROR: No empty cells")
         new_pos = agent.random.choice(sorted(self.empties))
@@ -881,8 +879,8 @@ class NetworkGrid:
 
     def move_agent(self, agent: Agent, node_id: int) -> None:
         """ Move an agent from its current node to a new node. """
-        assert isinstance(agent.pos, int)
-        self._remove_agent(agent, agent.pos)
+        old_pos = cast(int, agent.pos)
+        self._remove_agent(agent, old_pos)
         self._place_agent(agent, node_id)
         agent.pos = node_id
 

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -13,6 +13,7 @@ MultiGrid: extension to Grid where each cell is a set of objects.
 # good reason to use one-character variable names for x and y.
 # pylint: disable=invalid-name
 
+from abc import abstractmethod
 import itertools
 
 import numpy as np
@@ -41,7 +42,7 @@ NetworkCoordinate = int
 Position = Union[Coordinate, FloatCoordinate, NetworkCoordinate]
 
 GridContent = Optional[Agent]
-MultiGridContent = Set[Agent]
+MultiGridContent = List[Agent]
 
 F = TypeVar("F", bound=Callable[..., Any])
 Content = TypeVar("Content")
@@ -122,6 +123,7 @@ class BaseGrid(Generic[Content]):
         self.empties = set(itertools.product(*(range(self.width), range(self.height))))
 
     @staticmethod
+    @abstractmethod
     def default_val() -> Content:
         pass
 
@@ -436,16 +438,6 @@ class SingleGrid(Grid):
 
     empties: Set[Coordinate] = set()
 
-    def __init__(self, width: int, height: int, torus: bool) -> None:
-        """Create a new single-item grid.
-
-        Args:
-            width, height: The width and width of the grid
-            torus: Boolean whether the grid wraps or not.
-
-        """
-        super().__init__(width, height, torus)
-
     def position_agent(
         self, agent: Agent, x: Union[int, str] = "random", y: Union[int, str] = "random"
     ) -> None:
@@ -501,7 +493,7 @@ class MultiGrid(BaseGrid[MultiGridContent]):
         return self.grid[index]
 
     @staticmethod
-    def default_val() -> Set[Agent]:
+    def default_val() -> List[Agent]:
         """ Default value for new cell elements. """
         return []
 


### PR DESCRIPTION
Even more type annotations for space.py (after #779 and #796)

This PR makes mypy happy for grid, multigrid and hexgrid, except for some cases where the subclasses override the base class types (which is not solvable with type annotations, but would require changes to the logic itself).  

@rht since you did the previous type annotations, could you do a code review?