### PR TITLE
Increase maximum line length to 100 characters

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,9 +212,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    ("index", "Mesa.tex", "Mesa Documentation", "Project Mesa Team", "manual")
-]
+latex_documents = [("index", "Mesa.tex", "Mesa Documentation", "Project Mesa Team", "manual")]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -953,11 +953,7 @@
     "# First, we filter the results\n",
     "one_episode_wealth = results_df[(results_df.N == 10) & (results_df.iteration == 2)]\n",
     "# Then, print the columns of interest of the filtered data frame\n",
-    "print(\n",
-    "    one_episode_wealth.to_string(\n",
-    "        index=False, columns=[\"Step\", \"AgentID\", \"Wealth\"], max_rows=25\n",
-    "    )\n",
-    ")\n",
+    "print(one_episode_wealth.to_string(index=False, columns=[\"Step\", \"AgentID\", \"Wealth\"], max_rows=25))\n",
     "# For a prettier display we can also convert the data frame to html, uncomment to test in a Jupyter Notebook\n",
     "# from IPython.display import display, HTML\n",
     "# display(HTML(one_episode_wealth.to_html(index=False, columns=['Step', 'AgentID', 'Wealth'], max_rows=25)))"

--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -40,9 +40,7 @@ def get_num_mid_agents(model):
     """return number of middle class agents"""
 
     mid_agents = [
-        a
-        for a in model.schedule.agents
-        if a.loans < 10 and a.savings < model.rich_threshold
+        a for a in model.schedule.agents if a.loans < 10 and a.savings < model.rich_threshold
     ]
     return len(mid_agents)
 

--- a/examples/bank_reserves/batch_run.py
+++ b/examples/bank_reserves/batch_run.py
@@ -54,9 +54,7 @@ def get_num_mid_agents(model):
     """list of middle class agents"""
 
     mid_agents = [
-        a
-        for a in model.schedule.agents
-        if a.loans < 10 and a.savings < model.rich_threshold
+        a for a in model.schedule.agents if a.loans < 10 and a.savings < model.rich_threshold
     ]
     # return number of middle class agents
     return len(mid_agents)

--- a/examples/boid_flockers/boid_flockers/model.py
+++ b/examples/boid_flockers/boid_flockers/model.py
@@ -60,14 +60,7 @@ class BoidFlockers(mesa.Model):
             pos = np.array((x, y))
             velocity = np.random.random(2) * 2 - 1
             boid = Boid(
-                i,
-                self,
-                pos,
-                self.speed,
-                velocity,
-                self.vision,
-                self.separation,
-                **self.factors
+                i, self, pos, self.speed, velocity, self.vision, self.separation, **self.factors
             )
             self.space.place_agent(boid, pos)
             self.schedule.add(boid)

--- a/examples/boid_flockers/boid_flockers/server.py
+++ b/examples/boid_flockers/boid_flockers/server.py
@@ -18,6 +18,4 @@ model_params = {
     "separation": 2,
 }
 
-server = mesa.visualization.ModularServer(
-    BoidFlockers, [boid_canvas], "Boids", model_params
-)
+server = mesa.visualization.ModularServer(BoidFlockers, [boid_canvas], "Boids", model_params)

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -40,9 +40,7 @@ def get_num_mid_agents(model):
     """return number of middle class agents"""
 
     mid_agents = [
-        a
-        for a in model.schedule.agents
-        if a.loans < 10 and a.savings < model.rich_threshold
+        a for a in model.schedule.agents if a.loans < 10 and a.savings < model.rich_threshold
     ]
     return len(mid_agents)
 

--- a/examples/color_patches/color_patches/model.py
+++ b/examples/color_patches/color_patches/model.py
@@ -81,9 +81,7 @@ class ColorPatches(mesa.Model):
         # for (contents, col, row) in self._grid.coord_iter():
         # replaced content with _ to appease linter
         for (_, row, col) in self._grid.coord_iter():
-            cell = ColorCell(
-                (row, col), self, ColorCell.OPINIONS[self.random.randrange(0, 16)]
-            )
+            cell = ColorCell((row, col), self, ColorCell.OPINIONS[self.random.randrange(0, 16)])
             self._grid.place_agent(cell, (row, col))
             self._schedule.add(cell)
 

--- a/examples/epstein_civil_violence/epstein_civil_violence/agent.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/agent.py
@@ -79,14 +79,9 @@ class Citizen(mesa.Agent):
         self.update_neighbors()
         self.update_estimated_arrest_probability()
         net_risk = self.risk_aversion * self.arrest_probability
