### PR TITLE
support package and local css includes

### DIFF
--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -125,10 +125,10 @@ class VisualizationElement:
     Defines an element of the visualization.
 
     Attributes:
-        package_includes: A list of external JavaScript files to include that
-                          are part of the Mesa packages.
-        local_includes: A list of JavaScript files that are local to the
-                        directory that the server is being run in.
+        package_includes: A list of external JavaScript and CSS files to
+                          include that are part of the Mesa packages.
+        local_includes: A list of JavaScript and CSS files that are local to
+                        the directory that the server is being run in.
         js_code: A JavaScript code string to instantiate the element.
 
     Methods:
@@ -174,8 +174,10 @@ class PageHandler(tornado.web.RequestHandler):
             port=self.application.port,
             model_name=self.application.model_name,
             description=self.application.description,
-            package_includes=self.application.package_includes,
-            local_includes=self.application.local_includes,
+            package_js_includes=self.application.package_js_includes,
+            package_css_includes=self.application.package_css_includes,
+            local_js_includes=self.application.local_js_includes,
+            local_css_includes=self.application.local_css_includes,
             scripts=self.application.js_code,
         )
 
@@ -266,14 +268,22 @@ class ModularServer(tornado.web.Application):
         """Create a new visualization server with the given elements."""
         # Prep visualization elements:
         self.visualization_elements = visualization_elements
-        self.package_includes = set()
-        self.local_includes = set()
+        self.package_js_includes = set()
+        self.package_css_includes = set()
+        self.local_js_includes = set()
+        self.local_css_includes = set()
         self.js_code = []
         for element in self.visualization_elements:
             for include_file in element.package_includes:
-                self.package_includes.add(include_file)
+                if self._is_stylesheet(include_file):
+                    self.package_css_includes.add(include_file)
+                else:
+                    self.package_js_includes.add(include_file)
             for include_file in element.local_includes:
-                self.local_includes.add(include_file)
+                if self._is_stylesheet(include_file):
+                    self.local_css_includes.add(include_file)
+                else:
+                    self.local_js_includes.add(include_file)
             self.js_code.append(element.js_code)
 
         # Initializing the model
@@ -338,3 +348,7 @@ class ModularServer(tornado.web.Application):
             webbrowser.open(url)
         tornado.autoreload.start()
         tornado.ioloop.IOLoop.current().start()
+
+    @staticmethod
+    def _is_stylesheet(filename):
+        return filename.lower().endswith(".css")

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -7,6 +7,14 @@
     <link href="/static/external/bootstrap-slider-9.8.0/dist/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/visualization.css" type="text/css" rel="stylesheet" />
 
+    <!-- CSS includes go here -->
+    {% for file_name in package_css_includes %}
+        <link href="/static/css/{{ file_name }}" type="text/css" rel="stylesheet" />
+    {% end %}
+    {% for file_name in local_css_includes %}
+        <link href="/local/{{ file_name }}" type="text/css" rel="stylesheet" />
+    {% end %}
+
 	<!-- This is the Tornado template for the Modular Visualization. The Javascript code opens a WebSocket connection to
 	the server (the port is set via the template). On every step, it receives inputs, one per module, and sends
 	them to the associated function to render. -->
@@ -78,10 +86,10 @@
     <script src="/static/external/bootstrap-slider-9.8.0/dist/bootstrap-slider.min.js"></script>
 
     <!-- Script includes go here -->
-	{% for file_name in package_includes %}
+	{% for file_name in package_js_includes %}
 		<script src="/static/js/{{ file_name }}" type="text/javascript"></script>
 	{% end %}
-	{% for file_name in local_includes %}
+	{% for file_name in local_js_includes %}
 		<script src="/local/{{ file_name }}" type="text/javascript"></script>
 	{% end %}
 


### PR DESCRIPTION
This PR tries to address https://github.com/projectmesa/mesa/issues/1267. The user interface remains the same, e.g.:

```python
class MyCustomModule(VisualizationElement):
    package_includes = ["PackageJavaScript.js", "PackageStylesheet.css"]
    local_includes = ["MyCustomJavaScript.js", "MyCustomStylesheet.css"]
```

Then these included files get saved into `package_js_includes`, `package_css_includes`, `local_js_includes` and `local_css_includes` attributes. Whether it's a stylesheet or not depends on whether the filename ends with `.css`.

**An alternative approach** that is not implemented with this PR would be to let users decide by themselves on demand. For example like this:

```python
class MyCustomModule(VisualizationElement):
    package_js_includes = ["PackageJavaScript.js"]
    package_css_includes = ["PackageStylesheet.css"]  # this is what Mesa-Geo needs
    local_js_includes = ["MyCustomJavaScript.js"]
    local_css_includes = ["MyCustomStylesheet.css"]
```

In this way we don't need to check whether files are stylesheets or scripts. But this breaks API and introduces more complexity in developing customized elements.

Please feel free to suggest other possible approaches.