### PR TITLE
Use Pathlib

### DIFF
--- a/mesa/main.py
+++ b/mesa/main.py
@@ -11,8 +11,8 @@ PROJECT_PATH = click.Path(
     exists=True, file_okay=False, dir_okay=True, resolve_path=True
 )
 COOKIECUTTER_DIR = "mesa/cookiecutter-mesa"
-SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
-COOKIECUTTER_PATH = os.path.join(os.path.dirname(SCRIPTS_DIR), COOKIECUTTER_DIR)
+SCRIPTS_DIR = Path(__file__).parent.resolve()
+COOKIECUTTER_PATH = SCRIPTS_DIR / COOKIECUTTER_DIR
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
@@ -43,7 +43,7 @@ def runserver(project):
 )
 def startproject(no_input):
     """Create a new mesa project"""
-    args = ["cookiecutter", COOKIECUTTER_PATH]
+    args = ["cookiecutter", str(COOKIECUTTER_PATH)]
     if no_input:
         args.append("--no-input")
     call(args)

--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -96,6 +96,7 @@ Client -> Server:
 """
 import asyncio
 import os
+from pathlib import Path
 import platform
 import webbrowser
 
@@ -305,7 +306,7 @@ class ModularServer(tornado.web.Application):
         self.settings = {
             "debug": True,
             "autoreload": False,
-            "template_path": os.path.dirname(__file__) + "/templates",
+            "template_path": Path(__file__).parent / "templates",
         }
 
         """Create a new visualization server with the given elements."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sys
 import unittest
 from unittest.mock import patch
@@ -25,10 +25,8 @@ class TestCli(unittest.TestCase):
     )
     def test_run(self):
         with patch("mesa.visualization.ModularServer") as ModularServer:  # noqa: N806
-            example_dir = os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "../examples/wolf_sheep")
-            )
+            example_dir = (Path(__file__).parent / "../examples/wolf_sheep").resolve()
             with self.runner.isolated_filesystem():
-                result = self.runner.invoke(cli, ["runserver", example_dir])
+                result = self.runner.invoke(cli, ["runserver", str(example_dir)])
                 assert result.exit_code == 0, result.output
                 assert ModularServer().launch.call_count == 1

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import unittest
 
 from click.testing import CliRunner
@@ -17,6 +18,6 @@ class ScaffoldTest(unittest.TestCase):
 
     def test_scaffold_creates_project_dir(self):
         with self.runner.isolated_filesystem():
-            assert not os.path.isdir("example_project")
+            assert not Path("example_project").is_dir()
             self.runner.invoke(cli, ["startproject", "--no-input"])
-            assert os.path.isdir("example_project")
+            assert Path("example_project").is_dir()


### PR DESCRIPTION
Pathlib is a new(-ish) standard library module (introduced 3.4) that provides a cleaner and more reliable way to handle file paths than the old os.path methods. They bake in OS-safety, adapting to Windows back-slashes and Unix forward-slashes seamlessly. Switching to Pathlib cleans up the code a little and avoids possible Windows problems.

Code by Phil Robare (@versilimidude2)