### PR TITLE
GA: Only run CI when pushed to master

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
See #973 for example of wasteful CI running because it is pushed to a non-master branch.