### PR TITLE
Make Grid class private

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -423,6 +423,12 @@ class _Grid:
         """
         return list(self.iter_cell_list_contents(cell_list))
 
+    def place_agent(self, agent: Agent, pos: Coordinate) -> None:
+        ...
+
+    def remove_agent(self, agent: Agent) -> None:
+        ...
+
     def move_agent(self, agent: Agent, pos: Coordinate) -> None:
         """Move an agent from its current position to a new position.
 
@@ -644,8 +650,8 @@ class MultiGrid(_Grid):
         )
 
 
-class _HexGrid(_Grid):
-    """Hexagonal Grid: Extends Grid to handle hexagonal neighbors.
+class HexGrid(SingleGrid):
+    """Hexagonal Grid: Extends SingleGrid to handle hexagonal neighbors.
 
     Functions according to odd-q rules.
     See http://www.redblobgames.com/grids/hexagons/#coordinates for more.
@@ -819,30 +825,6 @@ class _HexGrid(_Grid):
             A list of non-None objects in the given neighborhood
         """
         return list(self.iter_neighbors(pos, include_center, radius))
-
-
-class SingleHexGrid(_HexGrid, SingleGrid):
-    """Hexagonal SingleGrid: Extends SingleGrid to handle hexagonal neighbors.
-
-    Functions according to odd-q rules.
-    See http://www.redblobgames.com/grids/hexagons/#coordinates for more.
-
-    Properties:
-        width, height: The grid's width and height.
-        torus: Boolean which determines whether to treat the grid as a torus.
-    """
-
-
-class MultiHexGrid(_HexGrid, MultiGrid):
-    """Hexagonal MultiGrid: Extends MultiGrid to handle hexagonal neighbors.
-
-    Functions according to odd-q rules.
-    See http://www.redblobgames.com/grids/hexagons/#coordinates for more.
-
-    Properties:
-        width, height: The grid's width and height.
-        torus: Boolean which determines whether to treat the grid as a torus.
-    """
 
 
 class ContinuousSpace:

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -82,8 +82,8 @@ def is_integer(x: Real) -> bool:
 class _Grid:
     """Base class for a rectangular grid.
 
-    Grid cells are indexed by [x][y], where [0][0] is assumed to be the
-    bottom-left and [width-1][height-1] is the top-right. If a grid is
+    Grid cells are indexed by [x, y], where [0, 0] is assumed to be the
+    bottom-left and [width-1, height-1] is the top-right. If a grid is
     toroidal, the top and bottom, and left and right, edges wrap to each other
 
     Properties:
@@ -522,8 +522,8 @@ class _Grid:
 class SingleGrid(_Grid):
     """Rectangular grid where each cell contains exactly at most one agent.
 
-    Grid cells are indexed by [x][y], where [0][0] is assumed to be the
-    bottom-left and [width-1][height-1] is the top-right. If a grid is
+    Grid cells are indexed by [x, y], where [0, 0] is assumed to be the
+    bottom-left and [width-1, height-1] is the top-right. If a grid is
     toroidal, the top and bottom, and left and right, edges wrap to each other.
 
     Properties:
@@ -592,8 +592,8 @@ class SingleGrid(_Grid):
 class MultiGrid(_Grid):
     """Rectangular grid where each cell can contain more than one agent.
 
-    Grid cells are indexed by [x][y], where [0][0] is assumed to be at
-    bottom-left and [width-1][height-1] is the top-right. If a grid is
+    Grid cells are indexed by [x, y], where [0, 0] is assumed to be at
+    bottom-left and [width-1, height-1] is the top-right. If a grid is
     toroidal, the top and bottom, and left and right, edges wrap to each other.
 
     Properties:

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -4,7 +4,7 @@ Test the Grid objects.
 import random
 import unittest
 from unittest.mock import patch, Mock
-from mesa.space import SingleGrid, MultiGrid, SingleHexGrid
+from mesa.space import SingleGrid, MultiGrid, HexGrid
 
 # Initial agent positions for testing
 #
@@ -397,7 +397,7 @@ class TestMultiGrid(unittest.TestCase):
         assert len(neighbors) == 11
 
 
-class TestSingleHexGrid(unittest.TestCase):
+class TestHexGrid(unittest.TestCase):
     """
     Testing a hexagonal singlegrid.
     """
@@ -408,7 +408,7 @@ class TestSingleHexGrid(unittest.TestCase):
         """
         width = 3
         height = 5
-        self.grid = SingleHexGrid(width, height, torus=False)
+        self.grid = HexGrid(width, height, torus=False)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -452,7 +452,7 @@ class TestSingleHexGrid(unittest.TestCase):
         assert sum(x + y for x, y in neighborhood) == 39
 
 
-class TestSingleHexGridTorus(TestSingleGrid):
+class TestHexGridTorus(TestSingleGrid):
     """
     Testing a hexagonal toroidal singlegrid.
     """
@@ -465,7 +465,7 @@ class TestSingleHexGridTorus(TestSingleGrid):
         """
         width = 3
         height = 5
-        self.grid = SingleHexGrid(width, height, torus=True)
+        self.grid = HexGrid(width, height, torus=True)
         self.agents = []
         counter = 0
         for x in range(width):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -4,7 +4,7 @@ Test the Grid objects.
 import random
 import unittest
 from unittest.mock import patch, Mock
-from mesa.space import Grid, SingleGrid, MultiGrid, HexGrid
+from mesa.space import SingleGrid, MultiGrid, SingleHexGrid, MultiHexGrid
 
 # Initial agent positions for testing
 #
@@ -29,9 +29,9 @@ class MockAgent:
         self.pos = pos
 
 
