### PR TITLE
Aggegrated agent metric in DataCollection, graph in ChartModule

### DIFF
--- a/mesa/visualization/modules/ChartVisualization.py
+++ b/mesa/visualization/modules/ChartVisualization.py
@@ -34,7 +34,8 @@ class ChartModule(VisualizationElement):
                                       data_collector_name="datacollector")
 
     TODO:
-        Have it be able to handle agent-level variables as well.
+        Aggregate agent level variables other than mean (requires ChartModule
+        API change)
 
         More Pythonic customization; in particular, have both series-level and
         chart-level options settable in Python, and passed to the front-end
@@ -78,9 +79,18 @@ class ChartModule(VisualizationElement):
 
         for s in self.series:
             name = s["Label"]
-            try:
-                val = data_collector.model_vars[name][-1]  # Latest value
-            except (IndexError, KeyError):
+            if name in data_collector.model_vars.keys():
+                try:
+                    val = data_collector.model_vars[name][-1]  # Latest value
+                except (IndexError, KeyError):
+                    val = 0
+            elif name in data_collector.agent_name_index.keys():
+                try:
+                    # Returns mean of latest value of all agents
+                    val = data_collector.get_agent_metric(name)
+                except (IndexError, KeyError):
+                    val = 0
+            else:
                 val = 0
             current_values.append(val)
         return current_values


### PR DESCRIPTION
**Aggegrated agent variable**
Currently it's not possible to quickly get a aggegrated metric of an agent variable. This PR adds a method to the `DataCollector` class called `get_agent_metric` that allows to quickly get a single value that describes the agent variable based on a stastistic.

By default, it takes the mean of the value of all agent's values for that variable. It always reports the variable in the current time step. The function supports all of [statistics](https://docs.python.org/3/library/statistics.html) functions, as well as the built-in `min()`, `max()`, `sum()` and `len()` functions.

To support this:

- `statistics` is imported
- Adds `agent_attr_index` dictionary, which list the place of each `reporter` in the `_agent_records` dictionary
- Adds `self.agent_name_index`, which can be used to lookup the `reporter` for each input variable `name`

**Example**
A model called `model1` is created, with agents that have an `agent_reporter` in `datacollector` variable called `"Neighbours"`
```Python
        self.datacollector = DataCollector(
            model_reporters={"Agents": lambda m: m.schedule.get_agent_count()},
            agent_reporters={"Neighbours": "neighbours"},
        )
```
The new `get_agent_metric()` function can now be used to get an aggerate level statistic of the number of neighbours of the agents:
```Python
model1.datacollector.get_agent_metric("Neighbours")
0.8984375
model1.datacollector.get_agent_metric("Neighbours", "min")
0
model1.datacollector.get_agent_metric("Neighbours", "median")
0.0
model1.datacollector.get_agent_metric("Neighbours", "max")
3
```

-----
**Plotting agent variables**
The `ChartModule` is also updated to support displaying agent variables. If it can't find a variable in the model variables, it checks if it is present in the agent variables, and if so, adds it to the chart.

**Example**
In a Game of Life model I build the DataCollector looks like this:
```Python
        self.datacollector = DataCollector(
            model_reporters={"Agents": lambda m: m.schedule.get_agent_count()},
            agent_reporters={"Neighbours": "neighbours"},
        )
```
The server contains two charts, one with the `Agents`, which is a model variable, and one with `Neighbours`, an agent variable.
```Python
chart1 = ChartModule([{"Label": "Agents", "Color": "Black"}], data_collector_name="datacollector")
chart2 = ChartModule([{"Label": "Neighbours", "Color": "Black"}], data_collector_name="datacollector")

server = ModularServer(LifeModel, [grid, chart1, chart2], "Game of Life", {"p": 0.12, "width": 40, "height": 40})
```
On the main branch, only the first chart is displayed correctly. On the second, both are.

<img width="1176" alt="Screenshot_692" src="https://user-images.githubusercontent.com/15776622/150698745-1d0db9cd-c1b0-4079-8e1e-1d5cf9baab06.png">

-----

@tpike3, @rht and others, I would love your feedback on this PR! Please consider performance, the naming of variables and functions and API stability. Also please let me know if (and where) tests and documentation should be added.