### PR TITLE
Perf: ContinuousSpace: speed-up add/remove agents

### DIFF
--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -24,6 +24,30 @@ REMOVAL_TEST_AGENTS = [
     (31, 41),
     (55, 32),
 ]
+TEST_AGENTS_PERF = 200000
+
+
+@pytest.mark.skip(reason="a perf test will slow down the CI")
+class TestSpacePerformance(unittest.TestCase):
+    """
+    Testing adding many agents for a continuous space.
+    """
+
+    def setUp(self):
+        """
+        Create a test space and populate with Mock Agents.
+        """
+        self.space = ContinuousSpace(10, 10, True, -10, -10)
+
+    def test_agents_add_many(self):
+        """
+        Add many agents
+        """
+        positions = np.random.rand(TEST_AGENTS_PERF, 2)
+        for i in range(TEST_AGENTS_PERF):
+            a = MockAgent(i, None)
+            pos = [positions[i, 0], positions[i, 1]]
+            self.space.place_agent(a, pos)
 
 
 class TestSpaceToroidal(unittest.TestCase):


### PR DESCRIPTION
Adding / removing many (100+K) Agents to a ContinuousSpace is slow.
This is due to ```numpy.array.append()``` not being optimized for appending.

This pull request changes the internal bookkeeping of the ```_agents_points``` numpy array, and the ```_agent_to_index``` and ```_index_to_agent``` dictionaries.
* re-use, or calculate the ```_agents_points``` array and the 2 dictionaries when needed (neighbor lookups)
* update the ```_agent_points``` array when moving an agent.
* drop the ```_agent_points``` array and clear the ```_index_to_agent``` dict when adding/removing agents
* The ```_agent_to_index``` dictionary is used to keep track of the agents placed in the space, also when the other two  (```_index_to_agent``` and ```_agent_points```) are cleared.

I've also added a test that just adds many agents (200K). Before this pull request, running the full test suite took 43 seconds; after this change the full test suite takes 6.5 seconds.

Fixes #1375 