### PR TITLE
Memoize positions in HexGrid.find_neighbors

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -633,9 +633,15 @@ class HexGrid(Grid):
         def torus_adj_2d(pos: Coordinate) -> Coordinate:
             return (pos[0] % self.width, pos[1] % self.height)
 
+        explored = dict()
         coordinates = set()
 
         def find_neighbors(pos: Coordinate, radius: int) -> None:
+
+            if pos in explored and explored[pos] >= radius:
+                return
+            explored[pos] = radius
+
             x, y = pos
 
             """

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -391,6 +391,9 @@ class TestHexGrid(unittest.TestCase):
         neighborhood = self.grid.get_neighborhood((1, 1), include_center=True)
         assert len(neighborhood) == 7
 
+        neighborhood = self.grid.get_neighborhood((1, 1), radius=3)
+        assert len(neighborhood) == 12
+
 
 class TestHexGridTorus(TestBaseGrid):
     """
@@ -434,6 +437,9 @@ class TestHexGridTorus(TestBaseGrid):
 
         neighborhood = self.grid.get_neighborhood((2, 4))
         assert len(neighborhood) == 6
+
+        neighborhood = self.grid.get_neighborhood((1, 1), include_center=True, radius=2)
+        assert len(neighborhood) == 13
 
 
 class TestIndexing:


### PR DESCRIPTION
Hi to all !

I found that the HexGrid.find_neighbors didn't memoize positions, making it really slow when the radius of the neighborhood increases, with this PR it becomes much faster, here it is a local comparison I made in relation to the size of the radius:

![Figure_2](https://user-images.githubusercontent.com/68152031/195219834-01437cbc-e348-4db6-ae0a-2987fc69ddda.png)

As you can see, now it's much faster...it becomes 2500 times faster when the radius is 9! A small drop of 4% and 2% in performance instead when the radius is 1 and 2 respectively.
