### PR TITLE
feat: Implement flat Mesa namespace alternative

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ branch = True
 [report]
 omit =
     tests/*
+    mesa/all/*

--- a/mesa/all/__init__.py
+++ b/mesa/all/__init__.py
@@ -1,0 +1,5 @@
+from mesa import *  # noqa
+from mesa.time import *  # noqa
+from mesa.space import *  # noqa
+from mesa.datacollection import *  # noqa
+from .visualization import *  # noqa

--- a/mesa/all/visualization.py
+++ b/mesa/all/visualization.py
@@ -1,0 +1,3 @@
+from mesa.visualization.ModularVisualization import *  # noqa
+from mesa.visualization.modules import *  # noqa
+from mesa.visualization.UserParam import *  # noqa


### PR DESCRIPTION
Close #1229.
Examples:
```ipython
In [1]: import mesa.all as ma

In [2]: ma.Agent
Out[2]: mesa.agent.Agent

In [3]: ma.Model
Out[3]: mesa.model.Model

In [4]: ma.RandomActivation
Out[4]: mesa.time.RandomActivation

In [5]: ma.SingleGrid
Out[5]: mesa.space.SingleGrid

In [6]: ma.ModularServer
Out[6]: mesa.visualization.ModularVisualization.ModularServer

In [7]: ma.UserSettableParameter
Out[7]: mesa.visualization.UserParam.UserSettableParameter

In [8]: ma.DataCollector
Out[8]: mesa.datacollection.DataCollector
```

I'm thinking of whether it should be called `import mesa.flat as mf` instead of `import mesa.all as ma`.