### PR TITLE
Docs/examples: Update links to use main instead of master as branch

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,7 +28,7 @@ No contribution is too small. Although, contributions can be too big, so let's d
 - Git commit your changes with a meaningful message: ``git commit -m "Fixes X issue."``
 - If implementing a new feature, include some documentation in docs folder.
 - Make sure that your submission passes the `Travis build`_. See "Testing and Standards below" to be able to run these locally.
-- Make sure that your code is formatted according to `the black`_ standard (you can do it via `pre-commit`_). 
+- Make sure that your code is formatted according to `the black`_ standard (you can do it via `pre-commit`_).
 - Push your changes to your fork on Github: ``git push origin NAME_OF_BRANCH``.
 - `Create a pull request`_.
 - Describe the change w/ ticket number(s) that the code fixes.
@@ -43,7 +43,7 @@ No contribution is too small. Although, contributions can be too big, so let's d
 Testing and Code Standards
 --------
 
-.. image:: https://codecov.io/gh/projectmesa/mesa/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/projectmesa/mesa/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/projectmesa/mesa
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
@@ -83,7 +83,7 @@ You should no longer have to worry about code formatting. If still in doubt you 
 .. code-block:: bash
 
     flake8 . --ignore=F403,E501,E123,E128,W504,W503 --exclude=docs,build
-    
+
 
 .. _`PEP8` : https://www.python.org/dev/peps/pep-0008
 .. _`Google Style Guide` : https://google.github.io/styleguide/pyguide.html
@@ -95,7 +95,7 @@ Licensing
 
 The license of this project is located in `LICENSE`_.  By submitting a contribution to this project, you are agreeing that your contribution will be released under the terms of this license.
 
-.. _`LICENSE` : https://github.com/projectmesa/mesa/blob/master/LICENSE
+.. _`LICENSE` : https://github.com/projectmesa/mesa/blob/main/LICENSE
 
 
 Special Thanks

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -485,7 +485,7 @@ Theme: Scipy Sprints ( ‘-’)人(ﾟ_ﾟ )
 * Fixes: Order of operations reversed: agent is removed first and then it is placed.
 * Improvement: `LICENSE`_ was updates from MIT to Apache 2.0.
 
-.. _`LICENSE` : https://github.com/projectmesa/mesa/blob/master/LICENSE
+.. _`LICENSE` : https://github.com/projectmesa/mesa/blob/main/LICENSE
 
 
 0.6.0 (2015-06-21)

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Mesa: Agent-based modeling in Python 3+
 .. image:: https://github.com/projectmesa/mesa/workflows/build/badge.svg
         :target: https://github.com/projectmesa/mesa/actions
 
-.. image:: https://codecov.io/gh/projectmesa/mesa/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/projectmesa/mesa/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/projectmesa/mesa
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
@@ -15,7 +15,7 @@ Mesa: Agent-based modeling in Python 3+
 It allows users to quickly create agent-based models using built-in core components (such as spatial grids and agent schedulers) or customized implementations; visualize them using a browser-based interface; and analyze their results using Python's data analysis tools. Its goal is to be the Python 3-based alternative to NetLogo, Repast, or MASON.
 
 
-.. image:: https://github.com/projectmesa/mesa/blob/master/docs/images/Mesa_Screenshot.png
+.. image:: https://github.com/projectmesa/mesa/blob/main/docs/images/Mesa_Screenshot.png
    :width: 100%
    :scale: 100%
    :alt: A screenshot of the Schelling Model in Mesa
@@ -50,7 +50,7 @@ You can also use `pip` to install the github version:
 
     $ pip install -e git+https://github.com/projectmesa/mesa#egg=mesa
 
-Take a look at the `examples <https://github.com/projectmesa/mesa/tree/master/examples>`_ folder for sample models demonstrating Mesa features.
+Take a look at the `examples <https://github.com/projectmesa/mesa/tree/main/examples>`_ folder for sample models demonstrating Mesa features.
 
 For more help on using Mesa, check out the following resources:
 
@@ -77,7 +77,7 @@ If you are a Mesa developer, first `install docker-compose <https://docs.docker.
     ...
     $ docker-compose up -d dev # start the docker container
     $ docker-compose exec dev bash # enter the docker container that has your current version of Mesa installed at /opt/mesa
-    $ mesa runserver examples/Schelling # or any other example model in examples
+    $ mesa runserver examples/schelling # or any other example model in examples
 
 
 The docker-compose file does two important things:
@@ -105,5 +105,5 @@ If you would like to add a feature, please reach out via `ticket`_ or the `dev e
 
 .. _`ticket` : https://github.com/projectmesa/mesa/issues
 .. _`dev email list` : https://groups.google.com/forum/#!forum/projectmesa-dev
