### PR TITLE
Delete recursion from HexGrid.iter_neighborhood

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -394,8 +394,9 @@ class TestHexGrid(unittest.TestCase):
         neighborhood = self.grid.get_neighborhood((1, 1), include_center=True)
         assert len(neighborhood) == 7
 
-        neighborhood = self.grid.get_neighborhood((1, 1), radius=3)
-        assert len(neighborhood) == 12
+        neighborhood = self.grid.get_neighborhood((0, 0), radius=4)
+        assert len(neighborhood) == 13
+        assert sum(x + y for x, y in neighborhood) == 39
 
 
 class TestHexGridTorus(TestBaseGrid):
@@ -443,6 +444,10 @@ class TestHexGridTorus(TestBaseGrid):
 
         neighborhood = self.grid.get_neighborhood((1, 1), include_center=True, radius=2)
         assert len(neighborhood) == 13
+
+        neighborhood = self.grid.get_neighborhood((0, 0), radius=4)
+        assert len(neighborhood) == 14
+        assert sum(x + y for x, y in neighborhood) == 45
 
 
 class TestIndexing:


### PR DESCRIPTION
I deleted the recursive function find_neighbors inside HexGrid.iter_neighborhood and made the function iterative, I also tweaked other parts of the code to speed it up a bit the function (but I'm not satisfied with the black formatting, what do you think about it?). I tested it with 

```
import timeit, mesa.space, mesa.space_2

res = []
for radius in range(1,18):
    
    setup_1 = "from mesa.space import HexGrid\nwidth, height = 100, 100\ngrid = HexGrid(width, height, torus=True)"
    setup_2 = "from mesa.space_2 import HexGrid\nwidth, height = 100, 100\ngrid = HexGrid(width, height, torus=True)"

    stmt = f"grid.get_neighborhood((1, 10), include_center=True, radius={radius})"

    a = min(timeit.repeat(stmt=stmt, setup=setup_1, repeat=10, number=1000))
    b = min(timeit.repeat(stmt=stmt, setup=setup_2, repeat=10, number=1000))

    print([a, b, a/b])
    res.append([a, b, a/b])
print(res)
```

where `mesa.space_2` contains the modified code. The results when `self.torus == False` is that it is always faster, here it is the case when `self.torus == True`, when the radius is equal to 1 there is a drop of 4%, in all other cases is faster as can be seen in the following graph:

![graph](https://user-images.githubusercontent.com/68152031/196047605-aaa2d1ec-ac85-4b91-bfdc-def67824df1d.png)

From the algorithmic point of view we passed from recursive dfs to iterative bfs which in a language like Python, where recursion is not so efficiently managed, makes the code run  faster