### PR TITLE
Convert all text strings to f-strings

### DIFF
--- a/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/server.py
+++ b/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/server.py
@@ -16,7 +16,7 @@ def network_portrayal(G):
             "color": "#CC0000" if not agents or agents[0].wealth == 0 else "#007959",
             "label": None
             if not agents
-            else "Agent:{} Wealth:{}".format(agents[0].unique_id, agents[0].wealth),
+            else f"Agent:{agents[0].unique_id} Wealth:{agents[0].wealth}",
         }
         for (node_id, agents) in G.nodes.data("agent")
     ]

--- a/examples/shape_example/shape_example/model.py
+++ b/examples/shape_example/shape_example/model.py
@@ -31,7 +31,7 @@ class ShapeExample(Model):
             heading = self.random.choice(self.headings)
             # heading = (1, 0)
             if self.grid.is_cell_empty(pos):
-                print("Creating agent {2} at ({0}, {1})".format(x, y, unique_id))
+                print(f"Creating agent {unique_id} at ({x}, {y})")
                 a = Walker(unique_id, self, pos, heading)
                 self.schedule.add(a)
                 self.grid.place_agent(a, pos)

--- a/examples/shape_example/shape_example/server.py
+++ b/examples/shape_example/shape_example/server.py
@@ -11,7 +11,7 @@ def agent_draw(agent):
         # aesthetics
         pass
     elif isinstance(agent, Walker):
-        print("Uid: {0}, Heading: {1}".format(agent.unique_id, agent.heading))
+        print(f"Uid: {agent.unique_id}, Heading: {agent.heading}")
         portrayal = {
             "Shape": "arrowHead",
             "Filled": "true",

--- a/examples/virus_on_network/virus_on_network/server.py
+++ b/examples/virus_on_network/virus_on_network/server.py
@@ -34,9 +34,7 @@ def network_portrayal(G):
         {
             "size": 6,
             "color": node_color(agents[0]),
-            "tooltip": "id: {}<br>state: {}".format(
-                agents[0].unique_id, agents[0].state.name
-            ),
+            "tooltip": f"id: {agents[0].unique_id}<br>state: {agents[0].state.name}",
         }
         for (_, agents) in G.nodes.data("agent")
     ]
@@ -67,7 +65,7 @@ chart = ChartModule(
 class MyTextElement(TextElement):
     def render(self, model):
         ratio = model.resistant_susceptible_ratio()
-        ratio_text = "&infin;" if ratio is math.inf else "{0:.2f}".format(ratio)
+        ratio_text = "&infin;" if ratio is math.inf else f"{ratio:.2f}"
         infected_text = str(number_infected(model))
 
         return "Resistant/Susceptible Ratio: {}<br>Infected Remaining: {}".format(

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -16,4 +16,4 @@ __all__ = ["Model", "Agent"]
 __title__ = "mesa"
 __version__ = "0.8.9"
 __license__ = "Apache 2.0"
-__copyright__ = "Copyright %s Project Mesa Team" % datetime.date.today().year
+__copyright__ = f"Copyright {datetime.date.today().year} Project Mesa Team"

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -428,7 +428,7 @@ class BatchRunnerMP(BatchRunner):
             # identify the number of processors available on users machine
             available_processors = cpu_count()
             self.processes = available_processors
-            print("BatchRunner MP will use {} processors.".format(self.processes))
+            print(f"BatchRunner MP will use {self.processes} processors.")
         else:
             self.processes = nr_processes
 

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -328,8 +328,8 @@ class ModularServer(tornado.web.Application):
         """Run the app."""
         if port is not None:
             self.port = port
-        url = "http://127.0.0.1:{PORT}".format(PORT=self.port)
-        print("Interface starting at {url}".format(url=url))
+        url = f"http://127.0.0.1:{self.port}"
+        print(f"Interface starting at {url}")
         self.listen(self.port)
         if open_browser:
             webbrowser.open(url)

--- a/mesa/visualization/UserParam.py
+++ b/mesa/visualization/UserParam.py
@@ -57,7 +57,7 @@ class UserSettableParameter:
         description=None,
     ):
         if param_type not in self.TYPES:
-            raise ValueError("{} is not a valid Option type".format(param_type))
+            raise ValueError(f"{param_type} is not a valid Option type")
         self.param_type = param_type
         self.name = name
         self._value = value

--- a/mesa/visualization/modules/NetworkVisualization.py
+++ b/mesa/visualization/modules/NetworkVisualization.py
@@ -17,7 +17,7 @@ class NetworkModule(VisualizationElement):
         library_types = ["sigma", "d3"]
         if library not in library_types:
             raise ValueError(
-                "Invalid javascript library type. Expected one of: %s" % library_types
+                f"Invalid javascript library type. Expected one of: {library_types}"
             )
 
         NetworkModule.package_includes = (
@@ -29,9 +29,7 @@ class NetworkModule(VisualizationElement):
         self.portrayal_method = portrayal_method
         self.canvas_height = canvas_height
         self.canvas_width = canvas_width
-        new_element = "new NetworkModule({}, {})".format(
-            self.canvas_width, self.canvas_height
-        )
+        new_element = f"new NetworkModule({self.canvas_width}, {self.canvas_height})"
         self.js_code = "elements.push(" + new_element + ");"
 
     def render(self, model):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -42,11 +42,11 @@ class TestExamples(unittest.TestCase):
         for example in os.listdir(self.EXAMPLES):
             if not os.path.isdir(os.path.join(self.EXAMPLES, example)):
                 continue
-            if hasattr(self, "test_{}".format(example.replace("-", "_"))):
+            if hasattr(self, f"test_{example.replace('-', '_')}"):
                 # non-standard example; tested below
                 continue
 
-            print("testing example {!r}".format(example))
+            print(f"testing example {example!r}")
             with self.active_example_dir(example):
                 try:
                     # model.py at the top level
@@ -55,11 +55,9 @@ class TestExamples(unittest.TestCase):
                     server.server.render_model()
                 except ImportError:
                     # <example>/model.py
-                    mod = importlib.import_module(
-                        "{}.model".format(example.replace("-", "_"))
-                    )
+                    mod = importlib.import_module(f"{example.replace('-', '_')}.model")
                     server = importlib.import_module(
-                        "{}.server".format(example.replace("-", "_"))
+                        f"{example.replace('-', '_')}.server"
                     )
                     server.server.render_model()
                 Model = getattr(mod, classcase(example))


### PR DESCRIPTION
Reformats all the text from the old "%-formatted" and .format(...) format to the newer f-string format, as defined in [PEP 498](https://www.python.org/dev/peps/pep-0498/). This Requires Python 3.6+.

[Flynt](https://github.com/ikamensh/flynt) 0.69 was used to reformat the strings. 16 f-strings were created in 10 files.

F-strings are in general more readable, concise and performant. See also: [PEP 498#Rationale](https://www.python.org/dev/peps/pep-0498/#Rationale).

```
Running flynt v.0.69
Can't parse mesa\mesa\cookiecutter-mesa\{{cookiecutter.snake}}\run.py as a python file.
Can't parse mesa\mesa\cookiecutter-mesa\{{cookiecutter.snake}}\{{cookiecutter.snake}}\model.py as a python file.

Flynt run has finished. Stats:

Execution time:                            1.377s
Files modified:                            10
Character count reduction:                 206 (0.06%)

Per expression type:
Old style (`%`) expressions attempted:     2/2 (100.0%)
`.format(...)` calls attempted:            19/19 (100.0%)
No concatenations attempted.
F-string expressions created:              16
```