### PR TITLE
Add alignment options to agent portrayals in CanvasGridVisualization

### DIFF
--- a/mesa/visualization/modules/CanvasGridVisualization.py
+++ b/mesa/visualization/modules/CanvasGridVisualization.py
@@ -25,9 +25,13 @@ class CanvasGrid(VisualizationElement):
             For Circles:
                 "r": The radius, defined as a fraction of cell size. r=1 will
                      fill the entire cell.
+                "xAlign", "yAlign": Alignment of the circle within the cell.
+                                    Defaults to 0.5 (center).
             For Rectangles:
                 "w", "h": The width and height of the rectangle, which are in
                           fractions of cell width and height.
+                "xAlign", "yAlign": Alignment of the rectangle within the
+                                    cell. Defaults to 0.5 (center).
             For arrowHead:
                 "scale": Proportion scaling as a fraction of cell size.
                 "heading_x": represents x direction unit vector.

--- a/mesa/visualization/templates/js/GridDraw.js
+++ b/mesa/visualization/templates/js/GridDraw.js
@@ -79,10 +79,19 @@ const GridVisualization = function (
       // If the stroke color is not defined, then the first color in the colors array is the stroke color.
       if (!p.stroke_color) p.stroke_color = p.Color[0];
 
+      // Default alignments to 0.5 (center of a cell)
+      p.xAlign ??= 0.5;
+      p.yAlign ??= 0.5;
+
+      p.xAlign = clamp(p.xAlign, 0.0, 1.0)
+      p.yAlign = clamp(p.yAlign, 0.0, 1.0)
+
       if (p.Shape == "rect")
         this.drawRectangle(
           p.x,
           p.y,
+          p.xAlign,
+          p.yAlign,
           p.w,
           p.h,
           p.Color,
@@ -95,6 +104,8 @@ const GridVisualization = function (
         this.drawCircle(
           p.x,
           p.y,
+          p.xAlign,
+          p.yAlign,
           p.r,
           p.Color,
           p.stroke_color,
@@ -130,6 +141,7 @@ const GridVisualization = function (
   /**
         Draw a circle in the specified grid cell.
         x, y: Grid coords
+        xAlign, yAlign: Alignment within the cell, defaults to 0.5 (center)
         r: Radius, as a multiple of cell size
         colors: List of colors for the gradient. Providing only one color will fill the shape with only that color, not gradient.
         stroke_color: Color to stroke the shape
@@ -140,6 +152,8 @@ const GridVisualization = function (
   this.drawCircle = function (
     x,
     y,
+    xAlign,
+    yAlign,
     radius,
     colors,
     stroke_color,
@@ -147,8 +161,8 @@ const GridVisualization = function (
     text,
     text_color
   ) {
-    const cx = (x + 0.5) * cellWidth;
-    const cy = (y + 0.5) * cellHeight;
+    const cx = (x + xAlign) * cellWidth;
+    const cy = (y + yAlign) * cellHeight;
     const r = radius * maxR;
 
     context.beginPath();
@@ -181,6 +195,7 @@ const GridVisualization = function (
   /**
         Draw a rectangle in the specified grid cell.
         x, y: Grid coords
+        xAlign, yAlign: Alignment within the cell, defaults to 0.5 (center)
         w, h: Width and height, [0, 1]
         colors: List of colors for the gradient. Providing only one color will fill the shape with only that color, not gradient.
         stroke_color: Color to stroke the shape
@@ -191,6 +206,8 @@ const GridVisualization = function (
   this.drawRectangle = function (
     x,
     y,
+    xAlign,
+    yAlign,
     w,
     h,
     colors,
@@ -203,9 +220,8 @@ const GridVisualization = function (
     const dx = w * cellWidth;
     const dy = h * cellHeight;
 
-    // Keep in the center of the cell:
-    const x0 = (x + 0.5) * cellWidth - dx / 2;
-    const y0 = (y + 0.5) * cellHeight - dy / 2;
+    const x0 = (x + xAlign) * cellWidth - dx / 2;
+    const y0 = (y + yAlign) * cellHeight - dy / 2;
 
     context.strokeStyle = stroke_color;
     context.strokeRect(x0, y0, dx, dy);
@@ -392,3 +408,7 @@ const GridVisualization = function (
     context.beginPath();
   };
 };
+
+const clamp = function (val, min, max) {
+  return Math.min(Math.max(min, val), max);
+}

--- a/mesa/visualization/templates/js/GridDraw.js
+++ b/mesa/visualization/templates/js/GridDraw.js
@@ -83,9 +83,6 @@ const GridVisualization = function (
       p.xAlign ??= 0.5;
       p.yAlign ??= 0.5;
 
-      p.xAlign = clamp(p.xAlign, 0.0, 1.0)
-      p.yAlign = clamp(p.yAlign, 0.0, 1.0)
-
       if (p.Shape == "rect")
         this.drawRectangle(
           p.x,
@@ -161,6 +158,12 @@ const GridVisualization = function (
     text,
     text_color
   ) {
+    // Prevent circle from being drawn outside cell bounds.
+    // Since a radius of 1 corresponds to a circle that fills
+    // the entire cell, it is necessary to divide radius by 2.
+    xAlign = clamp(xAlign, radius / 2, 1 - radius / 2);
+    yAlign = clamp(yAlign, radius / 2, 1 - radius / 2);
+
     const cx = (x + xAlign) * cellWidth;
     const cy = (y + yAlign) * cellHeight;
     const r = radius * maxR;
@@ -219,6 +222,10 @@ const GridVisualization = function (
     context.beginPath();
     const dx = w * cellWidth;
     const dy = h * cellHeight;
+
+    // Prevent rect from being drawn outside cell bounds.
+    xAlign = clamp(xAlign, w / 2, 1 - w / 2);
+    yAlign = clamp(yAlign, h / 2, 1 - h / 2);
 
     const x0 = (x + xAlign) * cellWidth - dx / 2;
     const y0 = (y + yAlign) * cellHeight - dy / 2;

--- a/mesa/visualization/templates/js/InteractionHandler.js
+++ b/mesa/visualization/templates/js/InteractionHandler.js
@@ -36,6 +36,8 @@ const InteractionHandler = function (width, height, gridWidth, gridHeight, ctx) 
     "r",
     "x",
     "y",
+    "xAlign",
+    "yAlign",
     "w",
     "h",
     "width",


### PR DESCRIPTION
Adds `xAlign` and `yAlign` properties to agent portrayals for a `CanvasGrid`. Both default to 0.5 when not specified (in line with the existing implementation). The main use case for this is displaying multiple agents that are in the same grid cell without having to resort to different layers or sizes.

![image](https://user-images.githubusercontent.com/16710281/171295863-81110c92-a696-451c-8773-e58ef4ba02f6.png)

Currently, it is only implemented for `circle` and `rect`, and values are clamped between 0.0 and 1.0, meaning that in some cases shapes can overflow past the cell boundaries. If needed, I can make some changes to ensure that this will never happen using the circle radius or the rect dimensions.