### PR TITLE
Fix broken monospace links

### DIFF
--- a/docs/tutorials/intro_tutorial.rst
+++ b/docs/tutorials/intro_tutorial.rst
@@ -652,13 +652,15 @@ applies each agent-level collection function to each agent currently in
 the schedule, associating the resulting value with the step of the
 model, and the agent’s ``unique_id``.
 
-Let’s add a DataCollector to the model with
-```mesa.DataCollector`` <https://github.com/projectmesa/mesa/blob/main/mesa/datacollection.py>`__,
+Let’s add a DataCollector to the model with |mesa.DataCollector|__,
 and collect two variables. At the agent level, we want to collect every
 agent’s wealth at every step. At the model level, let’s measure the
 model’s `Gini
 Coefficient <https://en.wikipedia.org/wiki/Gini_coefficient>`__, a
 measure of wealth inequality.
+
+.. |mesa.DataCollector| replace:: ``mesa.DataCollector``
+__ mesa.DataCollector: https://github.com/projectmesa/mesa/blob/main/mesa/datacollection.py
 
 .. code:: ipython3
 
@@ -896,9 +898,11 @@ Like we mentioned above, you usually won’t run a model only once, but
 multiple times, with fixed parameters to find the overall distributions
 the model generates, and with varying parameters to analyze how they
 drive the model’s outputs and behaviors. Instead of needing to write
-nested for-loops for each model, Mesa provides a
-```batch_run`` <https://github.com/projectmesa/mesa/blob/main/mesa/batchrunner.py>`__
-function which automates it for you.
+nested for-loops for each model, Mesa provides a |batch_run|__ function
+which automates it for you.
+
+.. |batch_run| replace:: ``batch_run``
+__ batch_run: https://github.com/projectmesa/mesa/blob/main/mesa/batchrunner.py
 
 The batch runner also requires an additional variable ``self.running``
 for the MoneyModel class. This variable enables conditional shut off of


### PR DESCRIPTION
Nested inline markup – here: a combination of [inline literals] and [embedded URIs] – is currently [not supported] by reStructuredText. Now using a substitution reference defined with the "replace" directive.

[inline literals]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-literals
[embedded URIs]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#embedded-uris-and-aliases
[not supported]: https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible