### PR TITLE
Change the location of the Boltzmann Wealth Model to account for exam…

### DIFF
--- a/docs/tutorials/intro_tutorial.rst
+++ b/docs/tutorials/intro_tutorial.rst
@@ -65,7 +65,7 @@ installed directly form the github repository by running:
 
 .. code:: bash
 
-       $ pip install -r https://raw.githubusercontent.com/projectmesa/mesa/main/examples/boltzmann_wealth_model/requirements.txt
+       $ pip install -r https://raw.githubusercontent.com/projectmesa/mesa-examples/main/examples/Boltzmann_Wealth_Model/requirements.txt
 
 | This will install the dependencies listed in the requirements.txt file
   which are:


### PR DESCRIPTION
In the intro tutorial, the pip install for the Boltzmann Wealth Model was still pointing to the main repo for an example.

Modify the url to point at the new mesa-examples repo (and capitalization of the model name) so the pip install command doesn't return a 404.