### PR TITLE
Fix bug in Grid.get_neighborhood

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -265,7 +265,9 @@ class Grid:
 
             # For each dimension, in the edge case where the radius is as big as
             # possible and the dimension is even we need to shrink by one the range
-            # of values to avoid duplicates in neighborhood
+            # of values to avoid duplicates in neighborhood. For example, if the
+            # width = 4 and x = radius = 2, we loop through range(0, 5) in respect 
+            # to x but this means that the 0 position is repeated since 0 % 4 = 4 % 4.
             xdim_even, ydim_even = (self.width + 1) % 2, (self.height + 1) % 2
             kx = int(x_radius == x_max_radius and xdim_even)
             ky = int(y_radius == y_max_radius and ydim_even)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -253,12 +253,12 @@ class Grid:
 
         # Using a list for neighhborhood in respect to any other built-in data
         # structure allows to optimize the code further (e.g. with Cython or Numba)
-        # more easily. Also, lists are more optimized in PyPy than in Cpython. Look at
+        # more easily. to better understand how the algorithm was conceived. Look at
         # https://github.com/projectmesa/mesa/pull/1476#issuecomment-1306220403 and in
-        # general to the PR#1476 to better understand how the algorithm was conceived.
+        # general to the PR#1476.
         neighborhood = []
-        x, y = pos
 
+        x, y = pos
         if self.torus:
             x_max_radius, y_max_radius = self.width // 2, self.height // 2
             x_radius, y_radius = min(radius, x_max_radius), min(radius, y_max_radius)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -266,7 +266,7 @@ class Grid:
             # For each dimension, in the edge case where the radius is as big as
             # possible and the dimension is even we need to shrink by one the range
             # of values to avoid duplicates in neighborhood. For example, if the
-            # width = 4 and x = radius = 2, we loop through range(0, 5) in respect 
+            # width = 4 and x = radius = 2, we loop through range(0, 5) in respect
             # to x but this means that the 0 position is repeated since 0 % 4 = 4 % 4.
             xdim_even, ydim_even = (self.width + 1) % 2, (self.height + 1) % 2
             kx = int(x_radius == x_max_radius and xdim_even)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -253,7 +253,7 @@ class Grid:
 
         # Using a list for neighhborhood in respect to any other built-in data
         # structure allows to optimize the code further (e.g. with Cython or Numba)
-        # more easily. to better understand how the algorithm was conceived. Look at
+        # more easily. To better understand how the algorithm was conceived, look at
         # https://github.com/projectmesa/mesa/pull/1476#issuecomment-1306220403 and in
         # general to the PR#1476.
         neighborhood = []

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -251,11 +251,12 @@ class Grid:
         if neighborhood is not None:
             return neighborhood
 
-        # Using a list for neighhborhood in respect to any other built-in data
-        # structure allows to optimize the code further (e.g. with Cython or Numba)
-        # more easily. To better understand how the algorithm was conceived, look at
-        # https://github.com/projectmesa/mesa/pull/1476#issuecomment-1306220403 and in
-        # general to the PR#1476.
+        # We use a list instead of a dict for the neighborhood because it would
+        # be easier to port the code to Cython or Numba (for performance
+        # purpose), with minimal changes. To better understand how the
+        # algorithm was conceived, look at
+        # https://github.com/projectmesa/mesa/pull/1476#issuecomment-1306220403
+        # and the discussion in that PR in general.
         neighborhood = []
 
         x, y = pos
@@ -264,10 +265,11 @@ class Grid:
             x_radius, y_radius = min(radius, x_max_radius), min(radius, y_max_radius)
 
             # For each dimension, in the edge case where the radius is as big as