-class TestBaseGrid(unittest.TestCase):
+class TestSingleGrid(unittest.TestCase):
     """
-    Testing a non-toroidal grid.
+    Testing a non-toroidal singlegrid.
     """
 
     torus = False
@@ -43,7 +43,7 @@ class TestBaseGrid(unittest.TestCase):
         # The height needs to be even to test the edge case described in PR #1517
         height = 6  # height of grid
         width = 3  # width of grid
-        self.grid = Grid(width, height, self.torus)
+        self.grid = SingleGrid(width, height, self.torus)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -149,8 +149,8 @@ class TestBaseGrid(unittest.TestCase):
     def test_agent_move(self):
         # get the agent at [0, 1]
         agent = self.agents[0]
-        self.grid.move_agent(agent, (1, 1))
-        assert agent.pos == (1, 1)
+        self.grid.move_agent(agent, (1, 0))
+        assert agent.pos == (1, 0)
         # move it off the torus and check for the exception
         if not self.torus:
             with self.assertRaises(Exception):
@@ -158,10 +158,10 @@ class TestBaseGrid(unittest.TestCase):
             with self.assertRaises(Exception):
                 self.grid.move_agent(agent, [1, self.grid.height + 1])
         else:
-            self.grid.move_agent(agent, [-1, 1])
-            assert agent.pos == (self.grid.width - 1, 1)
-            self.grid.move_agent(agent, [1, self.grid.height + 1])
-            assert agent.pos == (1, 1)
+            self.grid.move_agent(agent, [0, -1])
+            assert agent.pos == (0, self.grid.height - 1)
+            self.grid.move_agent(agent, [1, self.grid.height])
+            assert agent.pos == (1, 0)
 
     def test_agent_remove(self):
         agent = self.agents[0]
@@ -201,9 +201,9 @@ class TestBaseGrid(unittest.TestCase):
             self.grid.swap_pos(agent_a, agent_b)
 
 
-class TestBaseGridTorus(TestBaseGrid):
+class TestSingleGridTorus(TestSingleGrid):
     """
-    Testing the toroidal base grid.
+    Testing the toroidal singlegrid.
     """
 
     torus = True
@@ -243,12 +243,9 @@ class TestBaseGridTorus(TestBaseGrid):
         assert len(neighbors) == 3
 
 
-class TestSingleGrid(unittest.TestCase):
+class TestSingleGridEnforcement(unittest.TestCase):
     """
-    Test the SingleGrid object.
-
-    Since it inherits from Grid, all the functionality tested above should
-    work here too. Instead, this tests the enforcement.
+    Test the enforcement in SingleGrid.
     """
 
     def setUp(self):
@@ -400,9 +397,9 @@ class TestMultiGrid(unittest.TestCase):
         assert len(neighbors) == 11
 
 
-class TestHexGrid(unittest.TestCase):
+class TestSingleHexGrid(unittest.TestCase):
     """
-    Testing a hexagonal grid.
+    Testing a hexagonal singlegrid.
     """
 
     def setUp(self):
@@ -411,7 +408,7 @@ class TestHexGrid(unittest.TestCase):
         """
         width = 3
         height = 5
-        self.grid = HexGrid(width, height, torus=False)
+        self.grid = SingleHexGrid(width, height, torus=False)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -455,9 +452,9 @@ class TestHexGrid(unittest.TestCase):
         assert sum(x + y for x, y in neighborhood) == 39
 
 
-class TestHexGridTorus(TestBaseGrid):
+class TestSingleHexGridTorus(TestSingleGrid):
     """
-    Testing a hexagonal toroidal grid.
+    Testing a hexagonal toroidal singlegrid.
     """
 
     torus = True
@@ -468,7 +465,7 @@ class TestHexGridTorus(TestBaseGrid):
         """
         width = 3
         height = 5
-        self.grid = HexGrid(width, height, torus=True)
+        self.grid = SingleHexGrid(width, height, torus=True)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -508,7 +505,7 @@ class TestHexGridTorus(TestBaseGrid):
 
 class TestIndexing:
     # Create a grid where the content of each coordinate is a tuple of its coordinates
-    grid = Grid(3, 5, True)
+    grid = SingleGrid(3, 5, True)
     for _, x, y in grid.coord_iter():
         grid._grid[x][y] = (x, y)
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -4,7 +4,7 @@ Test the Grid objects.
 import random
 import unittest
 from unittest.mock import patch, Mock
-from mesa.space import SingleGrid, MultiGrid, SingleHexGrid, MultiHexGrid
+from mesa.space import SingleGrid, MultiGrid, SingleHexGrid
 
 # Initial agent positions for testing
 #

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from collections import defaultdict
 
 from mesa.model import Model
-from mesa.space import Grid
+from mesa.space import MultiGrid
 from mesa.time import SimultaneousActivation
 from mesa.visualization.ModularVisualization import ModularServer
 from mesa.visualization.modules import CanvasGrid, TextElement
@@ -21,7 +21,7 @@ class MockModel(Model):
         self.key1 = (key1,)
         self.key2 = key2
         self.schedule = SimultaneousActivation(self)
-        self.grid = Grid(width, height, torus=True)
+        self.grid = MultiGrid(width, height, torus=True)
 
         for (c, x, y) in self.grid.coord_iter():
             a = MockAgent(x + y * 100, self, x * y * 3)


### PR DESCRIPTION
As discussed I made the Grid class private and removed from it the methods `place_agent` and `remove_agent`, so that they are implemented only in the child public classes. 

Things still to do:

1. Implement SingleHexGrid and MultiHexGrid classes (and make HexGrid class private maybe) -> Deferred to some breaking change PR for mesa 2.0
2. Change tests and class docstrings -> Done
