### PR TITLE
Change OrderedDict in dict

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -8,7 +8,6 @@ A single class to manage a batch run or parameter sweep of a given model.
 import copy
 import itertools
 import random
-from collections import OrderedDict
 from functools import partial
 from itertools import count, product
 from multiprocessing import Pool, cpu_count
@@ -310,9 +309,8 @@ class FixedBatchRunner:
         if self.agent_reporters:
             self.agent_vars = {}
 
-        # Make Compatible with Python 3.5
-        self.datacollector_model_reporters = OrderedDict()
-        self.datacollector_agent_reporters = OrderedDict()
+        self.datacollector_model_reporters = {}
+        self.datacollector_agent_reporters = {}
 
         self.display_progress = display_progress
 
@@ -407,7 +405,7 @@ class FixedBatchRunner:
 
     def collect_model_vars(self, model):
         """Run reporters and collect model-level variables."""
-        model_vars = OrderedDict()
+        model_vars = {}
         for var, reporter in self.model_reporters.items():
             model_vars[var] = reporter(model)
 
@@ -415,9 +413,9 @@ class FixedBatchRunner:
 
     def collect_agent_vars(self, model):
         """Run reporters and collect agent-level variables."""
-        agent_vars = OrderedDict()
+        agent_vars = {}
         for agent in model.schedule._agents.values():
-            agent_record = OrderedDict()
+            agent_record = {}
             for var, reporter in self.agent_reporters.items():
                 agent_record[var] = getattr(agent, reporter)
             agent_vars[agent.unique_id] = agent_record

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -25,7 +25,7 @@ Key concepts:
 # Remove this __future__ import once the oldest supported Python is 3.10
 from __future__ import annotations
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 # mypy
 from typing import Iterator, Union
@@ -53,7 +53,7 @@ class BaseScheduler:
         self.model = model
         self.steps = 0
         self.time: TimeT = 0
-        self._agents: dict[int, Agent] = OrderedDict()
+        self._agents: dict[int, Agent] = {}
 
     def add(self, agent: Agent) -> None:
         """Add an Agent object to the schedule.


### PR DESCRIPTION
Given that Mesa 0.8.8 is the last version supporting Python 3.5 then we can safely move from OrderedDict  to dict I think
