### PR TITLE
docs: compile notebooks at build time

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "nbsphinx",
+    "myst_nb",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -114,6 +115,8 @@ pygments_style = "sphinx"
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+nb_execution_timeout = 60
+nb_execution_mode = "cache"
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -92,7 +92,7 @@
    "source": [
     "# SKIP THIS CELL unless running in colab\n",
     "\n",
-    "!pip install mesa\n",
+    "%pip install --quiet mesa\n",
     "# The exclamation points tell jupyter to do the command via the command line"
    ]
   },

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
 )
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from mesa.model import Model
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ extras_require = {
         "ipykernel",
         "pydata_sphinx_theme",
         "seaborn",
+        "myst-nb",
     ],
 }
 


### PR DESCRIPTION
This PR will allow Jupyter notebooks to be compiled at doc build time, so that cell outputs can be displayed at readthedocs website (currently missing for the [viz tutorial](https://mesa.readthedocs.io/en/stable/tutorials/visualization_tutorial.html)).