### PR TITLE
ci: Ensure wheel is install before `pip install` step

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -46,7 +46,7 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('Pipfile.lock') }}
     - name: Install dependencies
-      run: pip install .[dev]
+      run: pip install wheel && pip install .[dev]
     - name: Test with pytest
       run: pytest --cov=mesa tests/ --cov-report=xml
     - if: matrix.os == 'ubuntu'


### PR DESCRIPTION
Without this PR's fix, you see this message:
https://github.com/projectmesa/mesa/runs/6422630638?check_suite_focus=true#step%3A5%3A161=.