### PR TITLE
Pyupgrade 3.6: Update syntax with Python 3.6+ features

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # Mesa documentation build configuration file, created by
 # sphinx-quickstart on Sun Jan  4 23:34:09 2015.

--- a/examples/sugarscape_cg/sugarscape_cg/agents.py
+++ b/examples/sugarscape_cg/sugarscape_cg/agents.py
@@ -47,12 +47,12 @@ class SsAgent(Agent):
         ]
         neighbors.append(self.pos)
         # Look for location with the most sugar
-        max_sugar = max([self.get_sugar(pos).amount for pos in neighbors])
+        max_sugar = max(self.get_sugar(pos).amount for pos in neighbors)
         candidates = [
             pos for pos in neighbors if self.get_sugar(pos).amount == max_sugar
         ]
         # Narrow down to the nearest ones
-        min_dist = min([get_distance(self.pos, pos) for pos in candidates])
+        min_dist = min(get_distance(self.pos, pos) for pos in candidates)
         final_candidates = [
             pos for pos in candidates if get_distance(self.pos, pos) == min_dist
         ]

--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -15,7 +15,7 @@ class State(Enum):
 
 
 def number_state(model, state):
-    return sum([1 for a in model.grid.get_all_cell_contents() if a.state is state])
+    return sum(1 for a in model.grid.get_all_cell_contents() if a.state is state)
 
 
 def number_infected(model):

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Mesa Agent-Based Modeling Framework
 

--- a/mesa/cookiecutter-mesa/{{cookiecutter.snake}}/setup.py
+++ b/mesa/cookiecutter-mesa/{{cookiecutter.snake}}/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
 requires = ["mesa"]

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -623,8 +623,7 @@ class HexGrid(Grid):
         if not include_center and pos in coordinates:
             coordinates.remove(pos)
 
-        for i in coordinates:
-            yield i
+        yield from coordinates
 
     def neighbor_iter(self, pos: Coordinate) -> Iterator[GridContent]:
         """Iterate over position neighbors.

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -62,7 +62,7 @@ class BaseScheduler:
 
         if agent.unique_id in self._agents:
             raise Exception(
-                "Agent with unique id {0} already added to scheduler".format(
+                "Agent with unique id {} already added to scheduler".format(
                     repr(agent.unique_id)
                 )
             )

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -62,9 +62,7 @@ class BaseScheduler:
 
         if agent.unique_id in self._agents:
             raise Exception(
-                "Agent with unique id {} already added to scheduler".format(
-                    repr(agent.unique_id)
-                )
+                f"Agent with unique id {repr(agent.unique_id)} already added to scheduler"
             )
 
         self._agents[agent.unique_id] = agent

--- a/mesa/visualization/modules/__init__.py
+++ b/mesa/visualization/modules/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Container for all built-in visualization modules.
 """

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import re
 
 from setuptools import setup, find_packages
@@ -13,7 +12,7 @@ extras_require = {
 }
 
 version = ""
-with open("mesa/__init__.py", "r") as fd:
+with open("mesa/__init__.py") as fd:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
     ).group(1)

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -110,7 +110,7 @@ class TestDataCollector(unittest.TestCase):
         self.step_assertion(data_collector.model_vars["total_agents"])
         for element in data_collector.model_vars["model_value"]:
             assert element == 100
-        self.step_assertion((data_collector.model_vars["model_calc"]))
+        self.step_assertion(data_collector.model_vars["model_calc"])
         for element in data_collector.model_vars["model_calc_comp"]:
             assert element == 75
         for element in data_collector.model_vars["model_calc_fail"]:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 import os.path
 import unittest


### PR DESCRIPTION
Updated Python code with Python 3.6+ features:
- utf-8 encoding is now the default ([PEP 3120](https://www.python.org/dev/peps/pep-3120/), Python 3.0+)
- Replace list comprehensions by Generator Expressions ([PEP 289](https://www.python.org/dev/peps/pep-0289/), Python 2.4+)
- Replace yield loop by yield from ([PEP 380](https://www.python.org/dev/peps/pep-0380/), Python 3.3+)

Used [pyupgrade](https://github.com/asottile/pyupgrade) 2.29.1 with `--py36-plus`.