### PR TITLE
Docs: space.py: Fix single case of neighbor spelled as neighbour

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -569,7 +569,7 @@ class HexGrid(Grid):
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.
         get_neighborhood: Returns the cells surrounding a given cell.
-        neighbor_iter: Iterates over position neighbours.
+        neighbor_iter: Iterates over position neighbors.
         iter_neighborhood: Returns an iterator over cell coordinates that are
             in the neighborhood of a certain point.
 


### PR DESCRIPTION
Fix single case of neighbor spelled as neighbour in the space.py docs.