### PR TITLE
Create a Numpy MT generator to use in the simulation

### DIFF
--- a/mesa/time.py
+++ b/mesa/time.py
@@ -99,7 +99,7 @@ class BaseScheduler:
         # it's necessary to cast the keys view to a list.
         agent_keys = list(self._agents.keys())
         if shuffled:
-            self.model.random.shuffle(agent_keys)
+            self.model.np_rng.shuffle(agent_keys)
 
         for agent_key in agent_keys:
             if agent_key in self._agents:
@@ -193,7 +193,7 @@ class StagedActivation(BaseScheduler):
         # it's necessary to cast the keys view to a list.
         agent_keys = list(self._agents.keys())
         if self.shuffle:
-            self.model.random.shuffle(agent_keys)
+            self.model.np_rng.shuffle(agent_keys)
         for stage in self.stage_list:
             for agent_key in agent_keys:
                 if agent_key in self._agents:
@@ -202,7 +202,7 @@ class StagedActivation(BaseScheduler):
             # in the previous loop.
             agent_keys = list(self._agents.keys())
             if self.shuffle_between_stages:
-                self.model.random.shuffle(agent_keys)
+                self.model.np_rng.shuffle(agent_keys)
             self.time += self.stage_time
 
         self.steps += 1
@@ -266,7 +266,7 @@ class RandomActivationByType(BaseScheduler):
         # it's necessary to cast the keys view to a list.
         type_keys: list[type[Agent]] = list(self.agents_by_type.keys())
         if shuffle_types:
-            self.model.random.shuffle(type_keys)
+            self.model.np_rng.shuffle(type_keys)
         for agent_class in type_keys:
             self.step_type(agent_class, shuffle_agents=shuffle_agents)
         self.steps += 1
@@ -282,7 +282,7 @@ class RandomActivationByType(BaseScheduler):
         """
         agent_keys: list[int] = list(self.agents_by_type[type_class].keys())
         if shuffle_agents:
-            self.model.random.shuffle(agent_keys)
+            self.model.np_rng.shuffle(agent_keys)
         for agent_key in agent_keys:
             if agent_key in self.agents_by_type[type_class]:
                 self.agents_by_type[type_class][agent_key].step()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -123,10 +123,10 @@ class TestStagedActivation(TestCase):
 
     def test_shuffle_shuffles_agents(self):
         model = MockModel(shuffle=True)
-        model.random = mock.Mock()
-        assert model.random.shuffle.call_count == 0
+        model.np_rng = mock.Mock()
+        assert model.np_rng.shuffle.call_count == 0
         model.step()
-        assert model.random.shuffle.call_count == 1
+        assert model.np_rng.shuffle.call_count == 1
 
     def test_remove(self):
         """
@@ -164,9 +164,9 @@ class TestRandomActivation(TestCase):
         Test the random activation step
         """
         model = MockModel(activation=RANDOM)
-        model.random = mock.Mock()
+        model.np_rng = mock.Mock()
         model.schedule.step()
-        assert model.random.shuffle.call_count == 1
+        assert model.np_rng.shuffle.call_count == 1
 
     def test_random_activation_step_increments_step_and_time_counts(self):
         """
@@ -229,9 +229,9 @@ class TestRandomActivationByType(TestCase):
         Test the random activation by type step
         """
         model = MockModel(activation=RANDOM_BY_TYPE)
-        model.random = mock.Mock()
+        model.np_rng = mock.Mock()
         model.schedule.step()
-        assert model.random.shuffle.call_count == 2
+        assert model.np_rng.shuffle.call_count == 2
 
     def test_random_activation_step_increments_step_and_time_counts(self):
         """


### PR DESCRIPTION
This is the product of my exploration with the help and support of @rht on the topic of using different MT19937 random numbers generators in different parts of a simulation, seeding two MT generators with different seeds can sometimes be not enough since it can produce correlated results, see [here](https://scicomp.stackexchange.com/questions/23547/parallel-mersenne-twister-for-monte-carlo) and [here](https://en.wikipedia.org/wiki/Mersenne_Twister#Disadvantages). But there is a remedy to this, as described [in this paper](https://doi.org/10.1287/ijoc.1070.0251) by the original creator of the Mersenne Twister, from which I cite some relevant parts:

> Random number generators (RNGs) with multiple disjoint streams and substreams are an important component of any good general-purpose simulation or statistical software. they are very handy, for example, to obtain parallel RNGs and to support the implementation of variance reduction techniques (Hellekalek 1998, Kelton 2006, Law and Kelton 2000, L’Ecuyer et al. 2002). The most convenient way of getting these streams and substreams is to start with a backbone RNG having a huge period and partition its output sequence into long disjoint subse quences and subsubsequences whose starting points are at equidistant lags (Law and Kelton 2000, L’Ecuyer 1990, L’Ecuyer and Côté 1991). When a new stream is needed, we find its starting point by jumping ahead from the starting point of the current subsequence to the starting point of the next one. [...] We have developed a viable jump-ahead algorithm for large linear RNGs over 2 . With this technique, one can easily implement RNG packages with multiple streams and substreams, based on long-period generators such as the Mersenne twister and the WELL with a period length of 2^19937 − 1. For these generators, jumping ahead takes a few milliseconds with the proposed method. This is still significantly slower than for the MRG32k3a generator in L’Ecuyer et al. (2002), whose jump-ahead time is a few microseconds. On the other hand, MRG32k3a is slower to generate its numbers, by a factor of two or three on common 32-bit computers, and has a much shorter period length. For applications where jumping ahead is not required too frequently and where a fast long-period RNG is desired, the new jump-ahead algorithm comes in very handy.

So we can jump the state of one generator by an amount unreachable by the other so that extracting numbers from two generators is like having only one, since if it was true that the jumped generator has correlation with the non-jumped one, then also extracting numbers from only one generator would have correlation. We can use 1 jump since it shift the state as if 2^128 random numbers had been generated.