### PR TITLE
Establish reproducibility for NetworkGrid.get_neighbors when radius > 1

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1048,7 +1048,7 @@ class NetworkGrid:
             )
             if not include_center:
                 del neighbors_with_distance[node_id]
-            neighbors = list(neighbors_with_distance.keys())
+            neighbors = sorted(neighbors_with_distance.keys())
         return neighbors
 
     def move_agent(self, agent: Agent, node_id: int) -> None:


### PR DESCRIPTION
Right now the `_single_source_shortest_path_length`  uses sets (even if for integer unique_ids should be safe enough, but the deterministic behaviour in Python for this type is not ensured across releases) so we need to sort the result from the function. Fortunately I found a better algorithm for `_single_source_shortest_path_length` which also mantains reproducibility, hope will be merged in Networkx in next release! 