### PR TITLE
Use getattr for attribute strings in model data collection

### DIFF
--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -117,8 +117,6 @@ class DataCollector:
             reporter: Attribute string, or function object that returns the
                       variable when given a model instance.
         """
-        if type(reporter) is str:
-            reporter = partial(self._getattr, reporter)
         self.model_reporters[name] = reporter
         self.model_vars[name] = []
 
@@ -175,8 +173,8 @@ class DataCollector:
                 if isinstance(reporter, types.LambdaType):
                     self.model_vars[var].append(reporter(model))
                 # Check if model attribute
-                elif isinstance(reporter, partial):
-                    self.model_vars[var].append(reporter(model))
+                elif isinstance(reporter, str):
+                    self.model_vars[var].append(getattr(model, reporter, None))
                 # Check if function with arguments
                 elif isinstance(reporter, list):
                     self.model_vars[var].append(reporter[0](*reporter[1]))


### PR DESCRIPTION
The partial conversion in model_reporters slows down the look-up for attributes values, tested with:

```
import timeit
default = timeit.timeit("s(a)", "from functools import partial; a = lambda x: x; a.y=10; _getattr= lambda name, _object: getattr(_object, name, None); s=partial(_getattr, 'y')")
new = timeit.timeit("getattr(a, 'y', None)", "a = lambda x: x; a.y=10")
print(default, new)
```

shows that the new way is almost twice as fast