### PR TITLE
mypy: Improve space.py annotation, part 2

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -569,6 +569,8 @@ class MultiGrid(Grid):
         get_neighbors: Returns the objects surrounding a given cell.
     """
 
+    grid: List[List[MultiGridContent]]
+
     @staticmethod
     def default_val() -> MultiGridContent:
         """Default value for new cell elements."""

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -430,7 +430,7 @@ class Grid:
     def _remove_agent(self, pos: Coordinate, agent: Agent) -> None:
         """Remove the agent from the given location."""
         x, y = pos
-        self.grid[x][y] = None
+        self.grid[x][y] = self.default_val()
         self.empties.add(pos)
 
     def is_cell_empty(self, pos: Coordinate) -> bool:

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -197,9 +197,7 @@ class Grid:
             for col in range(self.height):
                 yield self.grid[row][col], row, col  # agent, x, y
 
-    def neighbor_iter(
-        self, pos: Coordinate, moore: bool = True
-    ) -> Iterator[GridContent]:
+    def neighbor_iter(self, pos: Coordinate, moore: bool = True) -> Iterator[Agent]:
         """Iterate over position neighbors.
 
         Args:
@@ -304,7 +302,7 @@ class Grid:
         moore: bool,
         include_center: bool = False,
         radius: int = 1,
-    ) -> Iterator[GridContent]:
+    ) -> Iterator[Agent]:
         """Return an iterator over neighbors to a certain point.
 
         Args:
@@ -332,7 +330,7 @@ class Grid:
         moore: bool,
         include_center: bool = False,
         radius: int = 1,
-    ) -> List[GridContent]:
+    ) -> List[Agent]:
         """Return a list of neighbors to a certain point.
 
         Args:
@@ -371,7 +369,7 @@ class Grid:
     @accept_tuple_argument
     def iter_cell_list_contents(
         self, cell_list: Iterable[Coordinate]
-    ) -> Iterator[GridContent]:
+    ) -> Iterator[Agent]:
         """Returns an iterator of the contents of the cells
         identified in cell_list.
 
@@ -387,9 +385,7 @@ class Grid:
         return filter(None, (self.grid[x][y] for x, y in cell_list))
 
     @accept_tuple_argument
-    def get_cell_list_contents(
-        self, cell_list: Iterable[Coordinate]
-    ) -> List[GridContent]:
+    def get_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> List[Agent]:
         """Returns a list of the contents of the cells
         identified in cell_list.
 
@@ -691,7 +687,7 @@ class HexGrid(Grid):
 
         yield from coordinates
 
-    def neighbor_iter(self, pos: Coordinate) -> Iterator[GridContent]:
+    def neighbor_iter(self, pos: Coordinate) -> Iterator[Agent]:
         """Iterate over position neighbors.
 
         Args:
@@ -725,7 +721,7 @@ class HexGrid(Grid):
 
     def iter_neighbors(
         self, pos: Coordinate, include_center: bool = False, radius: int = 1
-    ) -> Iterator[GridContent]:
+    ) -> Iterator[Agent]:
         """Return an iterator over neighbors to a certain point.
 
         Args:
@@ -743,7 +739,7 @@ class HexGrid(Grid):
 
     def get_neighbors(
         self, pos: Coordinate, include_center: bool = False, radius: int = 1
-    ) -> List[Coordinate]:
+    ) -> List[Agent]:
         """Return a list of neighbors to a certain point.
 
         Args:
@@ -852,7 +848,7 @@ class ContinuousSpace:
 
     def get_neighbors(
         self, pos: FloatCoordinate, radius: float, include_center: bool = True
-    ) -> List[GridContent]:
+    ) -> List[Agent]:
         """Get all objects within a certain radius.
 
         Args:


### PR DESCRIPTION
The remaining missing parts from #835 not yet implemented:
- type casting: https://github.com/projectmesa/mesa/pull/835/commits/9f6fb57121db63314fe1127934756c86f650b852#diff-0b13b631d2293f06d685774185de133aaacba213d467419dbfe3061ff130151bR346. This can be implemented at any time just by following Mypy error messages, and so there is no need to consult this commit
- generic content type: https://github.com/projectmesa/mesa/pull/835/commits/56a63b83a169b3214e991fbbc3994427effffac4. I don't think it's worth the complexity of using generic content type, and so I didn't implement it