### PR TITLE
Add "falsy" to .codespellignore

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -5,3 +5,4 @@ ist
 inactivate
 ue
 fpr
+falsy


### PR DESCRIPTION
This fixes this Codespell error: https://github.com/projectmesa/mesa/actions/runs/3010330720/jobs/4836305531#step:4:18.
This is due to newer Codespell considers this a typo.