### PR TITLE
Fix zoom on network visualisation

### DIFF
--- a/mesa/visualization/templates/js/NetworkModule_d3.js
+++ b/mesa/visualization/templates/js/NetworkModule_d3.js
@@ -23,11 +23,12 @@ const NetworkModule = function (svg_width, svg_height) {
     .attr("class", "d3tooltip")
     .style("opacity", 0);
 
-  svg.call(
-    d3.zoom().on("zoom", () => {
-      g.attr("transform", d3.event.transform);
-    })
-  );
+  const zoom = d3.zoom()
+    .on("zoom", (event) => {
+      g.attr("transform", event.transform);
+    });
+
+  svg.call(zoom);
 
   const links = g.append("g").attr("class", "links");
 

--- a/mesa/visualization/templates/js/NetworkModule_d3.js
+++ b/mesa/visualization/templates/js/NetworkModule_d3.js
@@ -14,8 +14,7 @@ const NetworkModule = function (svg_width, svg_height) {
   const height = +svg.attr("height");
   const g = svg
     .append("g")
-    .classed("network_root", true)
-    .attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
+    .classed("network_root", true);
 
   const tooltip = d3
     .select("body")
@@ -29,6 +28,11 @@ const NetworkModule = function (svg_width, svg_height) {
     });
 
   svg.call(zoom);
+
+  svg.call(
+    zoom.transform,
+    d3.zoomIdentity.translate(width / 2, height / 2)
+  );
 
   const links = g.append("g").attr("class", "links");
 


### PR DESCRIPTION
d3.event was removed in https://github.com/d3/d3/releases/tag/v6.0.0, which breaks zooming / translating.

Also, centre the graph with the zoom object rather than beforehand, to prevent everything from jumping when you first zoom.