### PR TITLE
Refactor HexGrid.iter_neighborhood

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -646,9 +646,6 @@ class HexGrid(Grid):
             """
             adjacent = [(x, y - 1), (x, y + 1)]
 
-            if include_center:
-                adjacent.append(pos)
-
             if x % 2 == 0:
                 adjacent += [(x - 1, y + 1), (x - 1, y), (x + 1, y + 1), (x + 1, y)]
             else:
@@ -668,8 +665,10 @@ class HexGrid(Grid):
 
         find_neighbors(pos, radius)
 
-        if not include_center and pos in coordinates:
-            coordinates.remove(pos)
+        if include_center:
+            coordinates.add(pos)
+        else:
+            coordinates.discard(pos)
 
         yield from coordinates
 


### PR DESCRIPTION
Small refactor of the include_center condition inside HexGrid. 

This works because 

- if `include_center == True` then we add the center after the execution of the `find_neighbors` function. Before this PR, the function appended `pos`  at each call, but that was not necessary because after the first execution which appends the center, it appends positions already present in the `coordinates` set because of previous executions of the function. Doing it this way makes the function a bit faster ;
- if `include_center == False`  we need to discard the center after the calls to `find_neighbors` because it could be present anyway, for example with the possible sequence `(x, y) -> (x + 1, y - 1) -> (x + 1, y - 1)`.