-.. _`Contributors guide` : https://github.com/projectmesa/mesa/blob/master/CONTRIBUTING.rst
+.. _`Contributors guide` : https://github.com/projectmesa/mesa/blob/main/CONTRIBUTING.rst
 .. _`Github` : https://github.com/projectmesa/mesa/

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,13 +29,13 @@ Updating docs can be confusing. Here are the basic setups.
  * ```git commit -am "Updating docs."```
 1. Push the branch
  * ```git push origin doc-updates```
-1. From here you will want to submit a pull request to master.
+1. From here you will want to submit a pull request to main.
 
 ##### Update read the docs
 
 From this point, you will need to find someone that has access to readthedocs. Currently, that is [@jackiekazil](https://github.com/jackiekazil) and [@dmasad](https://github.com/dmasad).
 
-1. Accept the pull request into master.
+1. Accept the pull request into main.
 1. Log into readthedocs and launch a new build -- builds take about 10 minutes or so.
 
 ### Helpful Sphnix tips

--- a/docs/best-practices.rst
+++ b/docs/best-practices.rst
@@ -27,7 +27,7 @@ organize them. For example, if the visualization uses image files, put those in
 an ``images`` directory.
 
 The `Schelling
-<https://github.com/projectmesa/mesa/tree/master/examples/schelling>`_ model is
+<https://github.com/projectmesa/mesa/tree/main/examples/schelling>`_ model is
 a good example of a small well-packaged model.
 
 It's easy to create a cookiecutter mesa model by running ``mesa startproject``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Mesa: Agent-based modeling in Python 3+
 .. image:: https://api.travis-ci.org/projectmesa/mesa.svg
     :target: https://travis-ci.org/projectmesa/mesa
 
-.. image:: https://codecov.io/gh/projectmesa/mesa/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/projectmesa/mesa/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/projectmesa/mesa
 
 `Mesa`_ is an Apache2 licensed agent-based modeling (or ABM) framework in Python.
@@ -72,7 +72,7 @@ If you would like to add a feature, please reach out via `ticket`_ or the `email
 
 .. _`ticket` : https://github.com/projectmesa/mesa/issues
 .. _`email list` : https://groups.google.com/d/forum/projectmesa
-.. _`Contributors guide` : https://github.com/projectmesa/mesa/blob/master/CONTRIBUTING.rst
+.. _`Contributors guide` : https://github.com/projectmesa/mesa/blob/main/CONTRIBUTING.rst
 .. _`Github` : https://github.com/projectmesa/mesa/
 
 

--- a/docs/tutorials/adv_tutorial.ipynb
+++ b/docs/tutorials/adv_tutorial.ipynb
@@ -364,7 +364,7 @@
     "            self.js_code = \"elements.push(\" + new_element + \");\"\n",
     "```\n",
     "\n",
-    "There are a few things going on here. `package_includes` is a list of JavaScript files that are part of Mesa itself that the visualization element relies on. You can see the included files in [mesa/visualization/templates/](https://github.com/projectmesa/mesa/tree/master/mesa/visualization/templates). Similarly, `local_includes` is a list of JavaScript files in the same directory as the class code itself. Note that both of these are class variables, not object variables -- they hold for all particular objects.\n",
+    "There are a few things going on here. `package_includes` is a list of JavaScript files that are part of Mesa itself that the visualization element relies on. You can see the included files in [mesa/visualization/templates/](https://github.com/projectmesa/mesa/tree/main/mesa/visualization/templates). Similarly, `local_includes` is a list of JavaScript files in the same directory as the class code itself. Note that both of these are class variables, not object variables -- they hold for all particular objects.\n",
     "\n",
     "Next, look at the `__init__` method. It takes three arguments: the number of bins, and the width and height for the histogram. It then uses these values to populate the `js_code` property; this is code that the server will insert into the visualization page, which will run when the page loads. In this case, it creates a new HistogramModule (the class we created in JavaScript in the step above) with the desired bins, width and height; it then appends  (`push`es) this object to `elements`, the list of visualization elements that the visualization page itself maintains.\n",
     "\n",
@@ -399,7 +399,7 @@
     "\n",
     "![Histogram Visualization](files/viz_histogram.png)\n",
     "\n",
-    "If you've felt comfortable with this section, it might be instructive to read the code for the [ModularServer](https://github.com/projectmesa/mesa/blob/master/mesa/visualization/ModularVisualization.py#L259) and the [modular_template](https://github.com/projectmesa/mesa/blob/master/mesa/visualization/templates/modular_template.html) to get a better idea of how all the pieces fit together."
+    "If you've felt comfortable with this section, it might be instructive to read the code for the [ModularServer](https://github.com/projectmesa/mesa/blob/main/mesa/visualization/ModularVisualization.py#L259) and the [modular_template](https://github.com/projectmesa/mesa/blob/main/mesa/visualization/templates/modular_template.html) to get a better idea of how all the pieces fit together."
    ]
   },
   {

--- a/docs/tutorials/adv_tutorial.rst
+++ b/docs/tutorials/adv_tutorial.rst
@@ -439,7 +439,7 @@ inherit from, and create the new visualization class.
 There are a few things going on here. ``package_includes`` is a list of
 JavaScript files that are part of Mesa itself that the visualization
 element relies on. You can see the included files in
-`mesa/visualization/templates/ <https://github.com/projectmesa/mesa/tree/master/mesa/visualization/templates>`__.
+`mesa/visualization/templates/ <https://github.com/projectmesa/mesa/tree/main/mesa/visualization/templates>`__.
 Similarly, ``local_includes`` is a list of JavaScript files in the same
 directory as the class code itself. Note that both of these are class
 variables, not object variables -- they hold for all particular objects.
@@ -499,9 +499,9 @@ visualization and updating along with the model!
 
 If you've felt comfortable with this section, it might be instructive to
 read the code for the
-`ModularServer <https://github.com/projectmesa/mesa/blob/master/mesa/visualization/ModularVisualization.py#L259>`__
+`ModularServer <https://github.com/projectmesa/mesa/blob/main/mesa/visualization/ModularVisualization.py#L259>`__
 and the
-`modular\_template <https://github.com/projectmesa/mesa/blob/master/mesa/visualization/templates/modular_template.html>`__
+`modular\_template <https://github.com/projectmesa/mesa/blob/main/mesa/visualization/templates/modular_template.html>`__
 to get a better idea of how all the pieces fit together.
 
 Happy Modeling!

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -56,7 +56,7 @@
     "When you do that, it will install Mesa itself, as well as any dependencies that aren't in your setup yet. Additional dependencies required by this tutorial can be found in the **examples/boltzmann_wealth_model/requirements.txt** file, which can be installed directly form the github repository by running:\n",
     "\n",
     "```bash\n",
-    "    $ pip install -r https://raw.githubusercontent.com/projectmesa/mesa/master/examples/boltzmann_wealth_model/requirements.txt  \n",
+    "    $ pip install -r https://raw.githubusercontent.com/projectmesa/mesa/main/examples/boltzmann_wealth_model/requirements.txt  \n",
     "```\n",
     "\n",
     "This will install the dependencies listed in the requirements.txt file which are:  \n",

--- a/docs/tutorials/intro_tutorial.rst
+++ b/docs/tutorials/intro_tutorial.rst
@@ -65,7 +65,7 @@ installed directly form the github repository by running:
 
 .. code:: bash
 
-       $ pip install -r https://raw.githubusercontent.com/projectmesa/mesa/master/examples/boltzmann_wealth_model/requirements.txt
+       $ pip install -r https://raw.githubusercontent.com/projectmesa/mesa/main/examples/boltzmann_wealth_model/requirements.txt
 
 | This will install the dependencies listed in the requirements.txt file
   which are:
@@ -223,7 +223,7 @@ Then create the model object, and run it for one step:
     Hi, I am agent 6.
     Hi, I am agent 8.
     Hi, I am agent 1.
-    
+
 
 Exercise
 ^^^^^^^^
@@ -306,10 +306,10 @@ this line, to make the graph appear.
 
     # For a jupyter notebook add the following line:
     %matplotlib inline
-    
+
     # The below is needed for both notebooks and scripts
     import matplotlib.pyplot as plt
-    
+
     agent_wealth = [a.wealth for a in model.schedule.agents]
     plt.hist(agent_wealth)
 
@@ -933,7 +933,7 @@ times (49* 5) for 245 iterations
 .. parsed-literal::
 
     245it [03:36,  1.13it/s]
-    
+
 
 BatchRunner has two ways to collect data.
 
@@ -972,7 +972,7 @@ iteration number and then the datacollector dataframe. So in this model
 
     #Get the Agent DataCollection
     data_collector_agents = batch_run.get_collector_agents()
-    
+
     data_collector_agents[(10,2)]
 
 
@@ -985,11 +985,11 @@ iteration number and then the datacollector dataframe. So in this model
         .dataframe tbody tr th:only-of-type {
             vertical-align: middle;
         }
-    
+
         .dataframe tbody tr th {
             vertical-align: top;
         }
-    
+
         .dataframe thead th {
             text-align: right;
         }
@@ -1064,10 +1064,10 @@ iteration number and then the datacollector dataframe. So in this model
 
 .. code:: ipython3
 
-    #Get the Model DataCollection. 
-    
+    #Get the Model DataCollection.
+
     data_collector_model = batch_run.get_collector_model()
-    
+
     data_collector_model[(10,1)]
 
 
@@ -1080,11 +1080,11 @@ iteration number and then the datacollector dataframe. So in this model
         .dataframe tbody tr th:only-of-type {
             vertical-align: middle;
         }
-    
+
         .dataframe tbody tr th {
             vertical-align: top;
         }
-    
+
         .dataframe thead th {
             text-align: right;
         }

--- a/examples/bank_reserves/bank_reserves/random_walk.py
+++ b/examples/bank_reserves/bank_reserves/random_walk.py
@@ -1,7 +1,7 @@
 """
 Citation:
 The following code is a copy from random_walk.py at
-https://github.com/projectmesa/mesa/blob/master/examples/wolf_sheep/wolf_sheep/random_walk.py
+https://github.com/projectmesa/mesa/blob/main/examples/wolf_sheep/wolf_sheep/random_walk.py
 Accessed on: November 2, 2017
 Original Author: Jackie Kazil
 

--- a/examples/bank_reserves/bank_reserves/server.py
+++ b/examples/bank_reserves/bank_reserves/server.py
@@ -7,7 +7,7 @@ from bank_reserves.model import BankReserves
 """
 Citation:
 The following code was adapted from server.py at
-https://github.com/projectmesa/mesa/blob/master/examples/wolf_sheep/wolf_sheep/server.py
+https://github.com/projectmesa/mesa/blob/main/examples/wolf_sheep/wolf_sheep/server.py
 Accessed on: November 2, 2017
 Author of original code: Taylor Mutch
 """

--- a/examples/charts/charts/random_walk.py
+++ b/examples/charts/charts/random_walk.py
@@ -1,7 +1,7 @@
 """
 Citation:
 The following code is a copy from random_walk.py at
-https://github.com/projectmesa/mesa/blob/master/examples/wolf_sheep/wolf_sheep/random_walk.py
+https://github.com/projectmesa/mesa/blob/main/examples/wolf_sheep/wolf_sheep/random_walk.py
 Accessed on: November 2, 2017
 Original Author: Jackie Kazil
 

--- a/examples/charts/charts/server.py
+++ b/examples/charts/charts/server.py
@@ -12,7 +12,7 @@ from charts.model import Charts
 """
 Citation:
 The following code was adapted from server.py at
-https://github.com/projectmesa/mesa/blob/master/examples/wolf_sheep/wolf_sheep/server.py
+https://github.com/projectmesa/mesa/blob/main/examples/wolf_sheep/wolf_sheep/server.py
 Accessed on: November 2, 2017
 Author of original code: Taylor Mutch
 """

--- a/examples/color_patches/Readme.md
+++ b/examples/color_patches/Readme.md
@@ -35,4 +35,4 @@ Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and p
 ## Further Reading
 
 Inspired from [this model](http://www.cs.sjsu.edu/~pearce/modules/lectures/abs/as/ca.htm) from San Jose University<br>
-Other similar models: [Schelling Segregation Model](https://github.com/projectmesa/mesa/tree/master/examples/Schelling)
+Other similar models: [Schelling Segregation Model](https://github.com/projectmesa/mesa/tree/main/examples/schelling)


### PR DESCRIPTION
I noticed that a few of the links and buttons were broken while reading the documentation, which was caused by renaming the default branch from `master` to `main` (in #969). This PR aims to fix all those broken links. I think I got them all, but please check carefully.

One link we have to watch carefully is http://mesa.readthedocs.org/en/master/. /main/ doesn't work yet, but it could break on the next release or docs update.

**Edit:** In commit e4855d3 from #707 the `examples/Schelling` directory was renamed to `examples/schelling`, decapitalizing it. This PR now also fixed a few of these cases.