### PR TITLE
Fix contributing (increasing black version)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: ^mesa/cookiecutter-mesa/


### PR DESCRIPTION
Sorry, just realised another issue with .pre-commit-config when attempting to commit py files: black 22.1.0 is incompatible with newer versions of click, so I increased to the recent black 22.3.0 (https://stackoverflow.com/a/71674345/3957413).