### PR TITLE
Improved clamp function and measured performance

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -56,9 +56,8 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def clamp(x: float, lowest: float, highest: float) -> float:
-    # This should be faster than np.clip for a scalar x.
-    # TODO: measure how much faster this function is.
-    return max(lowest, min(x, highest))
+    # much faster than np.clip for a scalar x.
+    return lowest if x <= lowest else (highest if x >= highest else x)
 
 
 def accept_tuple_argument(wrapped_function: F) -> F:


### PR DESCRIPTION
Hi to all!

I've measured the performance of the possible alternatives for the clamp function, this is the code:

```
import timeit

a = timeit.timeit(stmt="clamp(0.3, 0.0 ,1.0)", setup='import numpy as np\ndef clamp(x: float, lowest: float, highest: float) -> float: return np.clip(x, lowest, highest)')

b = timeit.timeit(stmt="clamp(0.3, 0.0 ,1.0)", setup='def clamp(x: float, lowest: float, highest: float) -> float: return max(lowest, min(x, highest))')

c = timeit.timeit(stmt="clamp(0.3, 0.0 ,1.0)", setup='def clamp(x: float, lowest: float, highest: float) -> float: return lowest if x < lowest else highest if x > highest else x')

print(a, b, c)

# result on test run: 12.690470200002892 0.3120805000071414 0.16836619999958202
```

The performance comparison doesn't change for numbers outside the range. Then, the fastest alternative is option c, which is about 75 times faster than the clip function on the test run.  Finally, I replaced the function with that alternative, hope it helps!