### PR TITLE
Replace random.choice with move_to_empty

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -415,7 +415,8 @@ class Grid:
 
     def remove_agent(self, agent: Agent) -> None:
         """Remove the agent from the grid and set its pos attribute to None."""
-        pos = agent.pos
+        if (pos := agent.pos) is None:
+            return
         x, y = pos
         self.grid[x][y] = self.default_val()
         self.empties.add(pos)
@@ -502,20 +503,18 @@ class SingleGrid(Grid):
         self, agent: Agent, x: int | str = "random", y: int | str = "random"
     ) -> None:
         """Position an agent on the grid.
-        This is used when first placing agents! Use 'move_to_empty()'
-        when you want agents to jump to an empty cell.
+        This is used when first placing agents! Setting either x or y to "random"
+        gives the same behavior as 'move_to_empty()' to get a random position.
+        If x or y are positive, they are used.
         Use 'swap_pos()' to swap agents positions.
-        If x or y are positive, they are used, but if "random",
-        we get a random position.
-        Ensure this random position is not occupied (in Grid).
         """
         if x == "random" or y == "random":
             if len(self.empties) == 0:
                 raise Exception("ERROR: Grid full")
-            coords = agent.random.choice(sorted(self.empties))
+            self.move_to_empty(agent)
         else:
             coords = (x, y)
-        self.place_agent(agent, coords)
+            self.place_agent(agent, coords)
 
     def place_agent(self, agent: Agent, pos: Coordinate) -> None:
         if self.is_cell_empty(pos):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -3,6 +3,7 @@ Test the Grid objects.
 """
 import random
 import unittest
+from unittest.mock import patch, Mock
 from mesa.space import Grid, SingleGrid, MultiGrid, HexGrid
 
 # Initial agent positions for testing
@@ -231,7 +232,8 @@ class TestSingleGrid(unittest.TestCase):
                 self.grid.place_agent(a, (x, y))
         self.num_agents = len(self.agents)
 
-    def test_enforcement(self):
+    @patch.object(MockAgent, "model", create=True)
+    def test_enforcement(self, mock_model):
         """
         Test the SingleGrid empty count and enforcement.
         """
@@ -242,6 +244,7 @@ class TestSingleGrid(unittest.TestCase):
             self.grid.place_agent(a, (0, 1))
 
         # Place the agent in an empty cell
+        mock_model.schedule.get_agent_count = Mock(side_effect=lambda: len(self.agents))
         self.grid.position_agent(a)
         self.num_agents += 1
         # Test whether after placing, the empty cells are reduced by 1


### PR DESCRIPTION
In #1052, the faster algorithm was only applied to `Grid.move_to_empty`. `SingleGrid.postion_agent` is still too slow because it uses `random.choice(sorted(self.empties))`. This PR replaces `random.choice` with `move_to_empty`.

There are two issues.

1. How to calculate `num_agents` in `SingleGrid.postion_agent`
`Grid` has no information about `Model`. It needs `num_agents`. `position_agent()` calculates `num_occupied` instead of `num_agents` because `position_agent` is in `SingleGrid`.

2. How to get `agent.pos` when positioning new agent in `Grid.remove_agent`
There is no `pos` for the new agent. It can't be removed because it is not in the grid yet. This PR makes `Grid.remove_agent()` ignore an agent that has no `pos`. 