### PR TITLE
[PERF] Improve move_to_empty performance

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -229,6 +229,7 @@ class TestSingleGrid(unittest.TestCase):
                 a = MockAgent(counter, None)
                 self.agents.append(a)
                 self.grid.place_agent(a, (x, y))
+        self.num_agents = len(self.agents)
 
     def test_enforcement(self):
         """
@@ -242,11 +243,14 @@ class TestSingleGrid(unittest.TestCase):
 
         # Place the agent in an empty cell
         self.grid.position_agent(a)
+        self.num_agents += 1
         # Test whether after placing, the empty cells are reduced by 1
         assert a.pos not in self.grid.empties
         assert len(self.grid.empties) == 8
         for i in range(10):
-            self.grid.move_to_empty(a)
+            # Since the agents and the grid are not associated with a model, we
+            # must explicitly tell move_to_empty the number of agents.
+            self.grid.move_to_empty(a, num_agents=self.num_agents)
         assert len(self.grid.empties) == 8
 
         # Place agents until the grid is full
@@ -254,13 +258,14 @@ class TestSingleGrid(unittest.TestCase):
         for i in range(empty_cells):
             a = MockAgent(101 + i, None)
             self.grid.position_agent(a)
+            self.num_agents += 1
         assert len(self.grid.empties) == 0
 
         a = MockAgent(110, None)
         with self.assertRaises(Exception):
             self.grid.position_agent(a)
         with self.assertRaises(Exception):
-            self.move_to_empty(self.agents[0])
+            self.move_to_empty(self.agents[0], num_agents=self.num_agents)
 
 
 # Number of agents at each position for testing


### PR DESCRIPTION
This fixes #1052. This is based on https://github.com/JuliaDynamics/Agents.jl/pull/541 (cc @Libbum).
Note:
- The first commit is #1110. I will rebase this PR once that one is merged
- I need to measure the speedup vs without `sorted(self.empties)`, since the `sorted()` operation is the slowest part as reported in #1052
- I haven't yet measured the cutoff value that result in a break-even with the old method. It seems to be smaller than Agents.jl's 0.998

I benchmarked this on the Schelling model.

![benchmark](https://user-images.githubusercontent.com/395821/147255666-0de8cf98-cfb1-4dc1-9e1d-0fb72954fd79.png)
The black line is a horizontal line at y = 1.
Haven't had the time to repeat the run multiple times to get a plot with standard deviation, but at least here you can see how much the speedup increases as we increase the grid size.

```python
densities = np.linspace(0.01, 0.9, 20)
for L in [5, 10, 15, 20]:
    speedups = []
    for density in densities:
        model_params = {
            "height": L,
            "width": L,
            # Agent density, from 0.8 to 1.0
            "density": density,
            # Fraction minority, from 0.2 to 1.0
            "minority_pc": 0.2,
            # Homophily, from 3 to 8
            "homophily": 3,
        }
        elapseds = []
        for cutoff in [0.0, 0.998]:
            model = Schelling(move_to_empty_cutoff=cutoff, **model_params)
            tic = time.time()
            for i in range(100):
                model.step()
            elapsed = time.time() - tic
            elapseds.append(elapsed)
        speedup = elapseds[0] / elapseds[1]
        speedups.append(speedup)
    plt.plot(densities, speedups, label=f"L={L}")
plt.axhline(1, color="black", label="1")
plt.legend()
plt.xlabel("Agent density")
plt.ylabel("Speedup (current main branch / this PR)")
plt.savefig("benchmark.png")
```