### PR TITLE
fix: examples: Make space x, y order consistent

### DIFF
--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -84,7 +84,7 @@ class EpsteinCivilViolence(mesa.Model):
             if self.random.random() < self.cop_density:
                 cop = Cop(unique_id, self, (x, y), vision=self.cop_vision)
                 unique_id += 1
-                self.grid[y][x] = cop
+                self.grid[x][y] = cop
                 self.schedule.add(cop)
             elif self.random.random() < (self.cop_density + self.citizen_density):
                 citizen = Citizen(
@@ -98,7 +98,7 @@ class EpsteinCivilViolence(mesa.Model):
                     vision=self.citizen_vision,
                 )
                 unique_id += 1
-                self.grid[y][x] = citizen
+                self.grid[x][y] = citizen
                 self.schedule.add(citizen)
 
         self.running = True

--- a/examples/forest_fire/Forest Fire Model.ipynb
+++ b/examples/forest_fire/Forest Fire Model.ipynb
@@ -149,7 +149,7 @@
     "                    # Set all trees in the first column on fire.\n",
     "                    if x == 0:\n",
     "                        new_tree.condition = \"On Fire\"\n",
-    "                    self.grid[y][x] = new_tree\n",
+    "                    self.grid[x][y] = new_tree\n",
     "                    self.schedule.add(new_tree)\n",
     "        self.running = True\n",
     "\n",


### PR DESCRIPTION
The `[x][y]` order is consistent with space.py: https://github.com/projectmesa/mesa/blob/c2103830cd9054bdb5437a712e1add1e474daf95/mesa/space.py#L418-L422.