### PR TITLE
Deprecate SingleGrid.position_agent

### DIFF
--- a/examples/schelling/model.py
+++ b/examples/schelling/model.py
@@ -70,7 +70,7 @@ class Schelling(mesa.Model):
                     agent_type = 0
 
                 agent = SchellingAgent((x, y), self, agent_type)
-                self.grid.position_agent(agent, (x, y))
+                self.grid.place_agent(agent, (x, y))
                 self.schedule.add(agent)
 
         self.running = True

--- a/examples/schelling/model.py
+++ b/examples/schelling/model.py
@@ -71,7 +71,6 @@ class Schelling(mesa.Model):
 
                 agent = SchellingAgent((x, y), self, agent_type)
                 self.grid.place_agent(agent, (x, y))
-
                 self.schedule.add(agent)
 
         self.running = True

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -504,6 +504,16 @@ class SingleGrid(Grid):
         If x or y are positive, they are used.
         Use 'swap_pos()' to swap agents positions.
         """
+        warn(
+            (
+                "`position_agent` is being deprecated; use instead "
+                "`place_agent` to place an agent at a specified "
+                "location or `move_to_empty` to place an agent "
+                "at a random empty cell."
+            ),
+            DeprecationWarning,
+        )
+
         if x == "random" or y == "random":
             if len(self.empties) == 0:
                 raise Exception("ERROR: Grid full")


### PR DESCRIPTION
As noted in #1509 `SingleGrid.position_agent` should be deprecated in favor of `place_agent` and `move_to_empty`