### PR TITLE
remove relative imports -- fix #855

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ target/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# pythonenv
+pythonenv*/

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -7,8 +7,8 @@ Core Objects: Model, and Agent.
 """
 import datetime
 
-from .model import Model
-from .agent import Agent
+from mesa.model import Model
+from mesa.agent import Agent
 
 
 __all__ = ["Model", "Agent"]

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 The agent class for Mesa framework.
 
@@ -6,7 +5,7 @@ Core Objects: Agent
 
 """
 # mypy
-from .model import Model
+from mesa.model import Model
 from random import Random
 
 

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Batchrunner
 ===========

--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Mesa Data Collection Module
 ===========================

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 The model class for Mesa framework.
 

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Mesa Space Module
 =================

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -19,7 +19,7 @@ import itertools
 import numpy as np
 
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
-from .agent import Agent
+from mesa.agent import Agent
 
 Coordinate = Tuple[int, int]
 GridContent = Union[Optional[Agent], Set[Agent]]

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Mesa Time Module
 ================
@@ -26,8 +25,8 @@ from collections import OrderedDict
 
 # mypy
 from typing import Dict, Iterator, List, Optional, Union
-from .agent import Agent
-from .model import Model
+from mesa.agent import Agent
+from mesa.model import Model
 
 
 # BaseScheduler has a self.time of int, while

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ModularServer
 =============

--- a/mesa/visualization/TextVisualization.py
+++ b/mesa/visualization/TextVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Text Visualization
 ==================

--- a/mesa/visualization/__init__.py
+++ b/mesa/visualization/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Mesa Visualization Module
 -------------------------

--- a/mesa/visualization/modules/BarChartVisualization.py
+++ b/mesa/visualization/modules/BarChartVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Pie Chart Module
 ============

--- a/mesa/visualization/modules/CanvasGridVisualization.py
+++ b/mesa/visualization/modules/CanvasGridVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Modular Canvas Rendering
 ========================

--- a/mesa/visualization/modules/ChartVisualization.py
+++ b/mesa/visualization/modules/ChartVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Chart Module
 ============

--- a/mesa/visualization/modules/HexGridVisualization.py
+++ b/mesa/visualization/modules/HexGridVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Modular Canvas Rendering
 ========================

--- a/mesa/visualization/modules/NetworkVisualization.py
+++ b/mesa/visualization/modules/NetworkVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Network Visualization Module
 ============

--- a/mesa/visualization/modules/PieChartVisualization.py
+++ b/mesa/visualization/modules/PieChartVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Pie Chart Module
 ============

--- a/mesa/visualization/modules/TextVisualization.py
+++ b/mesa/visualization/modules/TextVisualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Text Module
 ============


### PR DESCRIPTION
#855 fails due to sphinx having problem with relative imports, depending on the folder structure. With our current folder structure we can not use relative imports. This PR changes the relative import to absolute ones. 

Further details about the underlying issue can be found at [](https://stackoverflow.com/questions/20251007/sphinx-and-relative-imports-in-python-3)