### PR TITLE
Use built-in function for setting default_val

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -99,10 +99,11 @@ class Grid:
         self.width = width
         self.torus = torus
         self.num_cells = height * width
+        self._default_val = type(self.default_val())
 
         self.grid: list[list[GridContent]]
         self.grid = [
-            [self.default_val() for _ in range(self.height)] for _ in range(self.width)
+            [self._default_val() for _ in range(self.height)] for _ in range(self.width)
         ]
 
         # Add all cells to the empties list.
@@ -405,14 +406,14 @@ class Grid:
         if (pos := agent.pos) is None:
             return
         x, y = pos
-        self.grid[x][y] = self.default_val()
+        self.grid[x][y] = self._default_val()
         self.empties.add(pos)
         agent.pos = None
 
     def is_cell_empty(self, pos: Coordinate) -> bool:
         """Returns a bool of the contents of a cell."""
         x, y = pos
-        return self.grid[x][y] == self.default_val()
+        return self.grid[x][y] == self._default_val()
 
     def move_to_empty(
         self, agent: Agent, cutoff: float = 0.998, num_agents: int | None = None
@@ -543,7 +544,7 @@ class MultiGrid(Grid):
     grid: list[list[MultiGridContent]]
 
     @staticmethod
-    def default_val() -> MultiGridContent:
+    def default_val() -> list:
         """Default value for new cell elements."""
         return []
 


### PR DESCRIPTION
Setting default value with the type function makes faster start-up initialization for Grid and MultiGrid and everytime the attribute is called, for example timing it with

```
a = min(timeit.repeat("Grid(100,100,True)", "from mesa.space import Grid", repeat=20, number=20))
b = min(timeit.repeat("Grid(100,100,True)", "from mesa.space_2 import Grid", repeat=20, number=20))
print(a/b)
```

where `space_2` contains the modified code, gives me a ~30% less for the new way, also it is ~60% faster when calling it alone:

```
a = min(timeit.repeat("grid.default_val()", "from mesa.space import Grid\ngrid = Grid(5,5,True)", repeat=20, number=5000))
b = min(timeit.repeat("grid._default_val()", "from mesa.space_2 import Grid\ngrid = Grid(5,5,True)", repeat=20, number=5000))
print(a/b)
```