### PR TITLE
Fix batchrunner progress bar

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -80,7 +80,7 @@ def batch_run(
 
     results: List[Dict[str, Any]] = []
 
-    with tqdm(total_iterations, disable=not display_progress) as pbar:
+    with tqdm(total=total_iterations, disable=not display_progress) as pbar:
         iteration_counter: Counter[Tuple[Any, ...]] = Counter()
 
         def _fn(paramValues, rawdata):


### PR DESCRIPTION
It currently just shows the number of iterations done, not the progress, because total is passed in wrong (see [https://tqdm.github.io/docs/tqdm/#\_\_init\_\_](https://tqdm.github.io/docs/tqdm/#__init__))