### PR TITLE
fix: Add Matplotlib as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from setuptools import find_packages, setup
 requires = [
     "click",
     "cookiecutter",
+    "matplotlib",
     "networkx",
     "numpy",
     "pandas",


### PR DESCRIPTION
This is required for Solara viz.