### PR TITLE
Refactor Grid.move_to_empty

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -56,11 +56,6 @@ MultiGridContent = List[Agent]
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def clamp(x: float, lowest: float, highest: float) -> float:
-    # much faster than np.clip for a scalar x.
-    return lowest if x <= lowest else (highest if x >= highest else x)
-
-
 def accept_tuple_argument(wrapped_function: F) -> F:
     """Decorator to allow grid methods that take a list of (x, y) coord tuples
     to also handle a single position, by automatically wrapping tuple in
@@ -427,7 +422,7 @@ class Grid:
             warn(
                 (
                     "`num_agents` is being deprecated since it's no longer used "
-                    "inside the function, it shouldn't be passed as a parameter."
+                    "inside `move_to_empty`. It shouldn't be passed as a parameter."
                 ),
                 DeprecationWarning,
             )

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -103,6 +103,7 @@ class Grid:
         self.height = height
         self.width = width
         self.torus = torus
+        self.num_cells = height * width
 
         self.grid: list[list[GridContent]]
         self.grid = [
@@ -422,32 +423,24 @@ class Grid:
         self, agent: Agent, cutoff: float = 0.998, num_agents: int | None = None
     ) -> None:
         """Moves agent to a random empty cell, vacating agent's old cell."""
-        if len(self.empties) == 0:
+        if num_agents is not None:
+            warn(
+                (
+                    "`num_agents` is being deprecated since it's no longer used "
+                    "inside the function, it shouldn't be passed as a parameter."
+                ),
+                DeprecationWarning,
+            )
+        num_empty_cells = len(self.empties)
+        if num_empty_cells == 0:
             raise Exception("ERROR: No empty cells")
-        if num_agents is None:
-            try:
-                num_agents = agent.model.schedule.get_agent_count()
-            except AttributeError:
-                raise Exception(
-                    "Your agent is not attached to a model, and so Mesa is unable\n"
-                    "to figure out the total number of agents you have created.\n"
-                    "This number is required in order to calculate the threshold\n"
-                    "for using a much faster algorithm to find an empty cell.\n"
-                    "In this case, you must specify `num_agents`."
-                )
-        new_pos = (0, 0)  # Initialize it with a starting value.
-        # This method is based on Agents.jl's random_empty() implementation.
-        # See https://github.com/JuliaDynamics/Agents.jl/pull/541.
-        # For the discussion, see
-        # https://github.com/projectmesa/mesa/issues/1052.
-        # This switch assumes the worst case (for this algorithm) of one
-        # agent per position, which is not true in general but is appropriate
-        # here.
-        if clamp(num_agents / (self.width * self.height), 0.0, 1.0) < cutoff:
-            # The default cutoff value provided is the break-even comparison
-            # with the time taken in the else branching point.
-            # The number is measured to be 0.998 in Agents.jl, but since Mesa
-            # run under different environment, the number is different here.
+
+        # This method is based on Agents.jl's random_empty() implementation. See
+        # https://github.com/JuliaDynamics/Agents.jl/pull/541. For the discussion, see
+        # https://github.com/projectmesa/mesa/issues/1052. The default cutoff value
+        # provided is the break-even comparison with the time taken in the else
+        # branching point.
+        if 1 - num_empty_cells / self.num_cells < cutoff:
             while True:
                 new_pos = (
                     agent.random.randrange(self.width),

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -251,8 +251,6 @@ class TestSingleGrid(unittest.TestCase):
         assert a.pos not in self.grid.empties
         assert len(self.grid.empties) == 8
         for i in range(10):
-            # Since the agents and the grid are not associated with a model, we
-            # must explicitly tell move_to_empty the number of agents.
             self.grid.move_to_empty(a, num_agents=self.num_agents)
         assert len(self.grid.empties) == 8
 


### PR DESCRIPTION
The previous implementation was a bit strange, it used the number of agents parameter in the if branch, but I don't think it's the relevant parameter, the one to use should be the number of empty cells so that you can find out the density `num_empty_cell / number_of_points_of_the_grid` to choose one branch or the other. Don't know if I'm wrong on something. Maybe we should warn on the number of agents parameter being deprecated and leave it as a parameter to remove in the future or not? 