### PR TITLE
breaking: NetworkGrid: modify get_neighbors and create get_neighborhood

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1069,22 +1069,27 @@ class NetworkGrid:
         self.G.nodes[node_id]["agent"].append(agent)
         agent.pos = node_id
 
-    def get_neighbors(
+    def get_neighborhood(
         self, node_id: int, include_center: bool = False, radius: int = 1
     ) -> list[int]:
         """Get all adjacent nodes within a certain radius"""
         if radius == 1:
-            neighbors = list(self.G.neighbors(node_id))
+            neighborhood = list(self.G.neighbors(node_id))
             if include_center:
-                neighbors.append(node_id)
+                neighborhood.append(node_id)
         else:
             neighbors_with_distance = nx.single_source_shortest_path_length(
                 self.G, node_id, radius
             )
             if not include_center:
                 del neighbors_with_distance[node_id]
-            neighbors = sorted(neighbors_with_distance.keys())
-        return neighbors
+            neighborhood = sorted(neighbors_with_distance.keys())
+        return neighborhood
+
+    def get_neighbors(self, node_id: int, include_center: bool = False) -> list[Agent]:
+        """Get all agents in adjacent nodes."""
+        neighborhood = self.get_neighborhood(node_id, include_center)
+        return self.get_cell_list_contents(neighborhood)
 
     def move_agent(self, agent: Agent, node_id: int) -> None:
         """Move an agent from its current node to a new node."""

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -354,10 +354,10 @@ class TestSingleNetworkGrid(unittest.TestCase):
             assert a.pos == pos
 
     def test_get_neighbors(self):
-        assert len(self.space.get_neighbors(0, include_center=True)) == 3
-        assert len(self.space.get_neighbors(0, include_center=False)) == 2
-        assert len(self.space.get_neighbors(2, include_center=True, radius=3)) == 7
-        assert len(self.space.get_neighbors(2, include_center=False, radius=3)) == 6
+        assert len(self.space.get_neighborhood(0, include_center=True)) == 3
+        assert len(self.space.get_neighborhood(0, include_center=False)) == 2
+        assert len(self.space.get_neighborhood(2, include_center=True, radius=3)) == 7
+        assert len(self.space.get_neighborhood(2, include_center=False, radius=3)) == 6
 
     def test_move_agent(self):
         initial_pos = 1
@@ -426,11 +426,11 @@ class TestMultipleNetworkGrid(unittest.TestCase):
 
     def test_get_neighbors(self):
         assert (
-            len(self.space.get_neighbors(0, include_center=True))
+            len(self.space.get_neighborhood(0, include_center=True))
             == TestMultipleNetworkGrid.GRAPH_SIZE
         )
         assert (
-            len(self.space.get_neighbors(0, include_center=False))
+            len(self.space.get_neighborhood(0, include_center=False))
             == TestMultipleNetworkGrid.GRAPH_SIZE - 1
         )
 


### PR DESCRIPTION
NetworkGrid didn't have a get_neighbors function which returns the adjacent agents before this PR, but I think it's an important part of the API, unfortunately it has already a get_neighbors function which returns ids, but clearly changing it would be a breaking change. 

I think if we want to break it in 2.0 we could rename get_neighbors to get_neighborhood and rename this function to get_neighbors. Is it better to include this PR now as it is and make a separate PR with the breaking change or modify this one with the proposed changes?