### PR TITLE
Update pip statement for zsh

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,7 +28,7 @@ discuss via `Matrix`_ OR via `an issue`_.
 - `Clone your repository`_ from Github to your machine.
 - Create a new branch in your fork: ``git checkout -b BRANCH_NAME``
 - Run ``git config pull.rebase true``. This prevents messy merge commits when updating your branch on top of Mesa main branch.
-- Install an editable version with developer requirements locally: ``pip install -e .[dev]``
+- Install an editable version with developer requirements locally: ``pip install -e ".[dev]"``
 - Edit the code. Save.
 - Git add the new files and files with changes: ``git add FILE_NAME``
 - Git commit your changes with a meaningful message: ``git commit -m "Fix issue X"``


### PR DESCRIPTION
Editable install statement changed to workaround `zsh` error