-        if (
-            self.condition == "Quiescent"
-            and (self.grievance - net_risk) > self.threshold
-        ):
+        if self.condition == "Quiescent" and (self.grievance - net_risk) > self.threshold:
             self.condition = "Active"
-        elif (
-            self.condition == "Active" and (self.grievance - net_risk) <= self.threshold
-        ):
+        elif self.condition == "Active" and (self.grievance - net_risk) <= self.threshold:
             self.condition = "Quiescent"
         if self.model.movement and self.empty_neighbors:
             new_pos = self.random.choice(self.empty_neighbors)
@@ -96,13 +91,9 @@ class Citizen(mesa.Agent):
         """
         Look around and see who my neighbors are
         """
-        self.neighborhood = self.model.grid.get_neighborhood(
-            self.pos, moore=False, radius=1
-        )
+        self.neighborhood = self.model.grid.get_neighborhood(self.pos, moore=False, radius=1)
         self.neighbors = self.model.grid.get_cell_list_contents(self.neighborhood)
-        self.empty_neighbors = [
-            c for c in self.neighborhood if self.model.grid.is_cell_empty(c)
-        ]
+        self.empty_neighbors = [c for c in self.neighborhood if self.model.grid.is_cell_empty(c)]
 
     def update_estimated_arrest_probability(self):
         """
@@ -113,11 +104,7 @@ class Citizen(mesa.Agent):
         cops_in_vision = len([c for c in self.neighbors if c.breed == "cop"])
         actives_in_vision = 1.0  # citizen counts herself
         for c in self.neighbors:
-            if (
-                c.breed == "citizen"
-                and c.condition == "Active"
-                and c.jail_sentence == 0
-            ):
+            if c.breed == "citizen" and c.condition == "Active" and c.jail_sentence == 0:
                 actives_in_vision += 1
         self.arrest_probability = 1 - math.exp(
             -1 * self.model.arrest_prob_constant * (cops_in_vision / actives_in_vision)
@@ -177,10 +164,6 @@ class Cop(mesa.Agent):
         """
         Look around and see who my neighbors are.
         """
-        self.neighborhood = self.model.grid.get_neighborhood(
-            self.pos, moore=False, radius=1
-        )
+        self.neighborhood = self.model.grid.get_neighborhood(self.pos, moore=False, radius=1)
         self.neighbors = self.model.grid.get_cell_list_contents(self.neighborhood)
-        self.empty_neighbors = [
-            c for c in self.neighborhood if self.model.grid.is_cell_empty(c)
-        ]
+        self.empty_neighbors = [c for c in self.neighborhood if self.model.grid.is_cell_empty(c)]

--- a/examples/epstein_civil_violence/epstein_civil_violence/portrayal.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/portrayal.py
@@ -18,9 +18,7 @@ def citizen_cop_portrayal(agent):
     }
 
     if isinstance(agent, Citizen):
-        color = (
-            AGENT_QUIET_COLOR if agent.condition == "Quiescent" else AGENT_REBEL_COLOR
-        )
+        color = AGENT_QUIET_COLOR if agent.condition == "Quiescent" else AGENT_REBEL_COLOR
         color = JAIL_COLOR if agent.jail_sentence else color
         portrayal["Color"] = color
         portrayal["r"] = 0.8

--- a/examples/epstein_civil_violence/epstein_civil_violence/server.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/server.py
@@ -22,9 +22,7 @@ def citizen_cop_portrayal(agent):
     }
 
     if type(agent) is Citizen:
-        color = (
-            AGENT_QUIET_COLOR if agent.condition == "Quiescent" else AGENT_REBEL_COLOR
-        )
+        color = AGENT_QUIET_COLOR if agent.condition == "Quiescent" else AGENT_REBEL_COLOR
         color = JAIL_COLOR if agent.jail_sentence else color
         portrayal["Color"] = color
         portrayal["r"] = 0.8

--- a/examples/forest_fire/Forest Fire Model.ipynb
+++ b/examples/forest_fire/Forest Fire Model.ipynb
@@ -340,9 +340,7 @@
    "source": [
     "# At the end of each model run, calculate the fraction of trees which are Burned Out\n",
     "model_reporter = {\n",
-    "    \"BurnedOut\": lambda m: (\n",
-    "        ForestFire.count_type(m, \"Burned Out\") / m.schedule.get_agent_count()\n",
-    "    )\n",
+    "    \"BurnedOut\": lambda m: (ForestFire.count_type(m, \"Burned Out\") / m.schedule.get_agent_count())\n",
     "}"
    ]
   },

--- a/examples/forest_fire/forest_fire/server.py
+++ b/examples/forest_fire/forest_fire/server.py
@@ -16,9 +16,7 @@ def forest_fire_portrayal(tree):
     return portrayal
 
 
-canvas_element = mesa.visualization.CanvasGrid(
-    forest_fire_portrayal, 100, 100, 500, 500
-)
+canvas_element = mesa.visualization.CanvasGrid(forest_fire_portrayal, 100, 100, 500, 500)
 tree_chart = mesa.visualization.ChartModule(
     [{"Label": label, "Color": color} for (label, color) in COLORS.items()]
 )

--- a/examples/pd_grid/pd_grid/model.py
+++ b/examples/pd_grid/pd_grid/model.py
@@ -17,9 +17,7 @@ class PdGrid(mesa.Model):
 
     payoff = {("C", "C"): 1, ("C", "D"): 0, ("D", "C"): 1.6, ("D", "D"): 0}
 
-    def __init__(
-        self, width=50, height=50, schedule_type="Random", payoffs=None, seed=None
-    ):
+    def __init__(self, width=50, height=50, schedule_type="Random", payoffs=None, seed=None):
         """
         Create a new Spatial Prisoners' Dilemma Model.
 
