### PR TITLE
setup.py: Update setup classifiers and add python_requires for Python>=3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,10 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Intended Audience :: Science/Research",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha",
@@ -59,4 +63,5 @@ setup(
         [console_scripts]
         mesa=mesa.main:cli
     """,
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Update `setup.py` with the Programming Language [classifiers](https://pypi.org/classifiers/) and [python_requires](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires) argument to reflect Mesa supporting Python 3.7 and higher.