### PR TITLE
perf: Access grid only once

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -394,8 +394,9 @@ class _Grid:
         """
         # iter_cell_list_contents returns only non-empty contents.
         return (
-            self._grid[x][y]
-            for x, y in itertools.filterfalse(self.is_cell_empty, cell_list)
+            cell
+            for x, y in cell_list
+            if (cell := self._grid[x][y]) != self.default_val()
         )
 
     @accept_tuple_argument
@@ -568,8 +569,9 @@ class MultiGrid(_Grid):
             An iterator of the agents contained in the cells identified in `cell_list`.
         """
         return itertools.chain.from_iterable(
-            self._grid[x][y]
-            for x, y in itertools.filterfalse(self.is_cell_empty, cell_list)
+            cell
+            for x, y in cell_list
+            if (cell := self._grid[x][y]) != self.default_val()
         )
 
 


### PR DESCRIPTION
In our current implementation we access the grid first to check if the cell is empty and then a second time to iterate over the contents. Inlining the check and using the walrus operator allows to access the content only once. 

Using the ABM framework comparison i get the following speedups on my laptop for the Schelling model.

| Model | main| this PR|
|--------|--------|--------|
| Schelling (small) | 136ms | 97ms |
| Schelling (large) | 2120ms| 1558ms |