### PR TITLE
Make the internal grid and empties_built in Grid class private

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -594,10 +594,7 @@ class MultiGrid(Grid):
 
     Properties:
         width, height: The grid's width and height.
-
         torus: Boolean which determines whether to treat the grid as a torus.
-
-        grid: Internal list-of-lists which holds the grid cells themselves.
 
     Methods:
         get_neighbors: Returns the objects surrounding a given cell.

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -168,7 +168,7 @@ class TestBaseGrid(unittest.TestCase):
         x, y = agent.pos
         self.grid.remove_agent(agent)
         assert agent.pos is None
-        assert self.grid.grid[x][y] is None
+        assert self.grid[x][y] is None
 
     def test_swap_pos(self):
 
@@ -510,7 +510,7 @@ class TestIndexing:
     # Create a grid where the content of each coordinate is a tuple of its coordinates
     grid = Grid(3, 5, True)
     for _, x, y in grid.coord_iter():
-        grid.grid[x][y] = (x, y)
+        grid._grid[x][y] = (x, y)
 
     def test_int(self):
         assert self.grid[0][0] == (0, 0)

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -302,10 +302,10 @@ class TestSingleGrid(unittest.TestCase):
         for i, pos in enumerate(TEST_AGENTS_GRID):
             a = self.agents[i]
             assert a.pos == pos
-            assert self.space.grid[pos[0]][pos[1]] == a
+            assert self.space[pos[0]][pos[1]] == a
             self.space.remove_agent(a)
             assert a.pos is None
-            assert self.space.grid[pos[0]][pos[1]] is None
+            assert self.space[pos[0]][pos[1]] is None
 
     def test_empty_cells(self):
         if self.space.exists_empty_cells():
@@ -325,12 +325,12 @@ class TestSingleGrid(unittest.TestCase):
         _agent = self.agents[agent_number]
 
         assert _agent.pos == initial_pos
-        assert self.space.grid[initial_pos[0]][initial_pos[1]] == _agent
-        assert self.space.grid[final_pos[0]][final_pos[1]] is None
+        assert self.space[initial_pos[0]][initial_pos[1]] == _agent
+        assert self.space[final_pos[0]][final_pos[1]] is None
         self.space.move_agent(_agent, final_pos)
         assert _agent.pos == final_pos
-        assert self.space.grid[initial_pos[0]][initial_pos[1]] is None
-        assert self.space.grid[final_pos[0]][final_pos[1]] == _agent
+        assert self.space[initial_pos[0]][initial_pos[1]] is None
+        assert self.space[final_pos[0]][final_pos[1]] == _agent
 
 
 class TestSingleNetworkGrid(unittest.TestCase):


### PR DESCRIPTION
The internal grid in the Grid class should be made private as was done in #815, the internal mechanic of the class should not be used by the user (if he doesn't really want to do so) and we should be free to change it as we want if needed.

Something should be changed in the tests folder also, but I'd like to finish the PR when it gets some approval :-)