### PR TITLE
Public remove_agent function for NetworkGrid

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -871,6 +871,12 @@ class NetworkGrid:
 
         self.G.nodes[node_id]["agent"].remove(agent)
 
+    def remove_agent(self, agent: Agent) -> None:
+        """ Remove the agent from the network and set its pos variable to None. """
+        pos = agent.pos
+        self._remove_agent(agent, pos)
+        agent.pos = None
+
     def is_cell_empty(self, node_id: int) -> bool:
         """ Returns a bool of the contents of a cell. """
         return not self.G.nodes[node_id]["agent"]

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -357,6 +357,15 @@ class TestSingleNetworkGrid(unittest.TestCase):
         assert _agent not in self.space.G.nodes[initial_pos]["agent"]
         assert _agent in self.space.G.nodes[final_pos]["agent"]
 
+    def test_remove_agent(self):
+        for i, pos in enumerate(TEST_AGENTS_NETWORK_SINGLE):
+            a = self.agents[i]
+            assert a.pos == pos
+            assert a in self.space.G.nodes[pos]["agent"]
+            self.space.remove_agent(a)
+            assert a.pos is None
+            assert a not in self.space.G.nodes[pos]["agent"]
+
     def test_is_cell_empty(self):
         assert not self.space.is_cell_empty(0)
         assert self.space.is_cell_empty(TestSingleNetworkGrid.GRAPH_SIZE - 1)


### PR DESCRIPTION
Closes #1000.

This pull request implements a new feature: a public function for removing an agent from a NetworkGrid. For more, see issue #1000. 

The pull request only adds a view lines of code, most of which was just a slightly altered version of what already existed. In particular, this code exposes the `_remove_agent` in the same way that the `space.Grid` superclass does.