### PR TITLE
frontend: Update Bootstrap 4.6.1 -> 5.1.3

### DIFF
--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -188,25 +188,30 @@ const initGUI = function (model_params) {
 
   const addBooleanInput = function (param, obj) {
     const domID = param + "_id";
-    sidebar.append(
-      [
-        "<div>",
-        "<p><label for='" +
-          domID +
-          "' class='badge badge-primary'>" +
-          obj.name +
-          "</label></p>",
-        "<input class='model-parameter' id='" + domID + "' type='checkbox'/>",
-        "</div>",
-      ].join("")
-    );
-    $("#" + domID).bootstrapSwitch({
-      state: obj.value,
-      size: "small",
-      onSwitchChange: function (e, state) {
-        onSubmitCallback(param, state);
-      },
+    const _switch = document.createElement("div");
+    _switch.className = "form-check form-switch";
+
+    const label = `
+      <label class="form-check-label badge bg-primary" for="${domID}">
+        ${obj.name}
+      </label>
+    `;
+    _switch.innerHTML += label;
+
+    const input = document.createElement("input");
+    Object.assign(input, {
+      className: "form-check-input model-parameter",
+      type: "checkbox",
+      id: domID,
+      checked: obj.value,
     });
+    input.setAttribute("role", "switch");
+    input.addEventListener("change", (event) =>
+      onSubmitCallback(param, event.currentTarget.checked)
+    );
+    _switch.appendChild(input);
+
+    sidebar.append(_switch);
   };
 
   const addNumberInput = function (param, obj) {
@@ -216,7 +221,7 @@ const initGUI = function (model_params) {
         "<div>",
         "<p><label for='" +
           domID +
-          "' class='badge badge-primary'>" +
+          "' class='badge bg-primary'>" +
           obj.name +
           "</label></p>",
         "<input class='model-parameter' id='" + domID + "' type='number'/>",
@@ -236,16 +241,16 @@ const initGUI = function (model_params) {
     let tooltip = "";
     // Enable tooltip label
     if (obj.description !== null) {
-      tooltip = `title='${obj.description}'`
+      tooltip = `title='${obj.description}'`;
     }
 
     sidebar.append(
       [
         "<div>",
         "<p>",
-        `<a id='${tooltipID}' ${tooltip} data-toggle='tooltip' data-placement='top' class='badge badge-primary'>`,
+        `<span id='${tooltipID}' ${tooltip} data-bs-toggle='tooltip' data-bs-placement='top' class='badge bg-primary'>`,
         obj.name,
-        "</a>",
+        "</span>",
         "</p>",
         "<input id='" + domID + "' type='text' />",
         "</div>",
@@ -274,13 +279,13 @@ const initGUI = function (model_params) {
     const template = [
       "<p><label for='" +
         domID +
-        "' class='badge badge-primary'>" +
+        "' class='badge bg-primary'>" +
         obj.name +
         "</label></p>",
       "<div class='dropdown'>",
       "<button id='" +
         domID +
-        "' class='btn btn-default dropdown-toggle' type='button' data-toggle='dropdown'>" +
+        "' class='btn btn-default dropdown-toggle' type='button' data-bs-toggle='dropdown'>" +
         obj.value +
         " " +
         span,
@@ -292,7 +297,7 @@ const initGUI = function (model_params) {
       const choiceID = domID + "_choice_" + i;
       choiceIdentifiers.push(choiceID);
       template.push(
-        "<li role='presentation'><a class='pick-choice' id='" +
+        "<li role='presentation'><a class='pick-choice dropdown-item' id='" +
           choiceID +
           "' role='menuitem' tabindex='-1' href='#'>",
         obj.choices[i],

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <head>
 	<title>{{ model_name }} (Mesa visualization)</title>
-    <link href="/static/external/bootstrap-4.6.1-dist/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
-    <link href="/static/external/bootstrap-switch-3.3.4/dist/css/bootstrap3/bootstrap-switch.min.css" type="text/css" rel="stylesheet" />
+    <link href="/static/external/bootstrap-5.1.3-dist/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/external/bootstrap-slider-11.0.2/dist/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/visualization.css" type="text/css" rel="stylesheet" />
 
@@ -21,10 +20,10 @@
 <body>
 
     <!-- Navbar -->
-    <nav class="navbar navbar-dark bg-dark navbar-static-top navbar-expand-md mb-3">
+    <nav class="navbar navbar-dark bg-dark navbar-static-top navbar-expand-lg mb-3">
         <div class="container">
-            <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                <span class="sr-only">Toggle navigation</span>
+            <button type="button" class="navbar-toggler collapsed" data-bs-toggle="collapse" data-bs-target="#navbar" aria-expanded="false" aria-controls="navbar">
+                <span class="visually-hidden">Toggle navigation</span>
                 &#x2630;
             </button>
             <a class="navbar-brand" href="#">{{ model_name }}</a>
@@ -32,12 +31,12 @@
             <div id="navbar" class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li class="nav-item">
-                        <a href="#" data-toggle="modal" data-target="#about" data-title="About" data-content="#about-content" class="nav-link">
+                        <a href="#" data-bs-toggle="modal" data-bs-target="#about" data-bs-title="About" data-bs-content="#about-content" class="nav-link">
                             About
                         </a>
                     </li>
                 </ul>
-                <ul class="nav navbar-nav ml-auto">
+                <ul class="nav navbar-nav ms-auto">
                     <li id="play-pause" class="nav-item"><a href="#" class="nav-link">Start</a>
                     </li>
                     <li id="step" class="nav-item"><a href="#" class="nav-link">Step</a>
@@ -45,7 +44,7 @@
                     <li id="reset" class="nav-item"><a href="#" class="nav-link">Reset</a>
                     </li>
                 </ul>
-            </div><!--/.nav-collapse -->
+            </div>
         </div>
     </nav>
     <div class="container d-flex flex-row">
@@ -53,7 +52,7 @@
         <div class="col-xl-8 col-lg-8 col-md-8 col-9" id="elements">
             <div id="elements-topbar">
                 <div">
-                    <label class="badge badge-primary" for="fps" style="margin-right: 15px">Frames Per Second</label>
+                    <label class="badge bg-primary" for="fps" style="margin-right: 15px">Frames Per Second</label>
                     <input id="fps" data-slider-id="fps" type="text">
                 </div>
                 <p>Current Step: <span id="currentStep">0</span>
@@ -63,12 +62,12 @@
     </div>
 
     <!-- About modal -->
-    <div id="about" class="modal fade" tabindex="-1" role="dialog">
+    <div id="about" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
                     <h4 class="modal-title">About {{ model_name }}</h4>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&#xD7;</span>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
                     </button>
                 </div>
                 <div class="modal-body">
@@ -82,8 +81,7 @@
 
     <!-- Bottom-load all JavaScript dependencies -->
     <script src="/static/js/external/jquery-2.2.4.min.js"></script>
-    <script src="/static/external/bootstrap-4.6.1-dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/static/external/bootstrap-switch-3.3.4/dist/js/bootstrap-switch.min.js"></script>
+    <script src="/static/external/bootstrap-5.1.3-dist/js/bootstrap.bundle.min.js"></script>
     <script src="/static/external/bootstrap-slider-11.0.2/dist/bootstrap-slider.min.js"></script>
 
     <!-- Script includes go here -->

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def ensure_JS_dep_single(url, out_name=None):
 # hardcoded included files and versions in: mesa/visualization/templates/modular_template.html
 
 # Ensure Bootstrap
-bootstrap_version = "4.6.1"
+bootstrap_version = "5.1.3"
 ensure_JS_dep(
     f"bootstrap-{bootstrap_version}-dist",
     f"https://github.com/twbs/bootstrap/releases/download/v{bootstrap_version}/bootstrap-{bootstrap_version}-dist.zip",
@@ -77,13 +77,6 @@ bootstrap_slider_version = "11.0.2"
 ensure_JS_dep(
     f"bootstrap-slider-{bootstrap_slider_version}",
     f"https://github.com/seiyria/bootstrap-slider/archive/refs/tags/v{bootstrap_slider_version}.zip",
-)
-
-# Ensure Bootstrap Switch
-bootstrap_switch_version = "3.3.4"
-ensure_JS_dep(
-    f"bootstrap-switch-{bootstrap_switch_version}",
-    f"https://github.com/Bttstrp/bootstrap-switch/archive/refs/tags/v{bootstrap_switch_version}.zip",
 )
 
 jquery_version = "2.2.4"


### PR DESCRIPTION
And also:
- remove bootstrap-switch dependency because Bootstrap already has
  switch
- Bootstrap 5 no longer uses jQuery under the hood

Testing checklist:
- Check that the start/step/reset works
- Check that on mobile view, the start/step/reset is hidden by the hamburger button
- Check the frame per second input works
- Check the modal (the about button) fades in/out correctly
- Check the user input title shows up correctly
- Check the user input description hover text appears correctly
- Check all the user inputs:
  * slider (boltzmann_wealth_model)
  * choice (pd_grid)
  * boolean switch (wolf_sheep)
  * raw text (virus_on_network)
  * number (no need to check this, because it's not in the examples, and I already check this myself)