### PR TITLE
Update to python 3.8, 3.9 breaks the build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.9"
+  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RE: Readthedocs -- `HEAD is now at c76546b Updates doc build to 3.9, 3.10 not supported`

Need to downgrade further to fix the build.

Related: #1449 #1447 