@@ -41,11 +39,7 @@ class PdGrid(mesa.Model):
                 self.schedule.add(agent)
 
         self.datacollector = mesa.DataCollector(
-            {
-                "Cooperating_Agents": lambda m: len(
-                    [a for a in m.schedule.agents if a.move == "C"]
-                )
-            }
+            {"Cooperating_Agents": lambda m: len([a for a in m.schedule.agents if a.move == "C"])}
         )
 
         self.running = True

--- a/examples/sugarscape_cg/sugarscape_cg/agents.py
+++ b/examples/sugarscape_cg/sugarscape_cg/agents.py
@@ -18,9 +18,7 @@ def get_distance(pos_1, pos_2):
 
 
 class SsAgent(mesa.Agent):
-    def __init__(
-        self, unique_id, pos, model, moore=False, sugar=0, metabolism=0, vision=0
-    ):
+    def __init__(self, unique_id, pos, model, moore=False, sugar=0, metabolism=0, vision=0):
         super().__init__(unique_id, model)
         self.pos = pos
         self.moore = moore
@@ -50,14 +48,10 @@ class SsAgent(mesa.Agent):
         neighbors.append(self.pos)
         # Look for location with the most sugar
         max_sugar = max(self.get_sugar(pos).amount for pos in neighbors)
-        candidates = [
-            pos for pos in neighbors if self.get_sugar(pos).amount == max_sugar
-        ]
+        candidates = [pos for pos in neighbors if self.get_sugar(pos).amount == max_sugar]
         # Narrow down to the nearest ones
         min_dist = min(get_distance(self.pos, pos) for pos in candidates)
-        final_candidates = [
-            pos for pos in candidates if get_distance(self.pos, pos) == min_dist
-        ]
+        final_candidates = [pos for pos in candidates if get_distance(self.pos, pos) == min_dist]
         self.random.shuffle(final_candidates)
         self.model.grid.move_agent(self, final_candidates[0])
 

--- a/examples/sugarscape_cg/sugarscape_cg/server.py
+++ b/examples/sugarscape_cg/sugarscape_cg/server.py
@@ -31,9 +31,7 @@ def SsAgent_portrayal(agent):
 
 
 canvas_element = mesa.visualization.CanvasGrid(SsAgent_portrayal, 50, 50, 500, 500)
