### PR TITLE
Readme: Fix links to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,8 @@ For more help on using Mesa, check out the following resources:
 * `Email list for users`_
 * `PyPI`_
 
-.. _`Intro to Mesa Tutorial` : http://mesa.readthedocs.org/en/master/tutorials/intro_tutorial.html
-.. _`Docs` : http://mesa.readthedocs.org/en/master/
+.. _`Intro to Mesa Tutorial` : http://mesa.readthedocs.org/en/main/tutorials/intro_tutorial.html
+.. _`Docs` : http://mesa.readthedocs.org/en/main/
 .. _`Email list for users` : https://groups.google.com/d/forum/projectmesa
 .. _`PyPI` : https://pypi.python.org/pypi/Mesa/
 


### PR DESCRIPTION
Default docs branch was changed from master to main, this PR updates the links in the readme to incorporate that.