### PR TITLE
ci: update black to prevent click error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.6.0
     hooks:
       - id: black
         exclude: ^mesa/cookiecutter-mesa/


### PR DESCRIPTION
Updating black to `22.6.0` to prevent `click` error during pre-commit.