### PR TITLE
Added a feature in mesa.time StagedActivation class

### DIFF
--- a/docs/useful-snippets/snippets.rst
+++ b/docs/useful-snippets/snippets.rst
@@ -12,6 +12,16 @@ If you have `Multiple` type agents and one of them has time attribute you can st
   if self.model.schedule.time in self.discrete_time:
       self.model.space.move_agent(self, new_pos)
 
+Implementing Model Level Functions in Staged Activation
+-------------------------------------------------------
+In staged activation, if you may want a function to be implemented only on the model level and not at the level of agents.
+For such functions, include the prefix "model." before the model function name, when defining the function list.
+For example, consider a central employment exchange which adjust the wage rate common to all laborers
+in the direction of excess demand.
+
+.. code:: python
+    stage_list=[Send_Labour_Supply, Send_Labour_Demand, model.Adjust_Wage_Rate]
+    self.schedule = StagedActivation(self,stage_list,shuffle=True)
 
 Using ```numpy.random```
 -------------

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -63,7 +63,7 @@ class BaseScheduler:
         """
         if agent.unique_id in self._agents:
             raise Exception(
-                f"Agent with unique id {repr(agent.unique_id)} already added to scheduler"
+                f"Agent with unique id {agent.unique_id!r} already added to scheduler"
             )
 
         self._agents[agent.unique_id] = agent
@@ -191,7 +191,10 @@ class StagedActivation(BaseScheduler):
         # it's necessary for the keys view to be a list.
         agent_keys = self.get_agent_keys(self.shuffle)
         for stage in self.stage_list:
-            self.do_each(stage, agent_keys=agent_keys)
+            if stage.startswith("model."):
+                getattr(self.model, stage[6:])()
+            else:
+                self.do_each(stage, agent_keys=agent_keys)
             # We recompute the keys because some agents might have been removed
             # in the previous loop.
             agent_keys = self.get_agent_keys(self.shuffle_between_stages)


### PR DESCRIPTION
Suggested solution to issue #1709

Hi team Mesa, 

Right now the Staged Activation class only allows for functions executed at Agent level. However, one can well want to implement a function which is executed at model level (for ex, in an Economy, adjust the wage rate of all labourers, who are agents and share the same wage rate). Hence suggesting writing "model." before the function name in the object stage_list to indicate its a model level function. 