### PR TITLE
Upgrade pre-commit CI (with pyupgrade and syntax checks)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,21 @@
+ci:
+    autoupdate_schedule: 'monthly'
+    autofix_prs: false
+
 repos:
--   repo: https://github.com/ambv/black
-    rev: 22.6.0
+-   repo: https://github.com/psf/black
+    rev: 22.8.0
     hooks:
-      - id: black
-        exclude: ^mesa/cookiecutter-mesa/
       - id: black-jupyter
+        exclude: ^mesa/cookiecutter-mesa/
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.38.2
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0  # Use the ref you want to point at
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-toml
+    -   id: check-yaml


### PR DESCRIPTION
This commit upgrades the [pre-commit](https://pre-commit.com/) configuration in the following ways:
 - It fixes and updates the [Black](https://github.com/psf/black) configuration (black-jupyter is inclusive of black)
 - It adds [pyupgrade](https://github.com/asottile/pyupgrade)
 - It check for trailing whitespaces and if toml and yaml syntax is correct
 - Updates itself monthly (using [pre-commit.ci](https://pre-commit.ci/))

pre-commit currently isn't enabled in Mesa's CI. I would recommend enabling it on https://pre-commit.ci/. Otherwise a custom GitHub Actions workflow could be written (but that's slower).

