### PR TITLE
Feature urlpath in ModularServer

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -156,4 +156,6 @@ To quickly spin up a model visualization, you might do something like:
 
 This will launch the browser-based visualization, on the default port 8521.
 
+To change the port, set environment variable ``PORT=<desired port>`` or call ``server.launch(port=<desired port>)``. 
 
+To add a path segment to the URL, e.g. to publish the model at ``localhost:8521/model``, set environment variable ``URLPATH=model``.

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -253,17 +253,22 @@ class ModularServer(tornado.web.Application):
     verbose = True
 
     port = int(os.getenv("PORT", 8521))  # Default port to listen on
+    urlpath = str(os.getenv("URLPATH", ""))
     max_steps = 100000
 
     # Handlers and other globals:
-    page_handler = (r"/", PageHandler)
+    page_handler = (r"/" + urlpath, PageHandler)
     socket_handler = (r"/ws", SocketHandler)
     static_handler = (
         r"/static/(.*)",
         tornado.web.StaticFileHandler,
         {"path": os.path.dirname(__file__) + "/templates"},
     )
-    local_handler = (r"/local/(.*)", tornado.web.StaticFileHandler, {"path": ""})
+    local_handler = (
+        r"/" + urlpath + "/local/(.*)",
+        tornado.web.StaticFileHandler,
+        {"path": ""},
+    )
 
     handlers = [page_handler, socket_handler, static_handler, local_handler]
 
@@ -353,11 +358,14 @@ class ModularServer(tornado.web.Application):
             visualization_state.append(element_state)
         return visualization_state
 
-    def launch(self, port=None, open_browser=True):
+    def launch(self, port=None, open_browser=True, urlpath=None):
         """Run the app."""
         if port is not None:
             self.port = port
-        url = f"http://127.0.0.1:{self.port}"
+        if urlpath is not None:
+            self.urlpath = urlpath
+
+        url = f"http://127.0.0.1:{self.port}/" + self.urlpath
         print(f"Interface starting at {url}")
         self.listen(self.port)
         if open_browser:

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -253,19 +253,21 @@ class ModularServer(tornado.web.Application):
     verbose = True
 
     port = int(os.getenv("PORT", 8521))  # Default port to listen on
-    urlpath = str(os.getenv("URLPATH", ""))
+    urlpath = str(os.getenv("URLPATH", "")).strip("/")
+    if len(urlpath) > 0:
+        urlpath += "/"
     max_steps = 100000
 
     # Handlers and other globals:
     page_handler = (r"/" + urlpath, PageHandler)
-    socket_handler = (r"/ws", SocketHandler)
+    socket_handler = (r"/" + urlpath + "ws", SocketHandler)
     static_handler = (
-        r"/static/(.*)",
+        r"/" + urlpath + "static/(.*)",
         tornado.web.StaticFileHandler,
         {"path": os.path.dirname(__file__) + "/templates"},
     )
     local_handler = (
-        r"/" + urlpath + "/local/(.*)",
+        r"/" + urlpath + "local/(.*)",
         tornado.web.StaticFileHandler,
         {"path": ""},
     )
@@ -358,12 +360,10 @@ class ModularServer(tornado.web.Application):
             visualization_state.append(element_state)
         return visualization_state
 
-    def launch(self, port=None, open_browser=True, urlpath=None):
+    def launch(self, port=None, open_browser=True):
         """Run the app."""
         if port is not None:
             self.port = port
-        if urlpath is not None:
-            self.urlpath = urlpath
 
         url = f"http://127.0.0.1:{self.port}/" + self.urlpath
         print(f"Interface starting at {url}")

--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -131,8 +131,8 @@ resetModelButton.onclick = () => controller.reset();
 /** Open the websocket connection; support TLS-specific URLs when appropriate */
 const ws = new WebSocket(
   (window.location.protocol === "https:" ? "wss://" : "ws://") +
-    location.host +
-    "/ws"
+    location.host + location.pathname + 
+    "ws"
 );
 
 /**

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -1,16 +1,17 @@
 <!DOCTYPE html>
 <head>
 	<title>{{ model_name }} (Mesa visualization)</title>
-    <link href="/static/external/bootstrap-5.1.3-dist/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
-    <link href="/static/external/bootstrap-slider-11.0.2/dist/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
-    <link href="/static/css/visualization.css" type="text/css" rel="stylesheet" />
+    <link href="./static/external/bootstrap-4.6.1-dist/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
+    <link href="./static/external/bootstrap-switch-3.3.4/dist/css/bootstrap3/bootstrap-switch.min.css" type="text/css" rel="stylesheet" />
+    <link href="./static/external/bootstrap-slider-11.0.2/dist/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
+    <link href="./static/css/visualization.css" type="text/css" rel="stylesheet" />
 
     <!-- CSS includes go here -->
     {% for file_name in package_css_includes %}
-        <link href="/static/css/{{ file_name }}" type="text/css" rel="stylesheet" />
+        <link href="./static/css/{{ file_name }}" type="text/css" rel="stylesheet" />
     {% end %}
     {% for file_name in local_css_includes %}
-        <link href="/local/{{ file_name }}" type="text/css" rel="stylesheet" />
+        <link href="./local/{{ file_name }}" type="text/css" rel="stylesheet" />
     {% end %}
 
 	<!-- This is the Tornado template for the Modular Visualization. The Javascript code opens a WebSocket connection to
@@ -80,22 +81,24 @@
     </div>
 
     <!-- Bottom-load all JavaScript dependencies -->
-    <script src="/static/external/bootstrap-5.1.3-dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/static/external/bootstrap-slider-11.0.2/dist/bootstrap-slider.min.js"></script>
+    <script src="./static/js/external/jquery-2.2.4.min.js"></script>
+    <script src="./static/external/bootstrap-4.6.1-dist/js/bootstrap.bundle.min.js"></script>
+    <script src="./static/external/bootstrap-switch-3.3.4/dist/js/bootstrap-switch.min.js"></script>
+    <script src="./static/external/bootstrap-slider-11.0.2/dist/bootstrap-slider.min.js"></script>
 
     <!-- Script includes go here -->
 	{% for file_name in package_js_includes %}
-		<script src="/static/js/{{ file_name }}" type="text/javascript"></script>
+		<script src="./static/js/{{ file_name }}" type="text/javascript"></script>
 	{% end %}
 	{% for file_name in local_js_includes %}
-		<script src="/local/{{ file_name }}" type="text/javascript"></script>
+		<script src="./local/{{ file_name }}" type="text/javascript"></script>
 	{% end %}
 
     <!-- template-specific code snippets here -->
     <script>
         var port = {{ port }};
     </script>
-    <script src="/static/js/runcontrol.js"></script>
+    <script src="./static/js/runcontrol.js"></script>
 
     <!-- Element-specific scripts go here -->
     <script>


### PR DESCRIPTION
When deploying several models on a public server behind a proxy, adding a url path segment is required, e.g. http://server/mesa-schelling > localhost:8521/mesa-schelling