### PR TITLE
Replacing `const chart` for `var chart` in advanced tutorial JS

### DIFF
--- a/docs/tutorials/adv_tutorial.ipynb
+++ b/docs/tutorials/adv_tutorial.ipynb
@@ -386,7 +386,7 @@
     "  };\n",
     "\n",
     "  // Create the chart object\n",
-    "  const chart = new Chart(context, {type: 'bar', data: data, options: options});\n",
+    "  let chart = new Chart(context, {type: 'bar', data: data, options: options});\n",
     "\n",
     "  // Now what?\n",
     "};\n",

--- a/docs/tutorials/adv_tutorial.rst
+++ b/docs/tutorials/adv_tutorial.rst
@@ -412,7 +412,7 @@ created, we can create the chart object.
       };
 
       // Create the chart object
-      const chart = new Chart(context, {type: 'bar', data: data, options: options});
+      let chart = new Chart(context, {type: 'bar', data: data, options: options});
 
       // Now what?
     };


### PR DESCRIPTION
I raised in #1678 that the JS part of the advanced tutorial declares `chart` as a `const`, and subsequently tries to assign a new value to it. This breaks the visualizations for users following along with the tutorial. Declaring `chart` as a `var` instead solves this issue and removes the `Uncaught TypeError` previously logged in the console.