### PR TITLE
fix: sugarscape_cg: Use better way to check if a cell is occupied by SsAgent

### DIFF
--- a/examples/sugarscape_cg/sugarscape_cg/agents.py
+++ b/examples/sugarscape_cg/sugarscape_cg/agents.py
@@ -34,7 +34,7 @@ class SsAgent(Agent):
 
     def is_occupied(self, pos):
         this_cell = self.model.grid.get_cell_list_contents([pos])
-        return len(this_cell) > 1
+        return any(isinstance(agent, SsAgent) for agent in this_cell)
 
     def move(self):
         # Get neighborhood within vision


### PR DESCRIPTION
The original method relies on an assumption that a cell always contains
a sugar patch.
We shouldn't assume. Also, we are probably going to optimize the code by
removing the sugar patches that have values that are always 0.