### PR TITLE
CI: Maintenance: Update to Python 3.10, split of lint jobs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,19 +9,22 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: False
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.9]
+        os: [windows, ubuntu, macos]
+        python-version: ["3.10"]
         include:
-          - os: ubuntu-latest
-            python-version: 3.6
-          - os: ubuntu-latest
-            python-version: 3.7
-          - os: ubuntu-latest
-            python-version: 3.8
-          - os: ubuntu-latest
+          - os: ubuntu
+            python-version: "3.9"
+          - os: ubuntu
+            python-version: "3.8"
+          - os: ubuntu
+            python-version: "3.7"
+          - os: ubuntu
+            python-version: "3.6"
+          - os: ubuntu
             python-version: pypy3
 
     steps:
@@ -36,20 +39,36 @@ jobs:
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('Pipfile.lock') }}
       if: matrix.python-version == 'pypy3'
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[dev]
-    - name: Lint with flake8
-      run: |
-        # Use settings from mesas .flake8 file
-        flake8 . --count --show-source --statistics
-    - name: Lint with black
-      if: matrix.python-version == '3.8'
-      run: |
-        pip install black
-        black --check --exclude=mesa/cookiecutter-mesa/* .
+      run: pip install .[dev]
     - name: Test with pytest
-      run: |
-        pytest --cov=mesa tests/ --cov-report=xml
+      run: pytest --cov=mesa tests/ --cov-report=xml
     - name: Codecov
       uses: codecov/codecov-action@v1.0.15
+
+  lint-flake:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: pip install .[dev]
+    - name: Lint with flake8
+      # Use settings from mesas .flake8 file
+      run: flake8 . --count --show-source --statistics
+
+  lint-black:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: pip install .[dev]
+    - run: pip install black
+    - name: Lint with black
+      run: black --check --exclude=mesa/cookiecutter-mesa/* .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -69,6 +69,6 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: pip install .[dev]
-    - run: pip install black
+    - run: pip install black black[jupyter]
     - name: Lint with black
       run: black --check --exclude=mesa/cookiecutter-mesa/* .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -53,8 +53,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
-    - name: Install dependencies
-      run: pip install .[dev]
+    - run: pip install flake8
     - name: Lint with flake8
       # Use settings from mesas .flake8 file
       run: flake8 . --count --show-source --statistics
@@ -67,8 +66,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
-    - name: Install dependencies
-      run: pip install .[dev]
-    - run: pip install black black[jupyter]
+    - run: pip install black[jupyter]
     - name: Lint with black
       run: black --check --exclude=mesa/cookiecutter-mesa/* .


### PR DESCRIPTION
- Update main build jobs to Python 3.10
- Split of lint steps in separate jobs, so that the other jobs passes if the lint jobs fails
- Install black[jupyter] to also lint Jupyter notebooks with black

The new build matrix now looks like this:
<img alt="Screenshot_671" src="https://user-images.githubusercontent.com/15776622/142190937-9b19855a-96cf-41be-aab1-e631716aa69f.png">

