### PR TITLE
ModularServer: Put new optional arg port last

### DIFF
--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -257,8 +257,8 @@ class ModularServer(tornado.web.Application):
         model_cls,
         visualization_elements,
         name="Mesa Model",
-        port=None,
         model_params=None,
+        port=None,
     ):
         """
         Args:


### PR DESCRIPTION
This is a newly added argument, and so we should preserve the existing arguments order instead.

Fixes #1431.