### PR TITLE
Updates doc build to 3.9, 3.10 not supported

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.10"
+  version: "3.9"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Previous PR caused a break in our doc build - https://github.com/projectmesa/mesa/pull/1447 

3.10 is causing build errors - but it looks like 3.9 is supported - https://github.com/readthedocs/readthedocs.org/issues/7554
This small PR should fix the issue. (Unless it turns out 3.9 isn't supported as well.)