### PR TITLE
Update slider to start at 1 FPS.

### DIFF
--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -99,11 +99,11 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
  */
 const fpsControl = new Slider("#fps", {
   max: 20,
-  min: 0,
+  min: 1,
   value: controller.fps,
-  ticks: [0, 20],
-  ticks_labels: [0, 20],
-  ticks_position: [0, 100],
+  ticks: [1, 20],
+  ticks_labels: [1, 20],
+  ticks_position: [1, 100],
 });
 fpsControl.on("change", () => controller.updateFPS(fpsControl.getValue()));
 


### PR DESCRIPTION
The FPS slider now starts at 1 FPS as 0 FPS is unnecessary with a stop button. 