### PR TITLE
docs: make windows multiprocessing code appear

### DIFF
--- a/docs/tutorials/intro_tutorial.rst
+++ b/docs/tutorials/intro_tutorial.rst
@@ -1014,6 +1014,7 @@ code as follows.
 
 
 .. code:: python
+
     from multiprocessing import freeze_support
 
     params = {"width": 10, "height": 10, "N": range(10, 500, 10)}


### PR DESCRIPTION
Apologies, apparently in read the docs you need a line in order for the code to be appear. Currently the [tutorial](https://mesa.readthedocs.io/en/latest/tutorials/intro_tutorial.html) is not showing the code needed for Windows and multi-processing.  