### PR TITLE
batch_run: Print the correct iteration number in output

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -87,7 +87,7 @@ def batch_run(
                     run_id = next(run_counter)
                     data = []
                     for run_data in rawdata:
-                        out = {"RunId": run_id, "iteration": iteration - 1}
+                        out = {"RunId": run_id, "iteration": iteration + 1}
                         out.update(run_data)
                         data.append(out)
                     results.extend(data)
@@ -102,7 +102,7 @@ def batch_run(
                     run_id = next(run_counter)
                     data = []
                     for run_data in rawdata:
-                        out = {"RunId": run_id, "iteration": iteration - 1}
+                        out = {"RunId": run_id, "iteration": iteration + 1}
                         out.update(run_data)
                         data.append(out)
                     results.extend(data)


### PR DESCRIPTION
Currently the `batch_run()` function in `batchrunner.py` print the iteration number from -1 to N-2. This commits changes that to 1 to N.

For example: `batch_run(iterations=5)` now returns values from 1 to 5 instead of -1 to 3.