### PR TITLE
Refactor iter_cell_list_contents

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -388,10 +388,8 @@ class Grid:
         Returns:
             An iterator of the contents of the cells identified in cell_list
         """
-        # Note: filter(None, iterator) filters away an element of iterator that
-        # is falsy. Hence, iter_cell_list_contents returns only non-empty
-        # contents.
-        return filter(None, (self.grid[x][y] for x, y in cell_list))
+        # iter_cell_list_contents returns only non-empty contents.
+        return (self.grid[x][y] for x, y in cell_list if self.grid[x][y])
 
     @accept_tuple_argument
     def get_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> list[Agent]:


### PR DESCRIPTION
This is easier and a bit faster 

import timeit
timeit.timeit("for y in (a[0][x] for x in range(s) if a[0][x]): pass", "a=[[None]*30+[1]*3+[None]*30+[1]*5]; s=len(a[0])") # -> 4 sec
timeit.timeit("for y in filter(None,(x for x in range(s))): pass", "a=[[None]*30+[1]*3+[None]*30+[1]*5]; s=len(a[0])") # -> 5 sec