### PR TITLE
fix install for visualization tutorial in colab

### DIFF
--- a/docs/tutorials/adv_tutorial_legacy.ipynb
+++ b/docs/tutorials/adv_tutorial_legacy.ipynb
@@ -9,7 +9,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -25,7 +24,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,7 +46,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -93,7 +90,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -120,7 +116,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -128,7 +123,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -170,7 +164,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -201,7 +194,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -211,7 +203,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -240,7 +231,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -277,7 +267,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -513,7 +502,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -43,10 +43,7 @@
     "import mesa\n",
     "\n",
     "# You can either define the BoltzmannWealthModel (aka MoneyModel) or install mesa-models:\n",
-    "%pip install --quiet -U -e git+https://github.com/projectmesa/mesa-examples#egg=mesa-models\n",
-    "\n",
-    "# For Colab you must change the directory to reference mesa-models installed from github on the previous line.\n",
-    "%cd src\n",
+    "%pip install --quiet -U git+https://github.com/projectmesa/mesa-examples#egg=mesa-models\n",
     "\n",
     "from mesa_models.boltzmann_wealth_model.model import BoltzmannWealthModel"
    ]


### PR DESCRIPTION
I removed the `-e` argument in the pip install because for colab that stores the install in `src` directory and presents some other challenges of mesa-example not being imported easily. 

Removing the `-e` installs mesa-examples in the standard colab install location and prevents an `ImportError` without effecting performance if someone is using a local instantiation of their jupyter notebook