### PR TITLE
Exclude notebook files from linter

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,5 +15,4 @@ jobs:
     - uses: codespell-project/actions-codespell@master
       with:
         ignore_words_file: .codespellignore
-        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map
-        ignore_regex: ^\s*"image\/png":\s.*
+        skip: .*bootstrap.*,*.js,.*bootstrap-theme.css.map,./docs/*.ipynb


### PR DESCRIPTION
Unfortunately, `codespell` doesn't pass on [the existing `--ignore-regex` flag](https://github.com/codespell-project/codespell/blob/master/codespell_lib/_codespell.py#L358) through the GitHub actions YAML file.