-chart_element = mesa.visualization.ChartModule(
-    [{"Label": "SsAgent", "Color": "#AA0000"}]
-)
+chart_element = mesa.visualization.ChartModule([{"Label": "SsAgent", "Color": "#AA0000"}])
 
 server = mesa.visualization.ModularServer(
     SugarscapeCg, [canvas_element, chart_element], "Sugarscape 2 Constant Growback"

--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -87,9 +87,7 @@ class VirusOnNetwork(mesa.Model):
 
     def resistant_susceptible_ratio(self):
         try:
-            return number_state(self, State.RESISTANT) / number_state(
-                self, State.SUSCEPTIBLE
-            )
+            return number_state(self, State.RESISTANT) / number_state(self, State.SUSCEPTIBLE)
         except ZeroDivisionError:
             return math.inf
 

--- a/examples/virus_on_network/virus_on_network/server.py
+++ b/examples/virus_on_network/virus_on_network/server.py
@@ -9,9 +9,7 @@ def network_portrayal(G):
     # The model ensures there is always 1 agent per node
 
     def node_color(agent):
-        return {State.INFECTED: "#FF0000", State.SUSCEPTIBLE: "#008000"}.get(
-            agent.state, "#808080"
-        )
+        return {State.INFECTED: "#FF0000", State.SUSCEPTIBLE: "#008000"}.get(agent.state, "#808080")
 
     def edge_color(agent1, agent2):
         if State.RESISTANT in (agent1.state, agent2.state):

--- a/examples/wolf_sheep/wolf_sheep/agents.py
+++ b/examples/wolf_sheep/wolf_sheep/agents.py
@@ -43,9 +43,7 @@ class Sheep(RandomWalker):
             # Create a new sheep:
             if self.model.grass:
                 self.energy /= 2
-            lamb = Sheep(
-                self.model.next_id(), self.pos, self.model, self.moore, self.energy
-            )
+            lamb = Sheep(self.model.next_id(), self.pos, self.model, self.moore, self.energy)
             self.model.grid.place_agent(lamb, self.pos)
             self.model.schedule.add(lamb)
 
@@ -85,9 +83,7 @@ class Wolf(RandomWalker):
             if self.random.random() < self.model.wolf_reproduce:
                 # Create a new wolf cub
                 self.energy /= 2
-                cub = Wolf(
-                    self.model.next_id(), self.pos, self.model, self.moore, self.energy
-                )
+                cub = Wolf(self.model.next_id(), self.pos, self.model, self.moore, self.energy)
                 self.model.grid.place_agent(cub, cub.pos)
                 self.model.schedule.add(cub)
 

--- a/examples/wolf_sheep/wolf_sheep/model.py
+++ b/examples/wolf_sheep/wolf_sheep/model.py
@@ -37,9 +37,7 @@ class WolfSheep(mesa.Model):
 
     verbose = False  # Print-monitoring
 
-    description = (
-        "A model for simulating wolf and sheep (predator-prey) ecosystem modelling."
-    )
+    description = "A model for simulating wolf and sheep (predator-prey) ecosystem modelling."
 
     def __init__(
         self,
@@ -87,9 +85,7 @@ class WolfSheep(mesa.Model):
             {
                 "Wolves": lambda m: m.schedule.get_type_count(Wolf),
                 "Sheep": lambda m: m.schedule.get_type_count(Sheep),
-                "Grass": lambda m: m.schedule.get_type_count(
-                    GrassPatch, lambda x: x.fully_grown
-                ),
+                "Grass": lambda m: m.schedule.get_type_count(GrassPatch, lambda x: x.fully_grown),
             }
         )
 

--- a/examples/wolf_sheep/wolf_sheep/server.py
+++ b/examples/wolf_sheep/wolf_sheep/server.py
@@ -52,12 +52,8 @@ model_params = {
     "title": mesa.visualization.StaticText("Parameters:"),
     "grass": mesa.visualization.Checkbox("Grass Enabled", True),
     "grass_regrowth_time": mesa.visualization.Slider("Grass Regrowth Time", 20, 1, 50),
-    "initial_sheep": mesa.visualization.Slider(
-        "Initial Sheep Population", 100, 10, 300
-    ),
-    "sheep_reproduce": mesa.visualization.Slider(
-        "Sheep Reproduction Rate", 0.04, 0.01, 1.0, 0.01
-    ),
+    "initial_sheep": mesa.visualization.Slider("Initial Sheep Population", 100, 10, 300),
+    "sheep_reproduce": mesa.visualization.Slider("Sheep Reproduction Rate", 0.04, 0.01, 1.0, 0.01),
     "initial_wolves": mesa.visualization.Slider("Initial Wolf Population", 50, 10, 300),
     "wolf_reproduce": mesa.visualization.Slider(
         "Wolf Reproduction Rate",
@@ -67,9 +63,7 @@ model_params = {
         0.01,
         description="The rate at which wolf agents reproduce.",
     ),
-    "wolf_gain_from_food": mesa.visualization.Slider(
-        "Wolf Gain From Food Rate", 20, 1, 50
-    ),
+    "wolf_gain_from_food": mesa.visualization.Slider("Wolf Gain From Food Rate", 20, 1, 50),
     "sheep_gain_from_food": mesa.visualization.Slider("Sheep Gain From Food", 4, 1, 10),
 }
 

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -96,9 +96,7 @@ def batch_run(
     return results
 
 
-def _make_model_kwargs(
-    parameters: Mapping[str, Union[Any, Iterable[Any]]]
-) -> List[Dict[str, Any]]:
+def _make_model_kwargs(parameters: Mapping[str, Union[Any, Iterable[Any]]]) -> List[Dict[str, Any]]:
     """Create model kwargs from parameters dictionary.
 
     Parameters
@@ -213,10 +211,7 @@ def _collect_data(
 
 
 class ParameterError(TypeError):
-    MESSAGE = (
-        "Parameters must map a name to a value. "
-        "These names did not match parameters: {}"
-    )
+    MESSAGE = "Parameters must map a name to a value. " "These names did not match parameters: {}"
 
     def __init__(self, bad_names):
         self.bad_names = bad_names
@@ -373,13 +368,9 @@ class FixedBatchRunner:
         # Collects data from datacollector object in model
         if results is not None:
             if results.model_reporters is not None:
-                self.datacollector_model_reporters[
-                    model_key
-                ] = results.get_model_vars_dataframe()
+                self.datacollector_model_reporters[model_key] = results.get_model_vars_dataframe()
             if results.agent_reporters is not None:
-                self.datacollector_agent_reporters[
-                    model_key
-                ] = results.get_agent_vars_dataframe()
+                self.datacollector_agent_reporters[model_key] = results.get_agent_vars_dataframe()
 
         return (
             getattr(self, "model_vars", None),
@@ -483,9 +474,7 @@ class FixedBatchRunner:
 
 class ParameterProduct:
     def __init__(self, variable_parameters):
-        self.param_names, self.param_lists = zip(
-            *(copy.deepcopy(variable_parameters)).items()
-        )
+        self.param_names, self.param_lists = zip(*(copy.deepcopy(variable_parameters)).items())
         self._product = product(*self.param_lists)
 
     def __iter__(self):
@@ -499,9 +488,7 @@ class ParameterProduct:
 # distributions, only lists.
 class ParameterSampler:
     def __init__(self, parameter_lists, n, random_state=None):
-        self.param_names, self.param_lists = zip(
-            *(copy.deepcopy(parameter_lists)).items()
-        )
+        self.param_names, self.param_lists = zip(*(copy.deepcopy(parameter_lists)).items())
         self.n = n
         if random_state is None:
             self.random_state = random.Random()
@@ -659,9 +646,7 @@ class BatchRunnerMP(BatchRunner):  # pragma: no cover
                 # run each iterations specific number of times
                 for iter in range(self.iterations):
                     kwargs_repeated = kwargs.copy()
-                    all_kwargs.append(
-                        [self.model_cls, kwargs_repeated, self.max_steps, iter]
-                    )
+                    all_kwargs.append([self.model_cls, kwargs_repeated, self.max_steps, iter])
 
         elif len(self.fixed_parameters):
             count = 1
@@ -751,9 +736,7 @@ class BatchRunnerMP(BatchRunner):  # pragma: no cover
 
         if self.processes > 1:
             with tqdm(total_iterations, disable=not self.display_progress) as pbar:
-                for params, model in self.pool.imap_unordered(
-                    self._run_wrappermp, run_iter_args
-                ):
+                for params, model in self.pool.imap_unordered(self._run_wrappermp, run_iter_args):
                     results[params] = model
                     pbar.update()
 

--- a/mesa/main.py
+++ b/mesa/main.py
@@ -3,9 +3,7 @@ import os
 import click
 from subprocess import call
 
-PROJECT_PATH = click.Path(
-    exists=True, file_okay=False, dir_okay=True, resolve_path=True
-)
+PROJECT_PATH = click.Path(exists=True, file_okay=False, dir_okay=True, resolve_path=True)
 COOKIECUTTER_DIR = "mesa/cookiecutter-mesa"
 SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 COOKIECUTTER_PATH = os.path.join(os.path.dirname(SCRIPTS_DIR), COOKIECUTTER_DIR)
@@ -34,9 +32,7 @@ def runserver(project):
 
 
 @click.command()
-@click.option(
-    "--no-input", is_flag=True, help="Do not prompt user for custom mesa model input."
-)
+@click.option("--no-input", is_flag=True, help="Do not prompt user for custom mesa model input.")
 def startproject(no_input):
     args = ["cookiecutter", COOKIECUTTER_PATH]
     if no_input:

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -363,9 +363,7 @@ class Grid:
         return x < 0 or x >= self.width or y < 0 or y >= self.height
 
     @accept_tuple_argument
-    def iter_cell_list_contents(
-        self, cell_list: Iterable[Coordinate]
-    ) -> Iterator[Agent]:
+    def iter_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> Iterator[Agent]:
         """Returns an iterator of the contents of the cells
         identified in cell_list.
 
@@ -651,9 +649,7 @@ class HexGrid(Grid):
                 adjacent += [(x - 1, y), (x - 1, y - 1), (x + 1, y), (x + 1, y - 1)]
 
             if self.torus is False:
-                adjacent = list(
-                    filter(lambda coords: not self.out_of_bounds(coords), adjacent)
-                )
+                adjacent = list(filter(lambda coords: not self.out_of_bounds(coords), adjacent))
             else:
                 adjacent = [torus_adj_2d(coord) for coord in adjacent]
 
@@ -789,9 +785,7 @@ class ContinuousSpace:
         for idx, agent in enumerate(agents):
             self._agent_to_index[agent] = idx
             self._index_to_agent[idx] = agent
-        self._agent_points = np.array(
-            [self._index_to_agent[idx].pos for idx in range(len(agents))]
-        )
+        self._agent_points = np.array([self._index_to_agent[idx].pos for idx in range(len(agents))])
 
     def _invalidate_agent_cache(self):
         """Clear cached data of Agents and positions in the space."""
@@ -862,14 +856,10 @@ class ContinuousSpace:
         dists = deltas[:, 0] ** 2 + deltas[:, 1] ** 2
 
         (idxs,) = np.where(dists <= radius**2)
-        neighbors = [
-            self._index_to_agent[x] for x in idxs if include_center or dists[x] > 0
-        ]
+        neighbors = [self._index_to_agent[x] for x in idxs if include_center or dists[x] > 0]
         return neighbors
 
-    def get_heading(
-        self, pos_1: FloatCoordinate, pos_2: FloatCoordinate
-    ) -> FloatCoordinate:
+    def get_heading(self, pos_1: FloatCoordinate, pos_2: FloatCoordinate) -> FloatCoordinate:
         """Get the heading angle between two points, accounting for toroidal space.
 
         Args:

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -121,9 +121,7 @@ CHART_JS_FILE = "external/chart-3.6.1.min.js"
 
 
 def is_user_param(val):
-    return isinstance(val, UserSettableParameter) or issubclass(
-        val.__class__, UserParam
-    )
+    return isinstance(val, UserSettableParameter) or issubclass(val.__class__, UserParam)
 
 
 class VisualizationElement:
@@ -209,9 +207,7 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
     def open(self):
         if self.application.verbose:
             print("Socket opened!")
-        self.write_message(
-            {"type": "model_params", "params": self.application.user_params}
-        )
+        self.write_message({"type": "model_params", "params": self.application.user_params})
 
     def check_origin(self, origin):
         return True
@@ -426,7 +422,5 @@ class ModularServer(tornado.web.Application):
         return MyTextElement()
 
     def _auto_convert_functions_to_TextElements(self, visualization_elements):
-        out_elements = [
-            self._auto_convert_fn_to_TextElement(e) for e in visualization_elements
-        ]
+        out_elements = [self._auto_convert_fn_to_TextElement(e) for e in visualization_elements]
         return out_elements

--- a/mesa/visualization/UserParam.py
+++ b/mesa/visualization/UserParam.py
@@ -95,9 +95,7 @@ class UserSettableParameter:
             valid = not (self.value is None)
 
         elif self.param_type == self.SLIDER:
-            valid = not (
-                self.value is None or self.min_value is None or self.max_value is None
-            )
+            valid = not (self.value is None or self.min_value is None or self.max_value is None)
 
         elif self.param_type == self.CHOICE:
             valid = not (self.value is None or len(self.choices) == 0)
@@ -133,9 +131,7 @@ class UserSettableParameter:
     @property
     def json(self):
         result = self.__dict__.copy()
-        result["value"] = result.pop(
-            "_value"
-        )  # Return _value as value, value is the same
+        result["value"] = result.pop("_value")  # Return _value as value, value is the same
         return result
 
 
@@ -145,9 +141,7 @@ class UserParam:
     @property
     def json(self):
         result = self.__dict__.copy()
-        result["value"] = result.pop(
-            "_value"
-        )  # Return _value as value, value is the same
+        result["value"] = result.pop("_value")  # Return _value as value, value is the same
         return result
 
     def maybe_raise_error(self, valid):
@@ -191,9 +185,7 @@ class Slider(UserParam):
         self.description = description
 
         # Validate option type to make sure values are supplied properly
-        valid = not (
-            self.value is None or self.min_value is None or self.max_value is None
-        )
+        valid = not (self.value is None or self.min_value is None or self.max_value is None)
         self.maybe_raise_error(valid)
 
     @property

--- a/mesa/visualization/modules/BarChartVisualization.py
+++ b/mesa/visualization/modules/BarChartVisualization.py
@@ -64,9 +64,7 @@ class BarChartModule(VisualizationElement):
 
         fields_json = json.dumps(self.fields)
         new_element = "new BarChartModule({}, {}, {}, '{}', '{}')"
-        new_element = new_element.format(
-            fields_json, canvas_width, canvas_height, sorting, sort_by
-        )
+        new_element = new_element.format(fields_json, canvas_width, canvas_height, sorting, sort_by)
         self.js_code = "elements.push(" + new_element + ")"
 
     def render(self, model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,7 @@ extras_require = {
 
 version = ""
 with open("mesa/__init__.py") as fd:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
-    ).group(1)
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE).group(1)
 
 with open("README.rst", "rb", encoding="utf-8") as f:
     readme = f.read()

--- a/tests/test_batchrunner.py
+++ b/tests/test_batchrunner.py
@@ -158,9 +158,7 @@ class TestBatchRunner(unittest.TestCase):
         if isinstance(self.variable_params, list):
             return len(self.variable_params) * self.iterations
         else:
-            return (
-                reduce(mul, map(len, self.variable_params.values())) * self.iterations
-            )
+            return reduce(mul, map(len, self.variable_params.values())) * self.iterations
 
     def test_model_level_vars(self):
         """
@@ -189,9 +187,7 @@ class TestBatchRunner(unittest.TestCase):
         agent_collector = batch.get_collector_agents()
         # extra columns with run index and agentId
         expected_cols = len(self.variable_params) + len(self.agent_reporters) + 2
-        self.assertEqual(
-            agent_vars.shape, (self.model_runs * NUM_AGENTS, expected_cols)
-        )
+        self.assertEqual(agent_vars.shape, (self.model_runs * NUM_AGENTS, expected_cols))
         assert "agent_val" in list(agent_vars.columns)
         assert "val_non_existent" not in list(agent_vars.columns)
         assert "agent_id" in list(agent_collector[(0, 1, 1)].columns)
@@ -200,9 +196,7 @@ class TestBatchRunner(unittest.TestCase):
         for var, values in self.variable_params.items():
             self.assertEqual(set(agent_vars[var].unique()), set(values))
 
-        self.assertEqual(
-            agent_collector[(0, 1, 0)].shape, (NUM_AGENTS * self.max_steps, 2)
-        )
+        self.assertEqual(agent_collector[(0, 1, 0)].shape, (NUM_AGENTS * self.max_steps, 2))
 
         with self.assertRaises(KeyError):
             agent_collector[(900, "k", 3)]
@@ -244,10 +238,7 @@ class TestBatchRunner(unittest.TestCase):
         batch = self.launch_batch_processing()
         model_vars = batch.get_model_vars_dataframe()
         expected_cols = (
-            len(self.variable_params)
-            + len(self.fixed_params)
-            + len(self.model_reporters)
-            + 1
+            len(self.variable_params) + len(self.fixed_params) + len(self.model_reporters) + 1
         )
         self.assertEqual(model_vars.shape, (self.model_runs, expected_cols))
         self.assertEqual(
@@ -270,9 +261,7 @@ class TestBatchRunner(unittest.TestCase):
 
         agent_vars = batch.get_agent_vars_dataframe()
         expected_cols = n_params + len(self.agent_reporters) + 2
-        self.assertEqual(
-            agent_vars.shape, (self.model_runs * NUM_AGENTS, expected_cols)
-        )
+        self.assertEqual(agent_vars.shape, (self.model_runs * NUM_AGENTS, expected_cols))
 
     def test_model_with_variable_kwargs_list_mixed_length(self):
         self.variable_params = [

--- a/tests/test_batchrunnerMP.py
+++ b/tests/test_batchrunnerMP.py
@@ -175,13 +175,9 @@ class TestBatchRunnerMP(unittest.TestCase):
         assert "Step" in list(agent_collector[(0, 1, 5)].index.names)
         assert "nose" not in list(agent_collector[(0, 1, 1)].columns)
 
-        self.assertEqual(
-            agent_vars.shape, (self.model_runs * NUM_AGENTS, expected_cols)
-        )
+        self.assertEqual(agent_vars.shape, (self.model_runs * NUM_AGENTS, expected_cols))
 
-        self.assertEqual(
-            agent_collector[(0, 1, 0)].shape, (NUM_AGENTS * self.max_steps, 2)
-        )
+        self.assertEqual(agent_collector[(0, 1, 0)].shape, (NUM_AGENTS * self.max_steps, 2))
 
     def test_agent_level_vars(self):
         """
@@ -218,10 +214,7 @@ class TestBatchRunnerMP(unittest.TestCase):
         batch = self.launch_batch_processing()
         model_vars = batch.get_model_vars_dataframe()
         expected_cols = (
-            len(self.variable_params)
-            + len(self.fixed_params)
-            + len(self.model_reporters)
-            + 1
+            len(self.variable_params) + len(self.fixed_params) + len(self.model_reporters) + 1
         )
         self.assertEqual(model_vars.shape, (self.model_runs, expected_cols))
         self.assertEqual(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -55,9 +55,7 @@ class TestExamples(unittest.TestCase):
                 except ImportError:
                     # <example>/model.py
                     mod = importlib.import_module(f"{example.replace('-', '_')}.model")
-                    server = importlib.import_module(
-                        f"{example.replace('-', '_')}.server"
-                    )
+                    server = importlib.import_module(f"{example.replace('-', '_')}.server")
                     server.server.render_model()
                 Model = getattr(mod, classcase(example))
                 model = Model()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -28,9 +28,7 @@ class LifeTimeModel(Model):
         self.schedule = RandomActivation(self)
 
         for _ in range(n_agents):
-            self.schedule.add(
-                FiniteLifeAgent(self.next_id(), self.agent_lifetime, self)
-            )
+            self.schedule.add(FiniteLifeAgent(self.next_id(), self.agent_lifetime, self))
 
     def step(self):
         """Add agents back to n_agents in each step"""
@@ -39,9 +37,7 @@ class LifeTimeModel(Model):
 
         if len(self.schedule.agents) < self.n_agents:
             for _ in range(self.n_agents - len(self.schedule.agents)):
-                self.schedule.add(
-                    FiniteLifeAgent(self.next_id(), self.agent_lifetime, self)
-                )
+                self.schedule.add(FiniteLifeAgent(self.next_id(), self.agent_lifetime, self))
 
     def run_model(self, step_count=100):
         for _ in range(step_count):

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -396,9 +396,11 @@ class TestSingleNetworkGrid(unittest.TestCase):
 
     def test_get_cell_list_contents(self):
         assert self.space.get_cell_list_contents([0]) == [self.agents[0]]
-        assert self.space.get_cell_list_contents(
-            list(range(TestSingleNetworkGrid.GRAPH_SIZE))
-        ) == [self.agents[0], self.agents[1], self.agents[2]]
+        assert self.space.get_cell_list_contents(list(range(TestSingleNetworkGrid.GRAPH_SIZE))) == [
+            self.agents[0],
+            self.agents[1],
+            self.agents[2],
+        ]
 
     def test_get_all_cell_contents(self):
         assert self.space.get_all_cell_contents() == [

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -84,7 +84,5 @@ class TestModularServer(TestCase):
         print(self.server.user_params)
         assert self.server.user_params == {
             "key1": UserSettableParameter("number", "Test Parameter", 101).json,
-            "key2": UserSettableParameter(
-                "slider", "Test Parameter", 200, 0, 300, 10
-            ).json,
+            "key2": UserSettableParameter("slider", "Test Parameter", 200, 0, 300, 10).json,
         }


### PR DESCRIPTION
This PR adds a `pyproject.toml` file that configures [Black](https://github.com/psf/black) with a maximum line length of 100 characters, up from the default of 88.

In many cases, this makes code more readable by allowing assignments and expressions to stay on a single line. It also encourages the use of longer, more descriptive variable names, which can make code easier to understand.

Please scroll through the diff and see if you agree this makes the code more readable. I would suggest viewing both the _Split_ and _Unified_ diff.
