### PR TITLE
js deps: Move Bootstrap to be inside external folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ dmypy.json
 
 # pythonenv
 pythonenv*/
+
+# JS dependencies
+mesa/visualization/templates/external/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,4 @@ include mesa/visualization/templates/*.html
 include mesa/visualization/templates/css/*
 include mesa/visualization/templates/fonts/*
 include mesa/visualization/templates/js/*
-include mesa/visualization/templates/bootstrap-3.3.7/*
+include mesa/visualization/templates/external/bootstrap-3.3.7/*

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <head>
 	<title>{{ model_name }} (Mesa visualization)</title>
-    <link href="/static/bootstrap-3.3.7/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
-    <link href="/static/bootstrap-3.3.7/css/bootstrap-theme.min.css" type="text/css" rel="stylesheet" />
+    <link href="/static/external/bootstrap-3.3.7/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
+    <link href="/static/external/bootstrap-3.3.7/css/bootstrap-theme.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/bootstrap-switch.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/visualization.css" type="text/css" rel="stylesheet" />
@@ -73,7 +73,7 @@
 
     <!-- Bottom-load all JavaScript dependencies -->
     <script src="/static/js/jquery.min.js"></script>
-    <script src="/static/bootstrap-3.3.7/js/bootstrap.min.js"></script>
+    <script src="/static/external/bootstrap-3.3.7/js/bootstrap.min.js"></script>
     <script src="/static/js/bootstrap-switch.min.js"></script>
     <script src="/static/js/bootstrap-slider.min.js"></script>
 

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,11 @@ with open("README.rst", "rb", encoding="utf-8") as f:
 # - mesa/visualization/templates/modular_template.html
 bootstrap_version = "3.3.7"
 bootstrap_dir = f"bootstrap-{bootstrap_version}"
-template_dir = "mesa/visualization/templates"
-dst_bootstrap_path = os.path.join(template_dir, bootstrap_dir)
+external_dir = "mesa/visualization/templates/external"
+dst_bootstrap_path = os.path.join(external_dir, bootstrap_dir)
 if not os.path.isdir(dst_bootstrap_path):
+    # First, ensure that the external/ directory exists
+    os.makedirs(external_dir, exist_ok=True)
     print("Downloading the Bootstrap dependency from the internet...")
     url = f"https://github.com/twbs/bootstrap/releases/download/v{bootstrap_version}/bootstrap-{bootstrap_version}-dist.zip"
     zip_file = "bootstrap-dist.zip"
@@ -59,7 +61,7 @@ setup(
             "visualization/templates/*.html",
             "visualization/templates/css/*",
             "visualization/templates/js/*",
-            f"visualization/templates/{bootstrap_dir}/**/*",
+            f"visualization/templates/external/{bootstrap_dir}/**/*",
         ],
         "cookiecutter-mesa": ["cookiecutter-mesa/*"],
     },


### PR DESCRIPTION
This is so that the directory content of mesa/visualization/templates
remains neat. And this helps clarify that the content inside external/
is downloaded manually, not part of the repo.

@EwoutH FYI, need to wait for this PR before doing anything in #1100.