### PR TITLE
CI: Run on pushed to main and release branches

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,8 @@ name: build
 on:
   push:
     branches:
-    - master
+    - main
+    - release**
   pull_request:
 
 jobs:


### PR DESCRIPTION
Now that the default branch is changed to `main` in #969, the GitHub Actions CI should be updated as well to run on pushes to that branch. It now also runs on pushes to release branches (starting with `release`).