### PR TITLE
Docs: Remove trailing white spaces

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -23,7 +23,7 @@ Most models consist of one class to represent the model itself; one class (or mo
 
 * ``mesa.Model``, ``mesa.Agent``
 * `mesa.time <apis/time.html>`_
-* `mesa.space <apis/space.html>`_ 
+* `mesa.space <apis/space.html>`_
 
 The skeleton of a model might look like this:
 
@@ -36,7 +36,7 @@ The skeleton of a model might look like this:
     class MyAgent(Agent):
         def __init__(self, name, model):
             super().__init__(name, model)
-            self.name = name 
+            self.name = name
 
         def step(self):
             print("{} activated".format(self.name))
@@ -73,7 +73,7 @@ Analysis modules
 If you're using modeling for research, you'll want a way to collect the data each model run generates. You'll probably also want to run the model multiple times, to see how some output changes with different parameters. Data collection and batch running are implemented in the appropriately-named analysis modules:
 
 * `mesa.datacollection <apis/datacollection.html>`_
-* `mesa.batchrunner <apis/batchrunner.html>`_ 
+* `mesa.batchrunner <apis/batchrunner.html>`_
 
 You'd add a data collector to the model like this:
 
@@ -86,7 +86,7 @@ You'd add a data collector to the model like this:
     class MyModel(Model):
         def __init__(self, n_agents):
             # ...
-            self.dc = DataCollector(model_reporters={"agent_count": 
+            self.dc = DataCollector(model_reporters={"agent_count":
                                         lambda m: m.schedule.get_agent_count()},
                                     agent_reporters={"name": lambda a: a.name})
 
@@ -148,9 +148,9 @@ To quickly spin up a model visualization, you might do something like:
         return portrayal
 
     grid = CanvasGrid(agent_portrayal, 10, 10, 500, 500)
-    server = ModularServer(MyModel, 
-                           [grid], 
-                           "My Model", 
+    server = ModularServer(MyModel,
+                           [grid],
+                           "My Model",
                            {'n_agents': 10})
     server.launch()
 

--- a/docs/packages.rst
+++ b/docs/packages.rst
@@ -37,7 +37,7 @@ User Guide
 
 **Step 1: Select a package**
 
-Currently, a central list of compatible packages is located on the `Mesa Wiki Packages Page <https://github.com/projectmesa/mesa/wiki/Mesa-Packages>`_. 
+Currently, a central list of compatible packages is located on the `Mesa Wiki Packages Page <https://github.com/projectmesa/mesa/wiki/Mesa-Packages>`_.
 
 **Step 2: Establish an environment**
 

--- a/examples/bank_reserves/Readme.md
+++ b/examples/bank_reserves/Readme.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-A highly abstracted, simplified model of an economy, with only one type of agent and a single bank representing all banks in an economy. People (represented by circles) move randomly within the grid. If two or more people are on the same grid location, there is a 50% chance that they will trade with each other. If they trade, there is an equal chance of giving the other agent $5 or $2. A positive trade balance will be deposited in the bank as savings. If trading results in a negative balance, the agent will try to withdraw from its savings to cover the balance. If it does not have enough savings to cover the negative balance, it will take out a loan from the bank to cover the difference. The bank is required to keep a certain percentage of deposits as reserves. If run.py is used to run the model, then the percent of deposits the bank is required to retain is a user settable parameter. The amount the bank is able to loan at any given time is a function of the amount of deposits, its reserves, and its current total outstanding loan amount. 
+A highly abstracted, simplified model of an economy, with only one type of agent and a single bank representing all banks in an economy. People (represented by circles) move randomly within the grid. If two or more people are on the same grid location, there is a 50% chance that they will trade with each other. If they trade, there is an equal chance of giving the other agent $5 or $2. A positive trade balance will be deposited in the bank as savings. If trading results in a negative balance, the agent will try to withdraw from its savings to cover the balance. If it does not have enough savings to cover the negative balance, it will take out a loan from the bank to cover the difference. The bank is required to keep a certain percentage of deposits as reserves. If run.py is used to run the model, then the percent of deposits the bank is required to retain is a user settable parameter. The amount the bank is able to loan at any given time is a function of the amount of deposits, its reserves, and its current total outstanding loan amount.
 
 The model demonstrates the following Mesa features:
  - MultiGrid for creating shareable space for agents
@@ -32,7 +32,7 @@ Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/), sele
 
 ## Batch Run
 
-To run the model as a batch run to collect data on multiple combinations of model parameters, run "batch_run.py" in this directory. 
+To run the model as a batch run to collect data on multiple combinations of model parameters, run "batch_run.py" in this directory.
 
 ```
     $ python batch_run.py
@@ -48,7 +48,7 @@ To update the parameters to test other parameter sweeps, edit the list of parame
 * ``bank_reserves/model.py``: Defines the Bank Reserves model and the DataCollector functions.
 * ``bank_reserves/server.py``: Sets up the interactive visualization server.
 * ``run.py``: Launches a model visualization server.
-* ``batch_run.py``: Basically the same as model.py, but includes a Mesa BatchRunner. The result of the batch run will be a .csv file with the data from every step of every run. 
+* ``batch_run.py``: Basically the same as model.py, but includes a Mesa BatchRunner. The result of the batch run will be a .csv file with the data from every step of every run.
 
 ## Further Reading
 

--- a/examples/charts/Readme.md
+++ b/examples/charts/Readme.md
@@ -37,4 +37,4 @@ Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/), sele
 
 ## Further Reading
 
-See the "bank_reserves" model for more information. 
+See the "bank_reserves" model for more information.

--- a/examples/color_patches/Readme.md
+++ b/examples/color_patches/Readme.md
@@ -22,9 +22,9 @@ To run the model interactively, run ``mesa runserver` in this directory. e.g.
 
 ```
     $ mesa runserver
-``` 
+```
 
-Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press Reset, then Run. 
+Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press Reset, then Run.
 
 ## Files
 

--- a/examples/conways_game_of_life/Readme.md
+++ b/examples/conways_game_of_life/Readme.md
@@ -13,9 +13,9 @@ To run the model interactively, run ``mesa runserver`` in this directory. e.g.
 
 ```
     $ mesa runserver
-``` 
+```
 
-Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press ``run``. 
+Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press ``run``.
 
 ## Files
 
@@ -23,7 +23,7 @@ Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and p
 * ``game_of_life/model.py``: Defines the model itself, initialized with a random configuration of alive and dead cells.
 * ``game_of_life/portrayal.py``: Describes for the front end how to render a cell.
 * ``game_of_live/server.py``: Defines an interactive visualization.
-* ``run.py``: Launches the visualization 
+* ``run.py``: Launches the visualization
 
 ## Further Reading
 [Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life)

--- a/examples/epstein_civil_violence/Readme.md
+++ b/examples/epstein_civil_violence/Readme.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This model is based on Joshua Epstein's simulation of how civil unrest grows and is suppressed. Citizen agents wander the grid randomly, and are endowed with individual risk aversion and hardship levels; there is also a universal regime legitimacy value. There are also Cop agents, who work on behalf of the regime. Cops arrest Citizens who are actively rebelling; Citizens decide whether to rebel based on their hardship and the regime legitimacy, and their perceived probability of arrest. 
+This model is based on Joshua Epstein's simulation of how civil unrest grows and is suppressed. Citizen agents wander the grid randomly, and are endowed with individual risk aversion and hardship levels; there is also a universal regime legitimacy value. There are also Cop agents, who work on behalf of the regime. Cops arrest Citizens who are actively rebelling; Citizens decide whether to rebel based on their hardship and the regime legitimacy, and their perceived probability of arrest.
 
 The model generates mass uprising as self-reinforcing processes: if enough agents are rebelling, the probability of any individual agent being arrested is reduced, making more agents more likely to join the uprising. However, the more rebelling Citizens the Cops arrest, the less likely additional agents become to join.
 
@@ -12,9 +12,9 @@ To run the model interactively, run ``EpsteinCivilViolenceServer.py`` in this di
 
 ```
     $ python EpsteinCivilViolenceServer.py
-``` 
+```
 
-Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press Reset, then Run. 
+Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press Reset, then Run.
 
 ## Files
 

--- a/examples/forest_fire/readme.md
+++ b/examples/forest_fire/readme.md
@@ -12,7 +12,7 @@ To run the model interactively, run ``mesa runserver`` in this directory. e.g.
     $ mesa runserver
 ```
 
-Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press Reset, then Run. 
+Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/) and press Reset, then Run.
 
 To view and run the model analyses, use the ``Forest Fire Model`` Notebook.
 

--- a/examples/hex_snowflake/Readme.md
+++ b/examples/hex_snowflake/Readme.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-In this model, each dead cell will become alive if it has exactly one neighbor. Alive cells stay alive forever.  
+In this model, each dead cell will become alive if it has exactly one neighbor. Alive cells stay alive forever.
 
 
 ## How to Run

--- a/examples/virus_on_network/README.md
+++ b/examples/virus_on_network/README.md
@@ -38,7 +38,7 @@ The full tutorial describing how the model is built can be found at:
 http://mesa.readthedocs.io/en/master/tutorials/intro_tutorial.html
 
 
-[Stonedahl, F. and Wilensky, U. (2008). NetLogo Virus on a Network model](http://ccl.northwestern.edu/netlogo/models/VirusonaNetwork). 
+[Stonedahl, F. and Wilensky, U. (2008). NetLogo Virus on a Network model](http://ccl.northwestern.edu/netlogo/models/VirusonaNetwork).
 Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
 
 


### PR DESCRIPTION
Remove trailing white spaces from docs and example Readme's.