### PR TITLE
CI: Add workflow to update Pipfile.lock every month

### DIFF
--- a/.github/workflows/update-pipfile.yml
+++ b/.github/workflows/update-pipfile.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
     - run: pip install wheel
     - run: pip install pipenv
     - run: pipenv lock

--- a/.github/workflows/update-pipfile.yml
+++ b/.github/workflows/update-pipfile.yml
@@ -1,0 +1,27 @@
+name: "Update Pipfile.lock"
+on:
+  schedule:
+    - cron: '0 6 1 * *' # 1st day of each month at 06:00 UTC
+  push:
+    paths:
+    - 'Pipfile'
+    - '.github/workflows/update-pipfile.yml'
+
+jobs:
+  piplock:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - run: pip install wheel
+    - run: pip install pipenv
+    - run: pipenv lock
+    - uses: actions/upload-artifact@v2
+      with:
+        name: "Pipfile lock"
+        path: Pipfile.lock
+    - uses: peter-evans/create-pull-request@v2
+      with:
+        title: "Update Pipfile.lock (dependencies)"
+        branch: update-pipfile
+        commit-message: "[Bot] Update Pipfile.lock dependencies"

--- a/.github/workflows/update-pipfile.yml
+++ b/.github/workflows/update-pipfile.yml
@@ -27,4 +27,5 @@ jobs:
       with:
         title: "Update Pipfile.lock (dependencies)"
         branch: update-pipfile
+        base: main
         commit-message: "[Bot] Update Pipfile.lock dependencies"

--- a/.github/workflows/update-pipfile.yml
+++ b/.github/workflows/update-pipfile.yml
@@ -15,14 +15,15 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: pip install wheel
-    - run: pip install pipenv
+    - run: pip install -U pip
+    - run: pip install -U wheel
+    - run: pip install -U pipenv
     - run: pipenv lock
     - uses: actions/upload-artifact@v2
       with:
         name: "Pipfile lock"
         path: Pipfile.lock
-    - uses: peter-evans/create-pull-request@v2
+    - uses: peter-evans/create-pull-request@v3
       with:
         title: "Update Pipfile.lock (dependencies)"
         branch: update-pipfile


### PR DESCRIPTION
Adds a workflow that generates a up to date lockfile based on the current Pipfile. The workflow runs every 1st day of each month, and if either this configuration or the Pipfile itself is modified. A run will open a PR with the updated pipfile.lock, and if a PR is already open it will update that PR.

By running and opening/updating a PR each month it's ensured the pipfile.lock stays up to date and updated frequently at convenient times, while reproducible builds are still ensured.

The schedule can be adjusted to fit development, of course.