### PR TITLE
space: Fix type error for Python < 3.9

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -44,7 +44,7 @@ import numpy.typing as npt
 
 Coordinate = Tuple[int, int]
 # used in ContinuousSpace
-FloatCoordinate = Union[tuple[float, float], npt.NDArray[float]]
+FloatCoordinate = Union[Tuple[float, float], npt.NDArray[float]]
 NetworkCoordinate = int
 
 Position = Union[Coordinate, FloatCoordinate, NetworkCoordinate]


### PR DESCRIPTION
I accidentally introduced an extra change in #1429.