### PR TITLE
Update travis python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,15 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install codecov
   - pip install .[dev]
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.5 ]]; then pip install -U black; fi
 script:
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
   - flake8 .
   - py.test --cov=mesa tests/ --cov-report=xml
-  - if [ $PYTHON != "3.5" ];
-    then black --check --exclude=mesa/cookiecutter-mesa/* .;
-    fi
+  - black --check --exclude=mesa/cookiecutter-mesa/* .
   # - ./tests/test_end_to_end_viz.sh  # needs to be investigated on why this took forever
 after_success:
   - codecov

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from codecs import open
 requires = ["click", "cookiecutter", "networkx", "numpy", "pandas", "tornado", "tqdm"]
 
 extras_require = {
-    "dev": ["coverage", "flake8", "pytest >= 4.6", "pytest-cov", "sphinx"],
+    "dev": ["black", "coverage", "flake8", "pytest >= 4.6", "pytest-cov", "sphinx"],
     "docs": ["sphinx"],
 }
 


### PR DESCRIPTION
Update to include Python 3.9 testing on travis.

Since we already removed support for Python 3.5 earlier, we don't need to juggle around with python versions for black and I now added black as a developer tool/install in `setup.py`. 