### PR TITLE
Try different argument --regex

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         ignore_words_file: .codespellignore
         skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        regex: ^\s*"image\/png":\s.*
+        ingore_word_regex: ^\s*"image\/png":\s.*

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         ignore_words_file: .codespellignore
         skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        ingore_word_regex: ^\s*"image\/png":\s.*
+        args: --ignore-regex "^\s*"image\/png":\s.*"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         ignore_words_file: .codespellignore
         skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        ignore_regex: ^\s*"image\/png":\s.*
+        regex: ^\s*"image\/png":\s.*

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         ignore_words_file: .codespellignore
         skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        IGNORE-REGEX: "^\s*"image\/png":\s.*"
+        IGNORE-REGEX: ^\s*"image\/png":\s.*

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         ignore_words_file: .codespellignore
         skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        args: --ignore-regex "^\s*"image\/png":\s.*"
+        IGNORE-REGEX: "^\s*"image\/png":\s.*"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         ignore_words_file: .codespellignore
         skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        IGNORE-REGEX: ^\s*"image\/png":\s.*
+        IGNORE_REGEX: ^\s*"image\/png":\s.*


### PR DESCRIPTION
  --ignore-regex IGNORE_REGEX
                        regular expression that is used to find patterns to ignore by treating as whitespace. When writing
                        regular expressions, consider ensuring there are boundary non-word chars, e.g., "\bmatch\b".
                        Defaults to empty/disabled.

...

  -r REGEX, --regex REGEX
                        regular expression that is used to find words. By default any alphanumeric character, the
                        underscore, the hyphen, and the apostrophe is used to build words. This option cannot be specified
                        together with --write-changes.