### PR TITLE
ci: Replace flake8 with Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-# Ignore list taken from https://github.com/psf/black/blob/master/.flake8
-# E203	Whitespace before ':'
-# E266	Too many leading '#' for block comment
-# E501	Line too long (82 > 79 characters)
-# W503	Line break occurred before a binary operator
-ignore = E203, E266, E501, W503
-exclude = docs, build

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -60,7 +60,7 @@ jobs:
       name: Codecov
       uses: codecov/codecov-action@v3
 
-  lint-flake:
+  lint-ruff:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -68,10 +68,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - run: pip install flake8
-    - name: Lint with flake8
-      # Use settings from mesas .flake8 file
-      run: flake8 . --count --show-source --statistics
+    - run: pip install ruff
+    - name: Lint with ruff
+      # Include `--format=github` to enable automatic inline annotations.
+      # Use settings from pyproject.toml.
+      run: ruff . --format=github --extend-exclude mesa/cookiecutter-mesa/*
 
   lint-black:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,11 +68,11 @@ If you're changing previous Mesa features, please make sure of the following:
 - Additional features or rewrites of current features are accompanied by tests.
 - New features are demonstrated in a model, so folks can understand more easily.
 
-To ensure that your submission will not break the build, you will need to install Flake8 and pytest.
+To ensure that your submission will not break the build, you will need to install Ruff and pytest.
 
 .. code-block:: bash
 
-    pip install flake8 pytest pytest-cov
+    pip install ruff pytest pytest-cov
 
 We test by implementing simple models and through traditional unit tests in the tests/ folder. The following only covers unit tests coverage. Ensure that your test coverage has not gone down. If it has and you need help, we will offer advice on how to structure tests for the contribution.
 
@@ -91,7 +91,7 @@ You should no longer have to worry about code formatting. If still in doubt you 
 
 .. code-block:: bash
 
-    flake8 . --ignore=F403,E501,E123,E128,W504,W503 --exclude=docs,build
+    ruff .
 
 
 .. _`PEP8` : https://www.python.org/dev/peps/pep-0008

--- a/mesa/visualization/UserParam.py
+++ b/mesa/visualization/UserParam.py
@@ -92,7 +92,7 @@ class UserSettableParameter:
         valid = True
 
         if self.param_type == self.NUMBER:
-            valid = not (self.value is None)
+            valid = self.value is not None
 
         elif self.param_type == self.SLIDER:
             valid = not (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+# Ignore list taken from https://github.com/psf/black/blob/master/.flake8
+# E203	Whitespace before ':'
+# E266	Too many leading '#' for block comment
+# E501	Line too long (82 > 79 characters)
+# W503	Line break occurred before a binary operator
+# But we don't specify them because ruff's Black already
+# checks for it.
+# See https://github.com/charliermarsh/ruff/issues/1842#issuecomment-1381210185
+extend-ignore = ["E501"]
+extend-exclude = ["docs", "build"]
+# Hardcode to Python 3.10.
+target-version = "py310"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from codecs import open
 requires = ["click", "cookiecutter", "networkx", "numpy", "pandas", "tornado", "tqdm"]
 
 extras_require = {
-    "dev": ["black", "coverage", "flake8", "pytest >= 4.6", "pytest-cov", "sphinx"],
+    "dev": ["black", "ruff", "coverage", "pytest >= 4.6", "pytest-cov", "sphinx"],
     "docs": ["sphinx", "ipython"],
 }
 


### PR DESCRIPTION
See https://notes.crmarsh.com/ruff-the-first-200-releases. Highlight:

> Probably the most complex and rewarding deployment (at least for me) thus far came from [Dagster](https://github.com/dagster-io/dagster), where they replaced 70 parallel CI jobs (to run Pylint) with a single pre-commit hook. It runs in 400 milliseconds, a ~1000x speed-up over their previous setup.
> It’s a perfect encapsulation of the impact that “faster tools” can have on a project, on a team, on a company. Ruff isn’t just faster; it’s so much faster that it completely changes the workflow.

@wang-boyu we should do this for Mesa-Geo. @EwoutH check this out.