### PR TITLE
Not describe again the types for overload decorated __getitem__

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -138,7 +138,7 @@ class _Grid:
         self._empties_built = True
 
     @overload
-    def __getitem__(self, index: int) -> list[GridContent]:
+    def __getitem__(self, index: int | Sequence[Coordinate]) -> list[GridContent]:
         ...
 
     @overload
@@ -147,14 +147,7 @@ class _Grid:
     ) -> GridContent | list[GridContent]:
         ...
 
-    @overload
-    def __getitem__(self, index: Sequence[Coordinate]) -> list[GridContent]:
-        ...
-
-    def __getitem__(
-        self,
-        index: int | Sequence[Coordinate] | tuple[int | slice, int | slice],
-    ) -> GridContent | list[GridContent]:
+    def __getitem__(self, index):
         """Access contents from the grid."""
 
         if isinstance(index, int):


### PR DESCRIPTION
Redeclare the types if the function uses the overload decorator should be avoided. Though we could also drop the overloaded methods and describe all just in the actual implementation of the function, losing a bit of accuracy in describing the returned value.