### PR TITLE
Refactor iter/get_cell_list_contents methods

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1082,6 +1082,5 @@ class NetworkGrid:
         """
         return itertools.chain.from_iterable(
             self.G.nodes[node_id]["agent"]
-            for node_id in cell_list
-            if not self.is_cell_empty(node_id)
+            for node_id in itertools.filterfalse(self.is_cell_empty, cell_list)
         )

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1083,5 +1083,5 @@ class NetworkGrid:
         nodes_to_agents = map(lambda node_id: self.G.nodes[node_id]["agent"], cell_list)
         return itertools.chain.from_iterable(
             self.G.nodes[node_id]["agent"]
-            for node_id in cell_list if self.is_cell_empty(node_id))
+            for node_id in cell_list if not self.is_cell_empty(node_id)
         )

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1082,5 +1082,6 @@ class NetworkGrid:
         """
         nodes_to_agents = map(lambda node_id: self.G.nodes[node_id]["agent"], cell_list)
         return itertools.chain.from_iterable(
-            itertools.filterfalse(self.is_cell_empty, nodes_to_agents)
+            self.G.nodes[node_id]["agent"]
+            for node_id in cell_list if self.is_cell_empty(node_id))
         )

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1080,8 +1080,8 @@ class NetworkGrid:
         """Returns an iterator of the agents contained in the nodes identified
         in `cell_list`; nodes with empty content are excluded.
         """
-        nodes_to_agents = map(lambda node_id: self.G.nodes[node_id]["agent"], cell_list)
         return itertools.chain.from_iterable(
             self.G.nodes[node_id]["agent"]
-            for node_id in cell_list if not self.is_cell_empty(node_id)
+            for node_id in cell_list
+            if not self.is_cell_empty(node_id)
         )


### PR DESCRIPTION
Improved the methods mentioned: for MultiGrid it is more or less a <del>3x</del>1.8x improvement, for NetworkGrid it is more or less a <del>2x</del>1.3x improvement. For Grid there will be a drop in performance of 2x due to make it consistent with the other classes.

Tested with:

```python
from mesa.mesa.space import Grid, MultiGrid, NetworkGrid
from time import perf_counter
import networkx as nx

class MockAgent():
    def __init__(self): self.pos = None

def timing(l_pos, grids):
    res = []
    for i in range(3):
        pos, grid = l_pos[i], grids[i]
        for x in range(width*height):
            grid.place_agent(MockAgent(), pos[x])
            q = 0
            for _ in range(1000):
                t_0 = perf_counter()
                grid.get_cell_list_contents(pos)
                t_1 = perf_counter()
                q += t_1-t_0
            res.append(q)
    return res

width, height = 10, 10
l_pos = [[(x, y) for x in range(width) for y in range(height)],[(x, y) for x in range(width) for y in range(height)],
       [x for x in range(100)]]
G = nx.cycle_graph(100)
grids = [Grid(width, height, True), MultiGrid(width, height, True), NetworkGrid(G)]
res_1 = timing(l_pos, grids)
from mesa.mesa.space_2 import Grid, MultiGrid, NetworkGrid
grids = [Grid(width, height, True), MultiGrid(width, height, True), NetworkGrid(G)]
res_2 = timing(l_pos, grids)
f = [x/y for x,y in zip(res_1, res_2)]
print(min(f[:100]), max(f[:100]), sum(f[:100])/100)
print(min(f[100:200]), max(f[100:200]), sum(f[100:200])/100)
print(min(f[200:]), max(f[200:]), sum(f[200:])/100)
```

where `space_2` contains the updated methods.