### PR TITLE
release CI: Run on all pushes and PRs, only publish on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,17 @@
 name: Release
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+    - main
+    - release**
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
-on:
-  release:
-    types:
-      - published
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   id-token: write
@@ -19,16 +16,17 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install -U pip wheel setuptools
-      - name: Build package
-        run: python setup.py sdist bdist_wheel
+        run: pip install -U pip build wheel setuptools
+      - name: Build distributions
+        run: python -m build
       - name: Upload package as artifact to GitHub
+        if: github.repository == 'projectmesa/mesa' && startsWith(github.ref, 'refs/tags')
         uses: actions/upload-artifact@v3
         with:
           name: package
           path: dist/
-      - name: Upload packages to PyPI
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Currently the release CI only run when a GitHub Release is created. This PR modifies that it runs on each PR and push (to test that wheel building works), and uploads the dist and wheel to PyPI when a tag is created (instead of only on a GitHub Release).

It uses the official action from PyPI: https://github.com/pypa/gh-action-pypi-publish

@jackiekazil you needs to upload the PyPI API token once as a secret to GitHub. After that, you don't need to be involved in a release any more. See the official documentation below:

> The example above uses the new [API token](https://pypi.org/help/#apitoken) feature of PyPI, which is recommended to restrict the access the action has.
> 
> The secret used in ${{ secrets.PYPI_API_TOKEN }} needs to be created on the settings page of your project on GitHub. See [Creating & using secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).

After uploading the API token, any maintainer can just create a new tag, after which this action will upload the wheel and dist to PyPI.

It also now uses [build](https://pypi.org/project/build/) to build the wheel, instead of calling `setup.py` directly, which is [deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html).

This closes #165 and closes #1252.

@tpike3 and @rht please review. @wang-boyu, if you like we can also implement this for Mesa-Geo.

---- 

There was some discussion in #1252 about security and potential two factor authentication, but I can assure this is the best practice on deploying to PyPI. It uses a API key stored in the GitHub that after uploading no one can access (so it can't even leak to maintainers). It's the [official way](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) PyPI recommends doing it (the action is developed by PyPI after all) and 