### PR TITLE
CI test: Increase timeout to 10 minutes

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     # We need an explicit timeout because sometimes the batch_runner test never
     # completes.
-    timeout-minutes: 6
+    timeout-minutes: 10
     strategy:
       fail-fast: False
       matrix:


### PR DESCRIPTION
The PyPy CI consistently errors out, because it keeps failing to install the new dependencies, because the cache has been invalidated. I'm increasing the timeout here.