### PR TITLE
readme: Improve the pip install for Git repo instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,13 +49,13 @@ You can also use `pip` to install the github version:
 
 .. code-block:: bash
 
-    $ pip install -e git+https://github.com/projectmesa/mesa#egg=mesa
+    $ pip install -U -e git+https://github.com/projectmesa/mesa@main#egg=mesa
 
 Or any other (development) branch on this repo or your own fork:
 
 .. code-block:: bash
 
-    $ pip install -e git+https://github.com/YOUR_FORK/mesa@YOUR_BRANCH#egg=mesa
+    $ pip install -U -e git+https://github.com/YOUR_FORK/mesa@YOUR_BRANCH#egg=mesa
 
 Take a look at the `examples <https://github.com/projectmesa/mesa/tree/main/examples>`_ folder for sample models demonstrating Mesa features.
 


### PR DESCRIPTION
This fixes #1415.

I'm not sure if the `-U` is necessary. It's a bit unclear even after reading https://stackoverflow.com/questions/17710947/pip-pulling-updates-from-remote-git-repository. I no longer can test since #1415 is solved. But I don't think adding `-U` will cause any problem.