### PR TITLE
Convert hex_snowflake, pd_grid, schelling to simple namespace; [BREAKING] Remove class name collision

### DIFF
--- a/examples/hex_snowflake/hex_snowflake/cell.py
+++ b/examples/hex_snowflake/hex_snowflake/cell.py
@@ -1,7 +1,7 @@
-from mesa import Agent
+import mesa
 
 
-class Cell(Agent):
+class Cell(mesa.Agent):
     """Represents a single ALIVE or DEAD cell in the simulation."""
 
     DEAD = 0

--- a/examples/hex_snowflake/hex_snowflake/model.py
+++ b/examples/hex_snowflake/hex_snowflake/model.py
@@ -1,11 +1,9 @@
-from mesa import Model
-from mesa.time import SimultaneousActivation
-from mesa.space import HexGrid
+import mesa
 
 from hex_snowflake.cell import Cell
 
 
-class HexSnowflake(Model):
+class HexSnowflake(mesa.Model):
     """
     Represents the hex grid of cells. The grid is represented by a 2-dimensional array of cells with adjacency rules specific to hexagons.
     """
@@ -21,10 +19,10 @@ class HexSnowflake(Model):
         # computing their next state simultaneously.  This needs to
         # be done because each cell's next state depends on the current
         # state of all its neighbors -- before they've changed.
-        self.schedule = SimultaneousActivation(self)
+        self.schedule = mesa.time.SimultaneousActivation(self)
 
         # Use a hexagonal grid, where edges wrap around.
-        self.grid = HexGrid(width, height, torus=True)
+        self.grid = mesa.space.HexGrid(width, height, torus=True)
 
         # Place a dead cell at each location.
         for (contents, x, y) in self.grid.coord_iter():

--- a/examples/hex_snowflake/hex_snowflake/server.py
+++ b/examples/hex_snowflake/hex_snowflake/server.py
@@ -1,5 +1,4 @@
-from mesa.visualization.modules import CanvasHexGrid
-from mesa.visualization.ModularVisualization import ModularServer
+import mesa
 
 from hex_snowflake.portrayal import portrayCell
 from hex_snowflake.model import HexSnowflake
@@ -7,8 +6,8 @@ from hex_snowflake.model import HexSnowflake
 width, height = 50, 50
 
 # Make a world that is 50x50, on a 500x500 display.
-canvas_element = CanvasHexGrid(portrayCell, width, height, 500, 500)
+canvas_element = mesa.visualization.CanvasHexGrid(portrayCell, width, height, 500, 500)
 
