### PR TITLE
ContiniousSpace: Speedup `get_heading`

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -864,6 +864,7 @@ class ContinuousSpace:
         self.height = y_max - y_min
         self.center = np.array(((x_max + x_min) / 2, (y_max + y_min) / 2))
         self.size = np.array((self.width, self.height))
+        self.half_size = self.size / 2
         self.torus = torus
 
         self._agent_points: npt.NDArray[FloatCoordinate] | None = None
@@ -962,15 +963,12 @@ class ContinuousSpace:
         Args:
             pos_1, pos_2: Coordinate tuples for both points.
         """
-        one = np.array(pos_1)
-        two = np.array(pos_2)
+        heading = np.asarray(pos_2) - np.asarray(pos_1)
+
         if self.torus:
-            one = (one - self.center) % self.size
-            two = (two - self.center) % self.size
-        heading = two - one
-        if isinstance(pos_1, tuple):
-            heading = tuple(heading)
-        return heading
+            heading = (heading + self.half_size) % self.half_size
+
+        return tuple(heading)
 
     def get_distance(self, pos_1: FloatCoordinate, pos_2: FloatCoordinate) -> float:
         """Get the distance between two point, accounting for toroidal space.

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -966,7 +966,7 @@ class ContinuousSpace:
         heading = np.asarray(pos_2) - np.asarray(pos_1)
 
         if self.torus:
-            heading = (heading + self.half_size) % self.half_size
+            heading = (heading + self.half_size) % self.size - self.half_size
 
         return tuple(heading)
 

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -107,6 +107,25 @@ class TestSpaceToroidal(unittest.TestCase):
         pos_2 = (-25, -25)
         self.assertEqual((10, 0), self.space.get_heading(pos_1, pos_2))
 
+    def test_heading_same_position(self):
+        pos_1 = (0, 0)
+        pos_2 = (0, 0)
+        self.assertEqual((0, 0), self.space.get_heading(pos_1, pos_2))
+
+    def test_heading_diagonal(self):
+        pos_1 = (-30, -30)
+        pos_2 = (40, -10)
+        self.assertEqual((-30, 20), self.space.get_heading(pos_1, pos_2))
+
+    def test_heading_edge_cases(self):
+        pos_1 = (70, 20)
+        pos_2 = (-30, -30)
+        self.assertEqual((0, 0), self.space.get_heading(pos_1, pos_2))
+
+        pos_1 = (40, -10)
+        pos_2 = (-30, -30)
+        self.assertEqual((30, -20), self.space.get_heading(pos_1, pos_2))
+
     def test_neighborhood_retrieval(self):
         """
         Test neighborhood retrieval
@@ -142,7 +161,7 @@ class TestSpaceToroidal(unittest.TestCase):
 
 class TestSpaceNonToroidal(unittest.TestCase):
     """
-    Testing a toroidal continuous space.
+    Testing a non-toroidal continuous space.
     """
 
     def setUp(self):
@@ -189,6 +208,25 @@ class TestSpaceNonToroidal(unittest.TestCase):
         pos_1 = (65, -25)
         pos_2 = (-25, -25)
         self.assertEqual((-90, 0), self.space.get_heading(pos_1, pos_2))
+
+    def test_heading_same_position(self):
+        pos_1 = (0, 0)
+        pos_2 = (0, 0)
+        self.assertEqual((0, 0), self.space.get_heading(pos_1, pos_2))
+
+    def test_heading_diagonal(self):
+        pos_1 = (-30, -30)
+        pos_2 = (40, -10)
+        self.assertEqual((70, 20), self.space.get_heading(pos_1, pos_2))
+
+    def test_heading_edge_cases(self):
+        pos_1 = (70, 20)
+        pos_2 = (-30, -30)
+        self.assertEqual((-100, -50), self.space.get_heading(pos_1, pos_2))
+
+        pos_1 = (40, -10)
+        pos_2 = (-30, -30)
+        self.assertEqual((-70, -20), self.space.get_heading(pos_1, pos_2))
 
     def test_neighborhood_retrieval(self):
         """


### PR DESCRIPTION
Speedup the get_heading calculations. This reduces the runtime for 500 boid_flockers runs from about 144ms (6.1% of runtime) to 83ms (3.6%).