### PR TITLE
ModularServer updates: Fix EventLoop and changes to default port

### DIFF
--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -236,7 +236,7 @@ class ModularServer(tornado.web.Application):
 
     verbose = True
 
-    port = 8521  # Default port to listen on
+    port = int(os.getenv("PORT", 8521))  # Default port to listen on
     max_steps = 100000
 
     # Handlers and other globals:

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -95,7 +95,9 @@ Client -> Server:
     }
 
 """
+import asyncio
 import os
+import sys
 import tornado.autoreload
 import tornado.ioloop
 import tornado.web
@@ -109,6 +111,10 @@ from mesa.visualization.UserParam import UserSettableParameter
 # Suppress several pylint warnings for this file.
 # Attributes being defined outside of init is a Tornado feature.
 # pylint: disable=attribute-defined-outside-init
+
+# Change the event loop policy for windows
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 class VisualizationElement:


### PR DESCRIPTION
First, this is a fix to an issue on windows, where the default event loop is incompatible with tornado (#854)

Second, I changed the default port to use an environmental variable `$PORT`, if it exists. This is for example used by Heroku and will make it a bit easier to deploy models there.