### PR TITLE
Fix bug in get_heading

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -934,7 +934,7 @@ class ContinuousSpace:
                 get_min_abs(heading[i], inverse_heading[i]) for i in range(2)
             )
         if isinstance(pos_1, np.ndarray):
-            heading = np.ndarray(heading)
+            heading = np.asarray(heading)
         else:
             heading = tuple(heading)
         return heading


### PR DESCRIPTION
This didn't work, in this pr https://github.com/JuliaDynamics/ABM_Framework_Comparisons/pull/54 the flocking model in mesa 2.1 throws 

```python
Traceback (most recent call last):
  File "/home/runner/work/ABM_Framework_Comparisons/ABM_Framework_Comparisons/./Flocking/Mesa/benchmark_flocking.py", line 33, in <module>
    a = tt.repeat(n_run, 1)
  File "/usr/lib/python3.10/timeit.py", line 206, in repeat
    t = self.timeit(number)
  File "/usr/lib/python3.10/timeit.py", line 178, in timeit
    timing = self.inner(it, self.timer)
  File "<timeit-src>", line 26, in inner
  File "<timeit-src>", line 16, in runthemodel
  File "/home/runner/work/ABM_Framework_Comparisons/ABM_Framework_Comparisons/Flocking/Mesa/Flocking.py", line 80, in step
    self.schedule.step()
  File "/home/runner/.local/lib/python3.10/site-packages/mesa/time.py", line 128, in step
    self.do_each("step", shuffle=True)
  File "/home/runner/.local/lib/python3.10/site-packages/mesa/time.py", line 110, in do_each
    getattr(self._agents[agent_key], method)()
  File "/home/runner/work/ABM_Framework_Comparisons/ABM_Framework_Comparisons/Flocking/Mesa/boid.py", line 69, in step
    heading = self.model.space.get_heading(self.pos, neighbor.pos)
  File "/home/runner/.local/lib/python3.10/site-packages/mesa/space.py", line 937, in get_heading
    heading = np.ndarray(heading)
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```