### PR TITLE
feat: viz: Allow initial tick label to be settable in ChartModule

### DIFF
--- a/mesa/visualization/modules/ChartVisualization.py
+++ b/mesa/visualization/modules/ChartVisualization.py
@@ -48,6 +48,7 @@ class ChartModule(VisualizationElement):
         canvas_height=200,
         canvas_width=500,
         data_collector_name="datacollector",
+        initial_tick=None,
     ):
         """
         Create a new line chart visualization.
@@ -69,6 +70,8 @@ class ChartModule(VisualizationElement):
         new_element = "new ChartModule({}, {},  {})"
         new_element = new_element.format(series_json, canvas_width, canvas_height)
         self.js_code = "elements.push(" + new_element + ");"
+        if initial_tick is not None:
+            self.js_code += f"controller.tick = {initial_tick};"
 
     def render(self, model):
         current_values = []

--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -22,8 +22,12 @@ const stepDisplay = document.getElementById("currentStep");
  * @param  {number} fps=3 - Run the model with this number of frames per second
  * @param  {boolean} running=false - Initialize the model in a running state?
  * @param  {boolean} finished=false - Initialize the model in a finished state?
+ *
+ * Specifying the tick to a certain number allows the the tick label start from
+ * this number every time the simulation is reset.
  */
 function ModelController(tick = 0, fps = 3, running = false, finished = false) {
+  this.initialTick = tick
   this.tick = tick;
   this.fps = fps;
   this.running = running;
@@ -55,7 +59,7 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
 
   /** Reset the model and visualization state but keep its running state */
   this.reset = function reset() {
-    this.tick = 0;
+    this.tick = this.initialTick;
     stepDisplay.innerText = this.tick;
     // Reset all the visualizations
     vizElements.forEach((element) => element.reset());


### PR DESCRIPTION
This attempts to address #1537 as a quick fix. There could be a better solution. I'm making this approach to start a discussion.