### PR TITLE
Correct toroidal heading - Issue #943

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,3 +16,4 @@ jobs:
       with:
         ignore_words_file: .codespellignore
         skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
+        ignore_regex: ^\s*"image\/png":\s.*

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,5 +15,4 @@ jobs:
     - uses: codespell-project/actions-codespell@master
       with:
         ignore_words_file: .codespellignore
-        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        IGNORE_REGEX: ^\s*"image\/png":\s.*
+        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map,./docs/*.ipynb

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,5 +15,4 @@ jobs:
     - uses: codespell-project/actions-codespell@master
       with:
         ignore_words_file: .codespellignore
-        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        ignore_regex: ^\s*"image\/png":\s.*
+        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map,./docs/*.ipynb

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,4 +15,5 @@ jobs:
     - uses: codespell-project/actions-codespell@master
       with:
         ignore_words_file: .codespellignore
-        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map,./docs/*.ipynb
+        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
+        IGNORE_REGEX: ^\s*"image\/png":\s.*

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -958,9 +958,24 @@ class ContinuousSpace:
         one = np.array(pos_1)
         two = np.array(pos_2)
         if self.torus:
-            one = (one - self.center) % self.size
-            two = (two - self.center) % self.size
-        heading = two - one
+            one = self.torus_adj(one)
+            two = self.torus_adj(two)
+            minimal_square_distance = float("inf")
+            winner_vector = np.array((0, 0))
+            for a in [-1, 0, 1]:
+                for b in [-1, 0, 1]:
+                    shifted_two = np.array(
+                        (two[0] + a * self.width, two[1] + b * self.height)
+                    )
+                    square_distance = (shifted_two[0] - one[0]) ** 2 + (
+                        shifted_two[1] - one[1]
+                    ) ** 2
+                    if square_distance < minimal_square_distance:
+                        minimal_square_distance = square_distance
+                        winner_vector = shifted_two
+            heading = winner_vector - one
+        else:
+            heading = two - one
         if isinstance(pos_1, tuple):
             heading = tuple(heading)
         return heading

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -957,25 +957,13 @@ class ContinuousSpace:
         """
         one = np.array(pos_1)
         two = np.array(pos_2)
+        heading = two - one
         if self.torus:
-            one = self.torus_adj(one)
-            two = self.torus_adj(two)
-            minimal_square_distance = float("inf")
-            winner_vector = np.array((0, 0))
-            for a in [-1, 0, 1]:
-                for b in [-1, 0, 1]:
-                    shifted_two = np.array(
-                        (two[0] + a * self.width, two[1] + b * self.height)
-                    )
-                    square_distance = (shifted_two[0] - one[0]) ** 2 + (
-                        shifted_two[1] - one[1]
-                    ) ** 2
-                    if square_distance < minimal_square_distance:
-                        minimal_square_distance = square_distance
-                        winner_vector = shifted_two
-            heading = winner_vector - one
-        else:
-            heading = two - one
+            wrapped_one = (one - self.center) % self.size
+            wrapped_two = (two - self.center) % self.size
+            wrapped_heading = wrapped_two - wrapped_one
+            # Use the heading vector with the smaller magnitude
+            heading = sorted((heading, wrapped_heading), key=np.linalg.norm)[0]
         if isinstance(pos_1, tuple):
             heading = tuple(heading)
         return heading

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -107,6 +107,10 @@ class TestSpaceToroidal(unittest.TestCase):
         pos_2 = (-25, -25)
         self.assertEqual((10, 0), self.space.get_heading(pos_1, pos_2))
 
+        pos_1 = (self.space.center[0] + 1, self.space.center[1] + 1)
+        pos_2 = (self.space.center[0] - 1, self.space.center[1] - 1)
+        self.assertEqual((-2, -2), self.space.get_heading(pos_1, pos_2))
+
     def test_neighborhood_retrieval(self):
         """
         Test neighborhood retrieval

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -108,11 +108,23 @@ class TestSpaceToroidal(unittest.TestCase):
         self.assertEqual((10, 0), self.space.get_heading(pos_1, pos_2))
 
     def test_heading_near_center(self):
+        """Verify get_heading correct between points straddling the centerline
+
+        Points are near to each other, and the short vector between them should
+        be found, not the long vector found by wrapping around the space's edge.
+        """
         pos_1 = (self.space.center[0] + 1, self.space.center[1] + 1)
         pos_2 = (self.space.center[0] - 1, self.space.center[1] - 1)
         self.assertEqual((-2, -2), self.space.get_heading(pos_1, pos_2))
 
     def test_heading_near_edge(self):
+        """Verify get_heading correct between points near the edge
+
+        Points are near to each other, because the space is toroidal,
+        and the short vector between them should be found, wrapping around the edges,
+        not the long vector across the space.
+        """
+
         pos_1 = (self.space.x_min + 1, self.space.y_min + 1)
         pos_2 = (self.space.x_max - 1, self.space.y_max - 1)
         self.assertEqual((-2, -2), self.space.get_heading(pos_1, pos_2))

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -117,7 +117,6 @@ class TestSpaceToroidal(unittest.TestCase):
         pos_2 = (self.space.x_max - 1, self.space.y_max - 1)
         self.assertEqual((-2, -2), self.space.get_heading(pos_1, pos_2))
 
-
     def test_neighborhood_retrieval(self):
         """
         Test neighborhood retrieval

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -107,9 +107,16 @@ class TestSpaceToroidal(unittest.TestCase):
         pos_2 = (-25, -25)
         self.assertEqual((10, 0), self.space.get_heading(pos_1, pos_2))
 
+    def test_heading_near_center(self):
         pos_1 = (self.space.center[0] + 1, self.space.center[1] + 1)
         pos_2 = (self.space.center[0] - 1, self.space.center[1] - 1)
         self.assertEqual((-2, -2), self.space.get_heading(pos_1, pos_2))
+
+    def test_heading_near_edge(self):
+        pos_1 = (self.space.x_min + 1, self.space.y_min + 1)
+        pos_2 = (self.space.x_max - 1, self.space.y_max - 1)
+        self.assertEqual((-2, -2), self.space.get_heading(pos_1, pos_2))
+
 
     def test_neighborhood_retrieval(self):
         """


### PR DESCRIPTION
Supersedes [PR 944](https://github.com/projectmesa/mesa/pull/944) - same effect with simpler code.  Both vectors (wrapped and non-wrapped) are valid, but the smaller-magnitude of the two is the desired one.

Fix for https://github.com/projectmesa/mesa/issues/943