### PR TITLE
feat: stop ModularServer closes #1642

### DIFF
--- a/mesa/visualization/ModularVisualization.py
+++ b/mesa/visualization/ModularVisualization.py
@@ -219,14 +219,22 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
         return {"type": "viz_state", "data": self.application.render_model()}
 
     def on_message(self, message):
-        """Receiving a message from the websocket, parse, and act accordingly."""
+        """Receiving a message from the websocket, parse, and act accordingly.
+
+        Args:
+            message (dict): A dictionary containing a key 'type'.
+        """
         if self.application.verbose:
             print(message)
         msg = tornado.escape.json_decode(message)
         try:
             msg_type = msg["type"]
         except KeyError:
-            print("Unexpected message. Key 'type' missing.")
+            print(
+                "Unexpected message. Key 'type' missing. All messages have to contain the key 'type'."
+            )
+            if self.application.is_debug_mode():
+                print("see SocketHandler.on_message")
             return
 
         if msg_type == "get_step":

--- a/mesa/visualization/templates/js/runcontrol.js
+++ b/mesa/visualization/templates/js/runcontrol.js
@@ -14,6 +14,7 @@ const vizElements = [];
 const startModelButton = document.getElementById("play-pause");
 const stepModelButton = document.getElementById("step");
 const resetModelButton = document.getElementById("reset");
+const shutDownButton = document.getElementById("shut-down");
 const stepDisplay = document.getElementById("currentStep");
 
 /**
@@ -65,6 +66,16 @@ function ModelController(tick = 0, fps = 3, running = false, finished = false) {
     }
     clearTimeout(this.timeout);
     send({ type: "reset" });
+  };
+
+  this.shutDown = function shutDown() {
+    disableNavItem(startModelButton);
+    disableNavItem(stepModelButton);
+    disableNavItem(resetModelButton);
+    disableNavItem(shutDownButton);
+
+    addShutDownAlert();
+    send({ "type": "shut_down" });
   };
 
   /** Stops the model and put it into a finished state */
@@ -124,6 +135,8 @@ stepModelButton.onclick = () => {
 };
 resetModelButton.onclick = () => controller.reset();
 
+shutDownButton.onclick = () => controller.shutDown();
+
 /*
  * Websocket opening and message handling
  */
@@ -131,8 +144,8 @@ resetModelButton.onclick = () => controller.reset();
 /** Open the websocket connection; support TLS-specific URLs when appropriate */
 const ws = new WebSocket(
   (window.location.protocol === "https:" ? "wss://" : "ws://") +
-    location.host +
-    "/ws"
+  location.host +
+  "/ws"
 );
 
 /**
@@ -170,6 +183,19 @@ const send = function (message) {
   const msg = JSON.stringify(message);
   ws.send(msg);
 };
+
+const disableNavItem = function (navItem) {
+  const navLink = navItem.querySelector(".nav-link");
+  navLink.classList.add("disabled");
+  navItem.onclick = function () { };
+};
+
+const addShutDownAlert = function () {
+  const statusInfo = document.getElementById('status-info');
+  const alertElement = document.createElement('div');
+  alertElement.innerHTML = '<div class="alert alert-danger" role="alert">The server has been shut down.</div>';
+  statusInfo.appendChild(alertElement);
+}
 
 /*
  * GUI initialization (for input parameters)

--- a/mesa/visualization/templates/modular_template.html
+++ b/mesa/visualization/templates/modular_template.html
@@ -43,6 +43,8 @@
                     </li>
                     <li id="reset" class="nav-item"><a href="#" class="nav-link">Reset</a>
                     </li>
+                    <li id="shut-down" class="nav-item"><a href="#" class="nav-link">Shut Down</a>
+                    </li>
                 </ul>
             </div>
         </div>
@@ -50,6 +52,8 @@
     <div class="container d-flex flex-row">
         <div class="col-xl-4 col-lg-4 col-md-4 col-3" id="sidebar"></div>
         <div class="col-xl-8 col-lg-8 col-md-8 col-9" id="elements">
+            <div id="status-info">
+            </div>
             <div id="elements-topbar">
                 <div>
                     <label class="badge bg-primary" for="fps" style="margin-right: 15px">Frames Per Second</label>


### PR DESCRIPTION
Implementation
-------------------

Python:

* ModularServer: add `stop` method
* SocketHandler: handle message type "shut_down" (only in debug mode)

UI: Add "Shut Down" button

* Disable the nav items.
* Add Bootstrap alert element.
* Send "shut_down" message to WebSocket.

Other
-------

SocketHandler.on_message: add error handling for message without a 'type' key