### PR TITLE
examples: Use nicer color for chart

### DIFF
--- a/examples/charts/charts/server.py
+++ b/examples/charts/charts/server.py
@@ -17,12 +17,13 @@ Accessed on: November 2, 2017
 Author of original code: Taylor Mutch
 """
 
+# The colors here are taken from Matplotlib's tab10 palette
 # Green
-RICH_COLOR = "#46FF33"
+RICH_COLOR = "#2ca02c"
 # Red
-POOR_COLOR = "#FF3C33"
+POOR_COLOR = "#d62728"
 # Blue
-MID_COLOR = "#3349FF"
+MID_COLOR = "#1f77b4"
 
 
 def person_portrayal(agent):


### PR DESCRIPTION
Before 
![2022-05-17-052427_877x566_scrot](https://user-images.githubusercontent.com/395821/168779072-35901a0d-ca52-402b-a178-f563c2541785.png)
After
![2022-05-17-052534_888x568_scrot](https://user-images.githubusercontent.com/395821/168779112-325dbcdd-2a15-40e3-908e-3dfee9163179.png)
The latter is taken from Matplotlib tab10 color palette.