### PR TITLE
CI: Split off codespell job, don't run build on doc changes

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -5,7 +5,13 @@ on:
     branches:
     - main
     - release**
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
 
 jobs:
   build:
@@ -72,12 +78,3 @@ jobs:
     - run: pip install black[jupyter]
     - name: Lint with black
       run: black --check --exclude=mesa/cookiecutter-mesa/* .
-
-  codespell:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: codespell-project/actions-codespell@master
-      with:
-        ignore_words_file: .codespellignore
-        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  push:
+    branches:
+    - main
+    - release**
+  pull_request:
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: codespell-project/actions-codespell@master
+      with:
+        ignore_words_file: .codespellignore
+        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map


### PR DESCRIPTION
Split the `python.yml` job into a `build.yml` with the build and lint jobs and `codespell.yml` with the codespell jobs.

The build and lint jobs now don't run when only changes to Markdown (`.md`) or reStructuredText (`.rst`) files have been made.