### PR TITLE
CI: Create Action to publish to PyPI on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,12 @@ jobs:
         run: pip install -U pip wheel setuptools
       - name: Build package
         run: python setup.py sdist bdist_wheel
-      - name: Upload package
+      - name: Upload package as artifact to GitHub
+        uses: actions/upload-artifact@v2
+        with:
+          name: package
+          path: dist/
+      - name: Upload packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    name: Deploy release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -U pip wheel setuptools
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      - name: Upload package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Creates a GitHub Action workflow that builds and published packaged distribution files to PyPI when a release is published in GitHub.

It builds and deploys the same two files as [currently deployed](https://pypi.org/project/Mesa/0.9.0/#files) to PyPI with 0.9.0:

- `Mesa-0.9.0.tar.gz` (Source Distribution)
- `Mesa-0.9.0-py3-none-any.whl` (Built Distribution)

A version to test: [package.zip](https://github.com/projectmesa/mesa/files/8116427/package.zip)

It runs whenever a GitHub Release is published, either from an existing tag of when creating a new tag when creating the release through the GitHub CLI or web interface ([mesa/releases](https://github.com/projectmesa/mesa/releases)). See [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for more information.

**TODO:** The secret used in `${{ secrets.PYPI_API_TOKEN }}` needs to be created on the settings page of your project on GitHub. See [Creating & using secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets). All maintainers can do so, see [Creating & using secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).

At some point (in another PR) we should probably switch to `pyproject.toml` as defined in [PEP 518](https://www.python.org/dev/peps/pep-0518/).

Example of creating a GitHub release, on which this workflow runs:
<img width="698" alt="Screenshot_712" src="https://user-images.githubusercontent.com/15776622/155128341-99470000-df79-42d5-a15b-e93d2839f963.png">