### PR TITLE
Make Grid.get_neighborhood faster

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -256,29 +256,37 @@ class Grid:
         if neighborhood is not None:
             return neighborhood
 
-        coordinates: set[Coordinate] = set()
+        neighborhood = []
 
         x, y = pos
-        for dy in range(-radius, radius + 1):
-            for dx in range(-radius, radius + 1):
-                # Skip coordinates that are outside manhattan distance
-                if not moore and abs(dx) + abs(dy) > radius:
-                    continue
+        if self.torus:
+            x_radius = min(radius, self.width // 2)
+            y_radius = min(radius, self.height // 2)
 
-                coord = (x + dx, y + dy)
+            for dx in range(-x_radius, x_radius + 1):
+                for dy in range(-y_radius, y_radius + 1):
 
-                if self.out_of_bounds(coord):
-                    # Skip if not a torus and new coords out of bounds.
-                    if not self.torus:
+                    if not moore and abs(dx) + abs(dy) > radius:
                         continue
-                    coord = self.torus_adj(coord)
 
-                coordinates.add(coord)
+                    nx, ny = (x + dx) % self.width, (y + dy) % self.height
+                    neighborhood.append((nx, ny))
 
-        if not include_center:
-            coordinates.discard(pos)
+        else:
+            x_range = range(max(0, x - radius), min(self.width, x + radius + 1))
+            y_range = range(max(0, y - radius), min(self.height, y + radius + 1))
 
-        neighborhood = sorted(coordinates)
+            for nx in x_range:
+                for ny in y_range:
+
+                    if not moore and abs(nx - x) + abs(ny - y) > radius:
+                        continue
+
+                    neighborhood.append((nx, ny))
+
+        if not include_center and neighborhood:
+            neighborhood.remove(pos)
+
         self._neighborhood_cache[cache_key] = neighborhood
 
         return neighborhood


### PR DESCRIPTION
<s>I created two different algorithms to speed up neighborhood calculations, one for Von Neumann neighborhood and one for Moore neighborhood</s>, these are the results of the new get_neighborhood vs the old one. There is now one unique algorithm for all cases. It takes the right neighborhood from the start, so that you don't need to check or transform anything later except for the von Neumann checking

These are the results: you can see how many times faster the new implementation is in respect to the old one in each case for the moore, torus and include center conditions:

![Figure_12](https://user-images.githubusercontent.com/68152031/198553313-fdb436c3-4747-4cdb-9b52-9cd60f4cc135.png)
[Updated at the latest commit](no more, see the graph with cache enabled below in the comments)

Tested with:

```
import timeit, itertools, mesa.space, mesa.space_2
import matplotlib.pyplot as plt

res = dict()
combs = itertools.product([True, False], repeat=3)
for val_torus, val_include, val_moore in combs:
    
    comb = f"torus={val_torus}, center={val_include}, moore={val_moore}"
    print("\n"+comb+"\n")
    res[comb] = []
    for radius in range(1,11):
        
        setup_1 = f"from mesa.space import Grid\nwidth, height = 100, 100\ngrid = Grid(width, height, torus={val_torus})"
        setup_2 = f"from mesa.space_2 import Grid\nwidth, height = 100, 100\ngrid = Grid(width, height, torus={val_torus})"

        stmt = f"grid.get_neighborhood((50, 50), include_center={val_include}, radius={radius}, moore={val_moore})"

        a = min(timeit.repeat(stmt=stmt, setup=setup_1, repeat=20, number=2500))
        b = min(timeit.repeat(stmt=stmt, setup=setup_2, repeat=20, number=2500))

        print([radius, b, a, b/a])
        res[comb].append([radius, b, a, b/a])

for comb in res: plt.plot([x[0] for x in res[comb]], [x[-1] for x in res[comb]], "-o", label=comb)

plt.xlabel("radius", fontsize=13); plt.ylabel("times faster", fontsize=13)
plt.yticks([1+0.5*x for x in range(11)]); plt.xticks([x for x in range(1, 11)])
plt.hlines([1], xmin=1, xmax=10, linestyles='dashed'); plt.margins(0,0.01)
plt.legend()
plt.show()
```

To achieve the same results the ` _neighborhood_cache` needs to be disabled (otherwise after the first iteration the position is cached and the two algorithms are not compared) and create a copy called `space_2.py` with the update.