-server = ModularServer(
+server = mesa.visualization.ModularServer(
     HexSnowflake, [canvas_element], "Hex Snowflake", {"height": height, "width": width}
 )

--- a/examples/pd_grid/pd_grid/agent.py
+++ b/examples/pd_grid/pd_grid/agent.py
@@ -1,7 +1,7 @@
-from mesa import Agent
+import mesa
 
 
-class PDAgent(Agent):
+class PDAgent(mesa.Agent):
     """Agent member of the iterated, spatial prisoner's dilemma model."""
 
     def __init__(self, pos, model, starting_move=None):

--- a/examples/pd_grid/pd_grid/model.py
+++ b/examples/pd_grid/pd_grid/model.py
@@ -1,18 +1,15 @@
-from mesa import Model
-from mesa.time import BaseScheduler, RandomActivation, SimultaneousActivation
-from mesa.space import SingleGrid
-from mesa.datacollection import DataCollector
+import mesa
 
 from .agent import PDAgent
 
 
-class PdGrid(Model):
+class PdGrid(mesa.Model):
     """Model class for iterated, spatial prisoner's dilemma model."""
 
     schedule_types = {
-        "Sequential": BaseScheduler,
-        "Random": RandomActivation,
-        "Simultaneous": SimultaneousActivation,
+        "Sequential": mesa.time.BaseScheduler,
+        "Random": mesa.time.RandomActivation,
+        "Simultaneous": mesa.time.SimultaneousActivation,
     }
 
     # This dictionary holds the payoff for this agent,
@@ -32,7 +29,7 @@ class PdGrid(Model):
                            Determines the agent activation regime.
             payoffs: (optional) Dictionary of (move, neighbor_move) payoffs.
         """
-        self.grid = SingleGrid(width, height, torus=True)
+        self.grid = mesa.space.SingleGrid(width, height, torus=True)
         self.schedule_type = schedule_type
         self.schedule = self.schedule_types[self.schedule_type](self)
 
@@ -43,7 +40,7 @@ class PdGrid(Model):
                 self.grid.place_agent(agent, (x, y))
                 self.schedule.add(agent)
 
-        self.datacollector = DataCollector(
+        self.datacollector = mesa.DataCollector(
             {
                 "Cooperating_Agents": lambda m: len(
                     [a for a in m.schedule.agents if a.move == "C"]

--- a/examples/pd_grid/pd_grid/server.py
+++ b/examples/pd_grid/pd_grid/server.py
@@ -1,18 +1,16 @@
-from mesa.visualization.ModularVisualization import ModularServer
-from mesa.visualization.modules import CanvasGrid
-from mesa.visualization.UserParam import UserSettableParameter
+import mesa
 
 from .portrayal import portrayPDAgent
 from .model import PdGrid
 
 
 # Make a world that is 50x50, on a 500x500 display.
-canvas_element = CanvasGrid(portrayPDAgent, 50, 50, 500, 500)
+canvas_element = mesa.visualization.CanvasGrid(portrayPDAgent, 50, 50, 500, 500)
 
 model_params = {
     "height": 50,
     "width": 50,
-    "schedule_type": UserSettableParameter(
+    "schedule_type": mesa.visualization.UserSettableParameter(
         "choice",
         "Scheduler type",
         value="Random",
@@ -20,4 +18,6 @@ model_params = {
     ),
 }
 
-server = ModularServer(PdGrid, [canvas_element], "Prisoner's Dilemma", model_params)
+server = mesa.visualization.ModularServer(
+    PdGrid, [canvas_element], "Prisoner's Dilemma", model_params
+)

--- a/examples/schelling/model.py
+++ b/examples/schelling/model.py
@@ -1,10 +1,7 @@
-from mesa import Model, Agent
-from mesa.time import RandomActivation
-from mesa.space import SingleGrid
-from mesa.datacollection import DataCollector
+import mesa
 
 
-class SchellingAgent(Agent):
+class SchellingAgent(mesa.Agent):
     """
     Schelling segregation agent
     """
@@ -35,7 +32,7 @@ class SchellingAgent(Agent):
             self.model.happy += 1
 
 
-class Schelling(Model):
+class Schelling(mesa.Model):
     """
     Model class for the Schelling segregation model.
     """
@@ -49,11 +46,11 @@ class Schelling(Model):
         self.minority_pc = minority_pc
         self.homophily = homophily
 
-        self.schedule = RandomActivation(self)
-        self.grid = SingleGrid(width, height, torus=True)
+        self.schedule = mesa.time.RandomActivation(self)
+        self.grid = mesa.space.SingleGrid(width, height, torus=True)
 
         self.happy = 0
-        self.datacollector = DataCollector(
+        self.datacollector = mesa.DataCollector(
             {"happy": "happy"},  # Model-level count of happy agents
             # For testing purposes, agent's individual x and y
             {"x": lambda a: a.pos[0], "y": lambda a: a.pos[1]},

--- a/examples/schelling/run_ascii.py
+++ b/examples/schelling/run_ascii.py
@@ -1,9 +1,9 @@
-from mesa.visualization.TextVisualization import TextData, TextGrid, TextVisualization
+import mesa
 
 from model import Schelling
 
 
-class SchellingTextVisualization(TextVisualization):
+class SchellingTextVisualization(mesa.visualization.TextVisualization):
     """
     ASCII visualization for schelling model
     """
@@ -14,8 +14,8 @@ class SchellingTextVisualization(TextVisualization):
         """
         self.model = model
 
-        grid_viz = TextGrid(self.model.grid, self.print_ascii_agent)
-        happy_viz = TextData(self.model, "happy")
+        grid_viz = mesa.visualization.TextGrid(self.model.grid, self.print_ascii_agent)
+        happy_viz = mesa.visualization.TextData(self.model, "happy")
         self.elements = [grid_viz, happy_viz]
 
     @staticmethod

--- a/examples/schelling/server.py
+++ b/examples/schelling/server.py
@@ -1,11 +1,9 @@
-from mesa.visualization.ModularVisualization import ModularServer
-from mesa.visualization.modules import CanvasGrid, ChartModule, TextElement
-from mesa.visualization.UserParam import UserSettableParameter
+import mesa
 
 from model import Schelling
 
 
-class HappyElement(TextElement):
+class HappyElement(mesa.visualization.TextElement):
     """
     Display a text count of how many happy agents there are.
     """
@@ -35,19 +33,23 @@ def schelling_draw(agent):
 
 
 happy_element = HappyElement()
-canvas_element = CanvasGrid(schelling_draw, 20, 20, 500, 500)
-happy_chart = ChartModule([{"Label": "happy", "Color": "Black"}])
+canvas_element = mesa.visualization.CanvasGrid(schelling_draw, 20, 20, 500, 500)
+happy_chart = mesa.visualization.ChartModule([{"Label": "happy", "Color": "Black"}])
 
 model_params = {
     "height": 20,
     "width": 20,
-    "density": UserSettableParameter("slider", "Agent density", 0.8, 0.1, 1.0, 0.1),
-    "minority_pc": UserSettableParameter(
+    "density": mesa.visualization.UserSettableParameter(
+        "slider", "Agent density", 0.8, 0.1, 1.0, 0.1
+    ),
+    "minority_pc": mesa.visualization.UserSettableParameter(
         "slider", "Fraction minority", 0.2, 0.00, 1.0, 0.05
     ),
-    "homophily": UserSettableParameter("slider", "Homophily", 3, 0, 8, 1),
+    "homophily": mesa.visualization.UserSettableParameter(
+        "slider", "Homophily", 3, 0, 8, 1
+    ),
 }
 
-server = ModularServer(
+server = mesa.visualization.ModularServer(
     Schelling, [canvas_element, happy_element, happy_chart], "Schelling", model_params
 )

--- a/mesa/flat/visualization.py
+++ b/mesa/flat/visualization.py
@@ -2,3 +2,4 @@
 from mesa.visualization.ModularVisualization import *  # noqa
 from mesa.visualization.modules import *  # noqa
 from mesa.visualization.UserParam import *  # noqa
+from mesa.visualization.TextVisualization import *  # noqa

--- a/mesa/visualization/TextVisualization.py
+++ b/mesa/visualization/TextVisualization.py
@@ -13,7 +13,7 @@ in some way using Elements, which are stored in a list and rendered in that
 order. Each element, in turn, renders a particular piece of information as
 text.
 
-TextElement: Parent class for all other ASCII elements. render() returns its
+ASCIIElement: Parent class for all other ASCII elements. render() returns its
 representative string, which can be printed via the overloaded __str__ method.
 
 TextData: Uses getattr to get the value of a particular property of a model
@@ -57,7 +57,7 @@ class TextVisualization:
         self.render()
 
 
-class TextElement:
+class ASCIIElement:
     """Base class for all TextElements to render.
 
     Methods:
@@ -76,7 +76,7 @@ class TextElement:
         return self.render()
 
 
-class TextData(TextElement):
+class TextData(ASCIIElement):
     """Prints the value of one particular variable from the base model."""
 
     def __init__(self, model, var_name):
@@ -88,7 +88,7 @@ class TextData(TextElement):
         return self.var_name + ": " + str(getattr(self.model, self.var_name))
 
 
-class TextGrid(TextElement):
+class TextGrid(ASCIIElement):
     """Class for creating an ASCII visualization of a basic grid object.
 
     By default, assume that each cell is represented by one character, and


### PR DESCRIPTION
- Convert hex_snowflake, pd_grid, schelling to simple namespace
- fix: Import TextVisualization to flat namespace (I somehow missed to import this file)
- BREAKING: Rename mesa.visualizations.modules.TextElement to TextModule

The last one is a breaking change, and it matters because: it collides with `mesa.visualizations.TextVisualization.TextElement`.
I chose to change it to TextModule *now*, because it will get harder to change the name to make it consistent with how the rest of the viz modules are named in the future.

This, together with `batch_run` defaulting to 1 CPU, need to be emphasized in the release note.