### PR TITLE
Construct default for comparisons in Grid and NetworkGrid

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -112,7 +112,7 @@ class Grid:
         # _empties as set() because in this case it would become impossible to discern
         # if the set hasn't still being built or if it has become empty after creation.
         self.empties_built = False
-        
+
         # Just for comparisons
         self.default = self.default_val()
 

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -113,8 +113,8 @@ class Grid:
         # if the set hasn't still being built or if it has become empty after creation.
         self.empties_built = False
 
-        # Just for comparisons
-        self.default = self.default_val()
+        # Useful to check if a cell is empty
+        self.empty_value = self.default_val()
 
         # Neighborhood Cache
         self._neighborhood_cache: dict[Any, list[Coordinate]] = dict()
@@ -478,7 +478,7 @@ class Grid:
     def is_cell_empty(self, pos: Coordinate) -> bool:
         """Returns a bool of the contents of a cell."""
         x, y = pos
-        return self.grid[x][y] == self.default
+        return self.grid[x][y] == self.empty_value
 
     def move_to_empty(
         self, agent: Agent, cutoff: float = 0.998, num_agents: int | None = None
@@ -1026,8 +1026,8 @@ class NetworkGrid:
         for node_id in self.G.nodes:
             G.nodes[node_id]["agent"] = self.default_val()
 
-        # Just for comparisons
-        self.default = self.default_val()
+        # Useful to check if a cell is empty
+        self.empty_value = self.default_val()
 
     @staticmethod
     def default_val() -> list:
@@ -1059,7 +1059,7 @@ class NetworkGrid:
 
     def is_cell_empty(self, node_id: int) -> bool:
         """Returns a bool of the contents of a cell."""
-        return self.G.nodes[node_id]["agent"] == self.default
+        return self.G.nodes[node_id]["agent"] == self.empty_value
 
     def get_cell_list_contents(self, cell_list: list[int]) -> list[Agent]:
         """Returns a list of the agents contained in the nodes identified

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -113,7 +113,7 @@ class Grid:
         # if the set hasn't still being built or if it has become empty after creation.
         self.empties_built = False
 
-        # Useful to check if a cell is empty
+        # Default value used to check if a cell is empty
         self.empty_value = self.default_val()
 
         # Neighborhood Cache
@@ -1026,7 +1026,7 @@ class NetworkGrid:
         for node_id in self.G.nodes:
             G.nodes[node_id]["agent"] = self.default_val()
 
-        # Useful to check if a cell is empty
+        # Default value used to check if a cell is empty
         self.empty_value = self.default_val()
 
     @staticmethod

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -113,7 +113,9 @@ class Grid:
         # if the set hasn't still being built or if it has become empty after creation.
         self.empties_built = False
 
-        # Default value used to check if a cell is empty
+        # Default value to use only to check if a cell is empty. To create new empty
+        # cells calling self.default_val() directly is necessary since the objects
+        # need to be independent.
         self.empty_value = self.default_val()
 
         # Neighborhood Cache

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -112,6 +112,9 @@ class Grid:
         # _empties as set() because in this case it would become impossible to discern
         # if the set hasn't still being built or if it has become empty after creation.
         self.empties_built = False
+        
+        # Just for comparisons
+        self.default = self.default_val()
 
         # Neighborhood Cache
         self._neighborhood_cache: dict[Any, list[Coordinate]] = dict()
@@ -475,7 +478,7 @@ class Grid:
     def is_cell_empty(self, pos: Coordinate) -> bool:
         """Returns a bool of the contents of a cell."""
         x, y = pos
-        return self.grid[x][y] == self.default_val()
+        return self.grid[x][y] == self.default
 
     def move_to_empty(
         self, agent: Agent, cutoff: float = 0.998, num_agents: int | None = None
@@ -1023,6 +1026,9 @@ class NetworkGrid:
         for node_id in self.G.nodes:
             G.nodes[node_id]["agent"] = self.default_val()
 
+        # Just for comparisons
+        self.default = self.default_val()
+
     @staticmethod
     def default_val() -> list:
         """Default value for a new node."""
@@ -1053,7 +1059,7 @@ class NetworkGrid:
 
     def is_cell_empty(self, node_id: int) -> bool:
         """Returns a bool of the contents of a cell."""
-        return self.G.nodes[node_id]["agent"] == self.default_val()
+        return self.G.nodes[node_id]["agent"] == self.default
 
     def get_cell_list_contents(self, cell_list: list[int]) -> list[Agent]:
         """Returns a list of the agents contained in the nodes identified


### PR DESCRIPTION
Instead of building a new default value at each comparison, we can build it just once