### PR TITLE
This should fix cookie cutter in the install. Fixes #850

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include HISTORY.rst
 include README.rst
 include setup.py
+include mesa/cookiecutter-mesa/*
 include mesa/visualization/templates/*.html
 include mesa/visualization/templates/css/*
 include mesa/visualization/templates/fonts/*


### PR DESCRIPTION
This fixes #850. The cookiecutter directory doesn't seem to be have been included in the manifest and no one noticed before... I guess. 