### PR TITLE
Update Black formatting (no spaces for power operator)

### DIFF
--- a/examples/sugarscape_cg/sugarscape_cg/agents.py
+++ b/examples/sugarscape_cg/sugarscape_cg/agents.py
@@ -14,7 +14,7 @@ def get_distance(pos_1, pos_2):
     x2, y2 = pos_2
     dx = x1 - x2
     dy = y1 - y2
-    return math.sqrt(dx ** 2 + dy ** 2)
+    return math.sqrt(dx**2 + dy**2)
 
 
 class SsAgent(Agent):

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -837,7 +837,7 @@ class ContinuousSpace:
             deltas = np.minimum(deltas, self.size - deltas)
         dists = deltas[:, 0] ** 2 + deltas[:, 1] ** 2
 
-        (idxs,) = np.where(dists <= radius ** 2)
+        (idxs,) = np.where(dists <= radius**2)
         neighbors = [
             self._index_to_agent[x] for x in idxs if include_center or dists[x] > 0
         ]

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -75,7 +75,7 @@ class TestSpaceToroidal(unittest.TestCase):
 
         pos_6 = (-30, -29)
         pos_7 = (21, -5)
-        assert self.space.get_distance(pos_6, pos_7) == np.sqrt(49 ** 2 + 24 ** 2)
+        assert self.space.get_distance(pos_6, pos_7) == np.sqrt(49**2 + 24**2)
 
     def test_heading(self):
         pos_1 = (-30, -30)


### PR DESCRIPTION
Black [was updated](https://github.com/psf/black/pull/2726) to hug power operators, this commit fixes that in the Mesa code base.

Closes #1155.