### PR TITLE
mypy: Use "|" operator instead of Union/Optional

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -4,8 +4,12 @@ The agent class for Mesa framework.
 Core Objects: Agent
 
 """
+# Mypy; for the `|` operator purpose
+# Remove this __future__ import once the oldest supported Python is 3.10
+from __future__ import annotations
+
 # mypy
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from random import Random
 
 if TYPE_CHECKING:
@@ -27,7 +31,7 @@ class Agent:
         """
         self.unique_id = unique_id
         self.model = model
-        self.pos: Optional[Position] = None
+        self.pos: Position | None = None
 
     def step(self) -> None:
         """A single step of the agent."""

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -4,12 +4,16 @@ The model class for Mesa framework.
 Core Objects: Model
 
 """
+# Mypy; for the `|` operator purpose
+# Remove this __future__ import once the oldest supported Python is 3.10
+from __future__ import annotations
+
 import random
 
 from mesa.datacollection import DataCollector
 
 # mypy
-from typing import Any, Optional
+from typing import Any
 
 
 class Model:
@@ -52,7 +56,7 @@ class Model:
         self.current_id += 1
         return self.current_id
 
-    def reset_randomizer(self, seed: Optional[int] = None) -> None:
+    def reset_randomizer(self, seed: int | None = None) -> None:
         """Reset the model random number generator.
 
         Args:

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -13,6 +13,10 @@ MultiGrid: extension to Grid where each cell is a set of objects.
 # good reason to use one-character variable names for x and y.
 # pylint: disable=invalid-name
 
+# Mypy; for the `|` operator purpose
+# Remove this __future__ import once the oldest supported Python is 3.10
+from __future__ import annotations
+
 import itertools
 import math
 from warnings import warn
@@ -26,7 +30,6 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    Optional,
     Set,
     Sequence,
     Tuple,
@@ -48,7 +51,7 @@ NetworkCoordinate = int
 
 Position = Union[Coordinate, FloatCoordinate, NetworkCoordinate]
 
-GridContent = Optional[Agent]
+GridContent = Union[Agent, None]
 MultiGridContent = List[Agent]
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -128,8 +131,8 @@ class Grid:
 
     @overload
     def __getitem__(
-        self, index: Tuple[Union[int, slice], Union[int, slice]]
-    ) -> Union[GridContent, List[GridContent]]:
+        self, index: Tuple[int | slice, int | slice]
+    ) -> GridContent | List[GridContent]:
         ...
 
     @overload
@@ -138,12 +141,8 @@ class Grid:
 
     def __getitem__(
         self,
-        index: Union[
-            int,
-            Sequence[Coordinate],
-            Tuple[Union[int, slice], Union[int, slice]],
-        ],
-    ) -> Union[GridContent, List[GridContent]]:
+        index: int | Sequence[Coordinate] | Tuple[int | slice, int | slice],
+    ) -> GridContent | List[GridContent]:
         """Access contents from the grid."""
 
         if isinstance(index, int):
@@ -436,7 +435,7 @@ class Grid:
         return self.grid[x][y] == self.default_val()
 
     def move_to_empty(
-        self, agent: Agent, cutoff: float = 0.998, num_agents: Optional[int] = None
+        self, agent: Agent, cutoff: float = 0.998, num_agents: int | None = None
     ) -> None:
         """Moves agent to a random empty cell, vacating agent's old cell."""
         if len(self.empties) == 0:
@@ -478,7 +477,7 @@ class Grid:
         self._place_agent(agent, new_pos)
         agent.pos = new_pos
 
-    def find_empty(self) -> Optional[Coordinate]:
+    def find_empty(self) -> Coordinate | None:
         """Pick a random empty cell."""
         import random
 
@@ -509,7 +508,7 @@ class SingleGrid(Grid):
     empties: Set[Coordinate] = set()
 
     def position_agent(
-        self, agent: Agent, x: Union[int, str] = "random", y: Union[int, str] = "random"
+        self, agent: Agent, x: int | str = "random", y: int | str = "random"
     ) -> None:
         """Position an agent on the grid.
         This is used when first placing agents! Use 'move_to_empty()'
@@ -781,7 +780,7 @@ class ContinuousSpace:
         self.size = np.array((self.width, self.height))
         self.torus = torus
 
-        self._agent_points: Optional[npt.NDArray[FloatCoordinate]] = None
+        self._agent_points: npt.NDArray[FloatCoordinate] | None = None
         self._index_to_agent: Dict[int, Agent] = {}
         self._agent_to_index: Dict[Agent, int] = {}
 

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -21,10 +21,14 @@ Key concepts:
     model has taken.
 """
 
+# Mypy; for the `|` operator purpose
+# Remove this __future__ import once the oldest supported Python is 3.10
+from __future__ import annotations
+
 from collections import OrderedDict, defaultdict
 
 # mypy
-from typing import Dict, Iterator, List, Optional, Union, Type
+from typing import Dict, Iterator, List, Type, Union
 from mesa.agent import Agent
 from mesa.model import Model
 
@@ -163,7 +167,7 @@ class StagedActivation(BaseScheduler):
     def __init__(
         self,
         model: Model,
-        stage_list: Optional[List[str]] = None,
+        stage_list: List[str] | None = None,
         shuffle: bool = False,
         shuffle_between_stages: bool = False,
     ) -> None:


### PR DESCRIPTION
Partially addresses #1341. To completely remove `Union`, sadly, we need to wait until 3.10 is the oldest supported version.

See https://peps.python.org/pep-0604/.