### PR TITLE
Implement radius for NetworkGrid.get_neighbors

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -26,6 +26,7 @@ import math
 from warnings import warn
 
 import numpy as np
+import networkx as nx
 
 from typing import (
     Any,
@@ -1033,11 +1034,21 @@ class NetworkGrid:
         self.G.nodes[node_id]["agent"].append(agent)
         agent.pos = node_id
 
-    def get_neighbors(self, node_id: int, include_center: bool = False) -> list[int]:
-        """Get all adjacent nodes"""
-        neighbors = list(self.G.neighbors(node_id))
-        if include_center:
-            neighbors.append(node_id)
+    def get_neighbors(
+        self, node_id: int, include_center: bool = False, radius: int = 1
+    ) -> list[int]:
+        """Get all adjacent nodes within a certain radius"""
+        if radius == 1:
+            neighbors = list(self.G.neighbors(node_id))
+            if include_center:
+                neighbors.append(node_id)
+        else:
+            neighbors_with_distance = nx.single_source_shortest_path_length(
+                self.G, node_id, radius
+            )
+            if not include_center:
+                del neighbors_with_distance[node_id]
+            neighbors = list(neighbors_with_distance.keys())
         return neighbors
 
     def move_agent(self, agent: Agent, node_id: int) -> None:

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -340,7 +340,7 @@ class TestSingleNetworkGrid(unittest.TestCase):
         """
         Create a test network grid and populate with Mock Agents.
         """
-        G = nx.complete_graph(TestSingleNetworkGrid.GRAPH_SIZE)
+        G = nx.cycle_graph(TestSingleNetworkGrid.GRAPH_SIZE)
         self.space = NetworkGrid(G)
         self.agents = []
         for i, pos in enumerate(TEST_AGENTS_NETWORK_SINGLE):
@@ -357,14 +357,10 @@ class TestSingleNetworkGrid(unittest.TestCase):
             assert a.pos == pos
 
     def test_get_neighbors(self):
-        assert (
-            len(self.space.get_neighbors(0, include_center=True))
-            == TestSingleNetworkGrid.GRAPH_SIZE
-        )
-        assert (
-            len(self.space.get_neighbors(0, include_center=False))
-            == TestSingleNetworkGrid.GRAPH_SIZE - 1
-        )
+        assert len(self.space.get_neighbors(0, include_center=True)) == 3
+        assert len(self.space.get_neighbors(0, include_center=False)) == 2
+        assert len(self.space.get_neighbors(2, include_center=True, radius=3)) == 7
+        assert len(self.space.get_neighbors(2, include_center=False, radius=3)) == 6
 
     def test_move_agent(self):
         initial_pos = 1


### PR DESCRIPTION
Implement a way to retrieve the neighbors of a certain node even when the radius is greater than 1. It should be the intended way with the networkx library. Still need to add some tests. There are no problem for reproducibility because everything inside `single_source_shortest_path_length` is done with dicts and not with sets.