### PR TITLE
Update cookiecutter to flat import style.

### DIFF
--- a/examples/schelling/analysis.ipynb
+++ b/examples/schelling/analysis.ipynb
@@ -431,9 +431,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:mesa]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-mesa-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -445,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.9.9"
   },
   "widgets": {
    "state": {},

--- a/mesa/cookiecutter-mesa/{{cookiecutter.snake}}/{{cookiecutter.snake}}/model.py
+++ b/mesa/cookiecutter-mesa/{{cookiecutter.snake}}/{{cookiecutter.snake}}/model.py
@@ -1,10 +1,7 @@
-from mesa import Agent, Model
-from mesa.time import RandomActivation
-from mesa.space import MultiGrid
-from mesa.datacollection import DataCollector
+import mesa
 
 
-class {{cookiecutter.agent}}(Agent):  # noqa
+class {{cookiecutter.agent}}(mesa.Agent):  # noqa
     """
     An agent
     """
@@ -24,7 +21,7 @@ class {{cookiecutter.agent}}(Agent):  # noqa
         pass
 
 
-class {{cookiecutter.model}}(Model):
+class {{cookiecutter.model}}(mesa.Model):
     """
     The model class holds the model-level attributes, manages the agents, and generally handles
     the global level of our model.
@@ -38,8 +35,8 @@ class {{cookiecutter.model}}(Model):
     def __init__(self, num_agents, width, height):
         super().__init__()
         self.num_agents = num_agents
-        self.schedule = RandomActivation(self)
-        self.grid = MultiGrid(width=width, height=height, torus=True)
+        self.schedule = mesa.time.RandomActivation(self)
+        self.grid = mesa.space.MultiGrid(width=width, height=height, torus=True)
 
         for i in range(self.num_agents):
             agent = {{cookiecutter.agent}}(i, self)
@@ -50,7 +47,7 @@ class {{cookiecutter.model}}(Model):
             self.grid.place_agent(agent, (x, y))
 
         # example data collector
-        self.datacollector = DataCollector()
+        self.datacollector = mesa.datacollection.DataCollector()
 
         self.running = True
         self.datacollector.collect(self)

--- a/mesa/cookiecutter-mesa/{{cookiecutter.snake}}/{{cookiecutter.snake}}/server.py
+++ b/mesa/cookiecutter-mesa/{{cookiecutter.snake}}/{{cookiecutter.snake}}/server.py
@@ -4,8 +4,7 @@ Configure visualization elements and instantiate a server
 
 from .model import {{ cookiecutter.model }}, {{ cookiecutter.agent }}  # noqa
 
-from mesa.visualization.ModularVisualization import ModularServer
-from mesa.visualization.modules import CanvasGrid, ChartModule
+import mesa
 
 
 def circle_portrayal_example(agent):
@@ -22,12 +21,14 @@ def circle_portrayal_example(agent):
     return portrayal
 
 
-canvas_element = CanvasGrid(circle_portrayal_example, 20, 20, 500, 500)
-chart_element = ChartModule([{"Label": "{{ cookiecutter.camel }}", "Color": "Pink"}])
+canvas_element = mesa.visualization.CanvasGrid(
+    circle_portrayal_example, 20, 20, 500, 500
+)
+chart_element = mesa.visualization.ChartModule([{"Label": "{{ cookiecutter.camel }}", "Color": "Pink"}])
 
 model_kwargs = {"num_agents": 10, "width": 10, "height": 10}
 
-server = ModularServer(
+server = mesa.visualization.ModularServer(
     {{cookiecutter.model}},
     [canvas_element, chart_element],
     "{{ cookiecutter.camel }}",


### PR DESCRIPTION
Description: This updates the cookiecutter template to use the flat style. 

How to test: 
* `mesa startproject` -- Use this to create a new project. 
* `mesa runserver` -- Make sure everything is running correctly. 
* Run black on the newly created project to insure nothing is in violation. 