### PR TITLE
Fix stray " in visualisation dropdown labels

### DIFF
--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -274,7 +274,7 @@ const initGUI = function (model_params) {
       `<p>
         <label for='${domID}' class='badge bg-primary'>
         ${obj.name}
-        "</label>
+        </label>
       </p>`,
       `<select
         id='${domID}'


### PR DESCRIPTION
It appears in the label, just a trivial annoyance.