### PR TITLE
Upgrade to Bootstrap 4!

### DIFF
--- a/mesa/visualization/templates/css/visualization.css
+++ b/mesa/visualization/templates/css/visualization.css
@@ -2,7 +2,8 @@
     margin-bottom: 15px;
 }
 
-div.tooltip {
+/* This is specific to the Network visualization */
+div.d3tooltip {
     position: absolute;
     text-align: center;
     padding: 1px;

--- a/mesa/visualization/templates/js/NetworkModule_d3.js
+++ b/mesa/visualization/templates/js/NetworkModule_d3.js
@@ -22,7 +22,7 @@ const NetworkModule = function (svg_width, svg_height) {
   const tooltip = d3
     .select("body")
     .append("div")
-    .attr("class", "tooltip")
+    .attr("class", "d3tooltip")
     .style("opacity", 0);
 
   svg.call(

--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -190,10 +190,10 @@ const initGUI = function (model_params) {
     const domID = param + "_id";
     sidebar.append(
       [
-        "<div class='input-group input-group-lg'>",
+        "<div>",
         "<p><label for='" +
           domID +
-          "' class='label label-primary'>" +
+          "' class='badge badge-primary'>" +
           obj.name +
           "</label></p>",
         "<input class='model-parameter' id='" + domID + "' type='checkbox'/>",
@@ -213,10 +213,10 @@ const initGUI = function (model_params) {
     const domID = param + "_id";
     sidebar.append(
       [
-        "<div class='input-group input-group-lg'>",
+        "<div>",
         "<p><label for='" +
           domID +
-          "' class='label label-primary'>" +
+          "' class='badge badge-primary'>" +
           obj.name +
           "</label></p>",
         "<input class='model-parameter' id='" + domID + "' type='number'/>",
@@ -235,11 +235,11 @@ const initGUI = function (model_params) {
     const tooltipID = domID + "_tooltip";
     sidebar.append(
       [
-        "<div class='input-group input-group-lg'>",
+        "<div>",
         "<p>",
         "<a id='" +
           tooltipID +
-          "' data-toggle='tooltip' data-placement='top' class='label label-primary'>",
+          "' data-toggle='tooltip' data-placement='top' class='badge badge-primary'>",
         obj.name,
         "</a>",
         "</p>",
@@ -278,7 +278,7 @@ const initGUI = function (model_params) {
     const template = [
       "<p><label for='" +
         domID +
-        "' class='label label-primary'>" +
+        "' class='badge badge-primary'>" +
         obj.name +
         "</label></p>",
       "<div class='dropdown'>",

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -3,7 +3,7 @@
 	<title>{{ model_name }} (Mesa visualization)</title>
     <link href="/static/external/bootstrap-4.6.1-dist/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/external/bootstrap-switch-3.3.4/dist/css/bootstrap3/bootstrap-switch.min.css" type="text/css" rel="stylesheet" />
-    <link href="/static/external/bootstrap-slider-9.8.0/dist/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
+    <link href="/static/external/bootstrap-slider-11.0.2/dist/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/visualization.css" type="text/css" rel="stylesheet" />
 
 	<!-- This is the Tornado template for the Modular Visualization. The Javascript code opens a WebSocket connection to
@@ -76,7 +76,7 @@
     <script src="/static/js/external/jquery-2.2.4.min.js"></script>
     <script src="/static/external/bootstrap-4.6.1-dist/js/bootstrap.bundle.min.js"></script>
     <script src="/static/external/bootstrap-switch-3.3.4/dist/js/bootstrap-switch.min.js"></script>
-    <script src="/static/external/bootstrap-slider-9.8.0/dist/bootstrap-slider.min.js"></script>
+    <script src="/static/external/bootstrap-slider-11.0.2/dist/bootstrap-slider.min.js"></script>
 
     <!-- Script includes go here -->
 	{% for file_name in package_includes %}

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <head>
 	<title>{{ model_name }} (Mesa visualization)</title>
-    <link href="/static/external/bootstrap-3.3.7-dist/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
-    <link href="/static/external/bootstrap-3.3.7-dist/css/bootstrap-theme.min.css" type="text/css" rel="stylesheet" />
+    <link href="/static/external/bootstrap-4.6.1-dist/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/external/bootstrap-switch-3.3.4/dist/css/bootstrap3/bootstrap-switch.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/external/bootstrap-slider-9.8.0/dist/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/visualization.css" type="text/css" rel="stylesheet" />
@@ -14,42 +13,43 @@
 <body>
 
     <!-- Navbar -->
-    <nav class="navbar navbar-inverse navbar-static-top">
+    <nav class="navbar navbar-dark bg-dark navbar-static-top navbar-expand-md mb-3">
         <div class="container">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
+            <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+                <span class="sr-only">Toggle navigation</span>
+                &#x2630;
+            </button>
             <a class="navbar-brand" href="#">{{ model_name }}</a>
-            </div>
+
             <div id="navbar" class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
-                    <li>
-                        <a href="#" data-toggle="modal" data-target="#about" data-title="About" data-content="#about-content">
+                    <li class="nav-item">
+                        <a href="#" data-toggle="modal" data-target="#about" data-title="About" data-content="#about-content" class="nav-link">
                             About
                         </a>
                     </li>
                 </ul>
-                <ul class="nav navbar-nav navbar-right">
-                    <li id="play-pause"><a href="#">Start</a></li>
-                    <li id="step"><a href="#">Step</a></li>
-                    <li id="reset"><a href="#">Reset</a></li>
+                <ul class="nav navbar-nav ml-auto">
+                    <li id="play-pause" class="nav-item"><a href="#" class="nav-link">Start</a>
+                    </li>
+                    <li id="step" class="nav-item"><a href="#" class="nav-link">Step</a>
+                    </li>
+                    <li id="reset" class="nav-item"><a href="#" class="nav-link">Reset</a>
+                    </li>
                 </ul>
             </div><!--/.nav-collapse -->
         </div>
     </nav>
-    <div class="container">
-        <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3" id="sidebar"></div>
-        <div class="col-lg-8 col-md-8 col-sm-8 col-xs-9" id="elements">
+    <div class="container d-flex flex-row">
+        <div class="col-xl-4 col-lg-4 col-md-4 col-3" id="sidebar"></div>
+        <div class="col-xl-8 col-lg-8 col-md-8 col-9" id="elements">
             <div id="elements-topbar">
-                <div class="input-group input-group-lg">
-                    <label class="label label-primary" for="fps" style="margin-right: 15px">Frames Per Second</label>
-                    <input id="fps" data-slider-id='fps' type="text" />
-                    <p>Current Step: <span id="currentStep">0</span></p>
+                <div">
+                    <label class="badge badge-primary" for="fps" style="margin-right: 15px">Frames Per Second</label>
+                    <input id="fps" data-slider-id="fps" type="text">
                 </div>
+                <p>Current Step: <span id="currentStep">0</span>
+                </p>
             </div>
         </div>
     </div>
@@ -59,12 +59,13 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">About {{ model_name }}</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&#xD7;</span>
+                    </button>
                 </div>
                 <div class="modal-body">
                     <div>{{ description }}</div>
-                    <div>&nbsp;</div>
+                    <div>&#xA0;</div>
                     <div style="clear: both;"></div>
                 </div>
             </div>
@@ -73,7 +74,7 @@
 
     <!-- Bottom-load all JavaScript dependencies -->
     <script src="/static/js/external/jquery-2.2.4.min.js"></script>
-    <script src="/static/external/bootstrap-3.3.7-dist/js/bootstrap.min.js"></script>
+    <script src="/static/external/bootstrap-4.6.1-dist/js/bootstrap.bundle.min.js"></script>
     <script src="/static/external/bootstrap-switch-3.3.4/dist/js/bootstrap-switch.min.js"></script>
     <script src="/static/external/bootstrap-slider-9.8.0/dist/bootstrap-slider.min.js"></script>
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ ensure_JS_dep(
 )
 
 # Ensure Bootstrap Slider
-bootstrap_slider_version = "9.8.0"
+bootstrap_slider_version = "11.0.2"
 ensure_JS_dep(
     f"bootstrap-slider-{bootstrap_slider_version}",
     f"https://github.com/seiyria/bootstrap-slider/archive/refs/tags/v{bootstrap_slider_version}.zip",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def ensure_JS_dep_single(url, out_name=None):
 # hardcoded included files and versions in: mesa/visualization/templates/modular_template.html
 
 # Ensure Bootstrap
-bootstrap_version = "3.3.7"
+bootstrap_version = "4.6.1"
 ensure_JS_dep(
     f"bootstrap-{bootstrap_version}-dist",
     f"https://github.com/twbs/bootstrap/releases/download/v{bootstrap_version}/bootstrap-{bootstrap_version}-dist.zip",


### PR DESCRIPTION
This PR is ready for review and testing.

I used this tool to do the migration (http://upgrade-bootstrap.bootply.com/) and reviewed the change line by line.

I have tested this myself on:
- bank_reserves
- wolf_sheep (has "boolean" user input)
- pd_grid (has "choice" user input)
- schelling
- virus on network

This PR also fixes the nasty bug of duplicate tooltip (if you hover over the slider, you will see both black and steelblue tooltip) caused by this commit: https://github.com/projectmesa/mesa/commit/e4225f4a3038a3ee08cb24655b13a27fff8f04a0. That `div.tooltip` is renamed to use "d3tooltip" as a class name to avoid collision with bootstrap-slider's tooltip.

When testing this PR, make sure to additionally try on mobile, where the menu items in the navigation bar collapse into a hamburger button.

@EwoutH check this out.