### PR TITLE
Travis: Remove python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
 cache:
   pip: true
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"


### PR DESCRIPTION
This is separated from #883 because the PyPy3 build failed. And we can already remove 3.5 without waiting on PyPy3 installation to be fixed.

Python 3.5 will reach EOL at 2020-09-13.