### PR TITLE
 Adding logic to check whether there is agent data

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -172,10 +172,15 @@ def _model_run_func(
     for step in steps:
         model_data, all_agents_data = _collect_data(model, step)
 
-        stepdata = [
-            {**{"Step": step}, **kwargs, **model_data, **agent_data}
-            for agent_data in all_agents_data
-        ]
+        # If there are agent_reporters, then create an entry for each agent
+        if all_agents_data:
+            stepdata = [
+                {**{"Step": step}, **kwargs, **model_data, **agent_data}
+                for agent_data in all_agents_data
+            ]
+        # If there is only model data, then create a single entry for the step
+        else:
+            stepdata = [{**{"Step": step}, **kwargs, **model_data}]
         data.extend(stepdata)
 
     return tuple(kwargs.values()), data

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -47,6 +47,7 @@ class MockModel(Model):
         variable_agent_param=None,
         fixed_model_param=None,
         schedule=None,
+        enable_agent_reporters=True,
         **kwargs
     ):
         super().__init__()
@@ -55,9 +56,13 @@ class MockModel(Model):
         self.variable_agent_param = variable_agent_param
         self.fixed_model_param = fixed_model_param
         self.n_agents = 3
+        if enable_agent_reporters:
+            agent_reporters = {"agent_id": "unique_id", "agent_local": "local"}
+        else:
+            agent_reporters = None
         self.datacollector = DataCollector(
             model_reporters={"reported_model_param": self.get_local_model_param},
-            agent_reporters={"agent_id": "unique_id", "agent_local": "local"},
+            agent_reporters=agent_reporters,
         )
         self.running = True
         self.init_agents()
@@ -119,6 +124,20 @@ def test_batch_run_with_params():
             "variable_agent_params": ["H", "E", "L", "L", "O"],
         },
     )
+
+
+def test_batch_run_no_agent_reporters():
+    result = batch_run(MockModel, {"enable_agent_reporters": False})
+    print(result)
+    assert result == [
+        {
+            "RunId": 0,
+            "iteration": 0,
+            "Step": 1000,
+            "enable_agent_reporters": False,
+            "reported_model_param": 42,
+        }
+    ]
 
 
 def test_batch_run_single_core():


### PR DESCRIPTION
 There was a bug where the model output was only produced
 if there were agent_reporters.

 This is because the output data was created in a list
 comprehension that ran once for every agent in
 agent_reporters.

 The new logic checks if there are agent reporters;
 if not, it just outputs the model_reporters.

 Also adds a simple unit test to make sure that output
 is produced when there aren't agent_reporters.

Fixes #1113 