### PR TITLE
Remove key check in BaseScheduler.agent_buffer

### DIFF
--- a/mesa/time.py
+++ b/mesa/time.py
@@ -102,8 +102,7 @@ class BaseScheduler:
             self.model.random.shuffle(agent_keys)
 
         for key in agent_keys:
-            if key in self._agents:
-                yield self._agents[key]
+            yield self._agents[key]
 
 
 class RandomActivation(BaseScheduler):


### PR DESCRIPTION
It is not necessary to check the presence of the key