### PR TITLE
examples: Convert nodes to list when drawing random sample

### DIFF
--- a/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
+++ b/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
@@ -25,7 +25,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
             agent_reporters={"Wealth": lambda _: _.wealth},
         )
 
-        list_of_random_nodes = self.random.sample(self.G.nodes(), self.num_agents)
+        list_of_random_nodes = self.random.sample(list(self.G), self.num_agents)
 
         # Create agents
         for i in range(self.num_agents):

--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -81,7 +81,7 @@ class VirusOnNetwork(Model):
             self.grid.place_agent(a, node)
 
         # Infect some nodes
-        infected_nodes = self.random.sample(self.G.nodes(), self.initial_outbreak_size)
+        infected_nodes = self.random.sample(list(self.G), self.initial_outbreak_size)
         for a in self.grid.get_cell_list_contents(infected_nodes):
             a.state = State.INFECTED
 


### PR DESCRIPTION
Using [`random.sample`](https://docs.python.org/3/library/random.html#random.sample) with a set has been depreciated in Python 3.9 and was removed in Python 3.11.

> Changed in version 3.11: The population must be a sequence. Automatic conversion of sets to lists is no longer supported.

This commit fixes two cases in which this happens, by converting the networkx.Graph.nodes set to a list before drawing a random sample from it.

See [networkx.Graph.nodes](https://networkx.org/documentation/stable/reference/classes/generated/networkx.Graph.nodes.html) for the recommended conversion from nodes to a list.

Closes #1329.