-            # possible and the dimension is even we need to shrink by one the range
-            # of values to avoid duplicates in neighborhood. For example, if the
-            # width = 4 and x = radius = 2, we loop through range(0, 5) in respect
-            # to x but this means that the 0 position is repeated since 0 % 4 = 4 % 4.
+            # possible and the dimension is even, we need to shrink by one the range
+            # of values, to avoid duplicates in neighborhood. For example, if
+            # the width is 4, while x, x_radius, and x_max_radius are 2, then
+            # (x + dx) has a value from 0 to 4 (inclusive), but this means that
+            # the 0 position is repeated since 0 % 4 and 4 % 4 are both 0.
             xdim_even, ydim_even = (self.width + 1) % 2, (self.height + 1) % 2
             kx = int(x_radius == x_max_radius and xdim_even)
             ky = int(y_radius == y_max_radius and ydim_even)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -15,7 +15,7 @@ from mesa.space import Grid, SingleGrid, MultiGrid, HexGrid
 #   1 0 1
 #   0 0 1
 # -------------------
-TEST_GRID = [[0, 1, 0, 1, 0], [0, 0, 1, 1, 0], [1, 1, 0, 0, 0]]
+TEST_GRID = [[0, 1, 0, 1, 0, 0], [0, 0, 1, 1, 0, 1], [1, 1, 0, 0, 0, 1]]
 
 
 class MockAgent:
@@ -40,8 +40,9 @@ class TestBaseGrid(unittest.TestCase):
         """
         Create a test non-toroidal grid and populate it with Mock Agents
         """
+        # The height needs to be even to test the edge case described in PR #1517
+        height = 6  # height of grid
         width = 3  # width of grid
-        height = 5  # height of grid
         self.grid = Grid(width, height, self.torus)
         self.agents = []
         counter = 0
@@ -109,10 +110,10 @@ class TestBaseGrid(unittest.TestCase):
         assert len(neighborhood) == 8
 
         neighborhood = self.grid.get_neighborhood((1, 4), moore=False)
-        assert len(neighborhood) == 3
+        assert len(neighborhood) == 4
 
         neighborhood = self.grid.get_neighborhood((1, 4), moore=True)
-        assert len(neighborhood) == 5
+        assert len(neighborhood) == 8
 
         neighborhood = self.grid.get_neighborhood((0, 0), moore=False)
         assert len(neighborhood) == 2
@@ -127,7 +128,7 @@ class TestBaseGrid(unittest.TestCase):
         assert len(neighbors) == 3
 
         neighbors = self.grid.get_neighbors((1, 3), moore=False, radius=2)
-        assert len(neighbors) == 2
+        assert len(neighbors) == 3
 
     def test_coord_iter(self):
         ci = self.grid.coord_iter()
@@ -221,17 +222,25 @@ class TestBaseGridTorus(TestBaseGrid):
         neighborhood = self.grid.get_neighborhood((0, 0), moore=False)
         assert len(neighborhood) == 4
 
+        # here we test the edge case described in PR #1517 using a radius
+        # measuring half of the grid height
+        neighborhood = self.grid.get_neighborhood((0, 0), moore=True, radius=3)
+        assert len(neighborhood) == 17
+
+        neighborhood = self.grid.get_neighborhood((1, 1), moore=False, radius=3)
+        assert len(neighborhood) == 15
+
         neighbors = self.grid.get_neighbors((1, 4), moore=False)
-        assert len(neighbors) == 1
+        assert len(neighbors) == 2
 
         neighbors = self.grid.get_neighbors((1, 4), moore=True)
-        assert len(neighbors) == 3
+        assert len(neighbors) == 4
 
         neighbors = self.grid.get_neighbors((1, 1), moore=False, include_center=True)
         assert len(neighbors) == 3
 
         neighbors = self.grid.get_neighbors((1, 3), moore=False, radius=2)
-        assert len(neighbors) == 2
+        assert len(neighbors) == 3
 
 
 class TestSingleGrid(unittest.TestCase):


### PR DESCRIPTION
One (hopefully last) bug was left unnoticed before merging, if a dimension is even and the radius is the maximum one possible, then we introduce duplicates in the list, consider the case of the width dimension equal to 4, and the user passes a value of 2 of radius and a x pos equal to 2 then we have a range(0, 5) but this means that we have two times the 0 position (0 % 4 and 4 % 4) . 

The way it is written now is not so good, hope to find a better way (a function for all the initial range conditions in the torus case?).