### PR TITLE
Change index at DataFrame creation in get_agent_vars_dataframe

### DIFF
--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -232,8 +232,8 @@ class DataCollector:
         df = pd.DataFrame.from_records(
             data=all_records,
             columns=["Step", "AgentID"] + rep_names,
+            index=["Step", "AgentID"],
         )
-        df = df.set_index(["Step", "AgentID"])
         return df
 
     def get_table_dataframe(self, table_name):


### PR DESCRIPTION
This is slightly faster as one would expect, code to reproduce:

```
import timeit
a = timeit.timeit("s =pd.DataFrame.from_records(t); s = s.set_index(['a', 'b'])","import pandas as pd\nq=list(range(1000)); t={'a':q,'b':q}", number=1000)
b = timeit.timeit("s =pd.DataFrame.from_records(t, index=['a', 'b'])","import pandas as pd\nq=list(range(1000)); t={'a':q,'b':q}", number=1000)
print(a, b)
```