### PR TITLE
Fix order of variable_params in model and agent vars data frames

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -257,10 +257,10 @@ class FixedBatchRunner:
         column as a key.
         """
         extra_cols = ["Run"] + (extra_cols or [])
-        index_cols = set()
-        for params in self.parameters_list:
-            index_cols |= params.keys()
-        index_cols = list(index_cols) + extra_cols
+        index_cols = []
+        if self.parameters_list:
+            index_cols = list(self.parameters_list[0].keys())
+        index_cols += extra_cols
 
         records = []
         for param_key, values in vars_dict.items():

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -100,6 +100,11 @@ class FixedBatchRunner:
         self.iterations = iterations
         self.max_steps = max_steps
 
+        for params in self.parameters_list:
+            if list(params) != list(self.parameters_list[0]):
+                msg = "parameter names in parameters_list are not equal across the list"
+                raise ValueError(msg)
+
         self.model_reporters = model_reporters
         self.agent_reporters = agent_reporters
 

--- a/tests/test_batchrunner.py
+++ b/tests/test_batchrunner.py
@@ -151,6 +151,11 @@ class TestBatchRunner(unittest.TestCase):
         )  # extra column with run index
         self.assertEqual(model_vars.shape, (self.model_runs, expected_cols))
         self.assertEqual(len(model_collector.keys()), self.model_runs)
+        for var, values in self.variable_params.items():
+            self.assertEqual(set(model_vars[var].unique()), set(values))
+        if self.fixed_params:
+            for var, values in self.fixed_params.items():
+                self.assertEqual(set(model_vars[var].unique()), set(values))
 
     def test_agent_level_vars(self):
         """
@@ -169,6 +174,8 @@ class TestBatchRunner(unittest.TestCase):
         assert "agent_id" in list(agent_collector[(0, 1, 1)].columns)
         assert "Step" in list(agent_collector[(0, 1, 5)].index.names)
         assert "nose" not in list(agent_collector[(0, 1, 1)].columns)
+        for var, values in self.variable_params.items():
+            self.assertEqual(set(agent_vars[var].unique()), set(values))
 
         self.assertEqual(
             agent_collector[(0, 1, 0)].shape, (NUM_AGENTS * self.max_steps, 2)

--- a/tests/test_batchrunner.py
+++ b/tests/test_batchrunner.py
@@ -273,19 +273,13 @@ class TestBatchRunner(unittest.TestCase):
             {"variable_model_param": 2},
             {"variable_model_param": 2, "variable_agent_param": 8},
             {"variable_model_param": 3, "variable_agent_param": 8},
+            {"variable_agent_param": 1},
         ]
-        max_n_params = max(len(p) for p in self.variable_params)
-        batch = self.launch_batch_processing_fixed_list()
+        # This is currently not supported. Check that it raises the correct error.
+        msg = "parameter names in parameters_list are not equal across the list"
+        with self.assertRaises(ValueError, msg=msg):
+            self.launch_batch_processing_fixed_list()
 
-        model_vars = batch.get_model_vars_dataframe()
-        expected_cols = max_n_params + len(self.model_reporters) + 1
-        self.assertEqual(model_vars.shape, (self.model_runs, expected_cols))
-
-        agent_vars = batch.get_agent_vars_dataframe()
-        expected_cols = max_n_params + len(self.agent_reporters) + 2
-        self.assertEqual(
-            agent_vars.shape, (self.model_runs * NUM_AGENTS, expected_cols)
-        )
 
 class TestParameters(unittest.TestCase):
     def test_product(self):


### PR DESCRIPTION
Demonstrates and ~(hopefully soon)~ fixes #978.

As mentioned in https://github.com/projectmesa/mesa/issues/978#issuecomment-765809899, there's an issue where `set()` is used, which results in a non-deterministic order of the columns of data frames created by `FixedBatchRunner._prepare_report_table`. Not using `set` should be the solution, here.