### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -38,8 +38,6 @@ jobs:
             python-version: "3.10"
           - os: ubuntu
             python-version: "3.9"
-          - os: ubuntu
-            python-version: "3.8"
           # Disabled for now. See https://github.com/projectmesa/mesa/issues/1253
           #- os: ubuntu
           #  python-version: 'pypy-3.8'

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "### Tutorial Setup\n",
     "\n",
-    "Create and activate a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/). *Python version 3.8 or higher is required*.\n",
+    "Create and activate a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/). *Python version 3.9 or higher is required*.\n",
     "\n",
     "Install Mesa:\n",
     "\n",

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -12,11 +12,11 @@ import operator
 import warnings
 import weakref
 from collections import defaultdict
-from collections.abc import MutableSet, Sequence
+from collections.abc import Iterable, Iterator, MutableSet, Sequence
 from random import Random
 
 # mypy
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     # We ensure that these are not imported during runtime to prevent cyclic

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -2,11 +2,7 @@ import itertools
 from collections.abc import Iterable, Mapping
 from functools import partial
 from multiprocessing import Pool
-from typing import (
-    Any,
-    Optional,
-    Union,
-)
+from typing import Any, Optional, Union
 
 from tqdm.auto import tqdm
 

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -1,16 +1,12 @@
 import itertools
+from collections.abc import Iterable, Mapping
 from functools import partial
 from multiprocessing import Pool
 from typing import (
     Any,
-    Dict,
-    List,
     Optional,
-    Tuple,
-    Type,
     Union,
 )
-from collections.abc import Iterable, Mapping
 
 from tqdm.auto import tqdm
 

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -4,14 +4,13 @@ from multiprocessing import Pool
 from typing import (
     Any,
     Dict,
-    Iterable,
     List,
-    Mapping,
     Optional,
     Tuple,
     Type,
     Union,
 )
+from collections.abc import Iterable, Mapping
 
 from tqdm.auto import tqdm
 
@@ -19,7 +18,7 @@ from mesa.model import Model
 
 
 def batch_run(
-    model_cls: Type[Model],
+    model_cls: type[Model],
     parameters: Mapping[str, Union[Any, Iterable[Any]]],
     # We still retain the Optional[int] because users may set it to None (i.e. use all CPUs)
     number_processes: Optional[int] = 1,
@@ -27,7 +26,7 @@ def batch_run(
     data_collection_period: int = -1,
     max_steps: int = 1000,
     display_progress: bool = True,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Batch run a mesa model with a set of parameter values.
 
     Parameters
@@ -67,7 +66,7 @@ def batch_run(
         data_collection_period=data_collection_period,
     )
 
-    results: List[Dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
 
     with tqdm(total=len(runs_list), disable=not display_progress) as pbar:
         if number_processes == 1:
@@ -86,7 +85,7 @@ def batch_run(
 
 def _make_model_kwargs(
     parameters: Mapping[str, Union[Any, Iterable[Any]]]
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Create model kwargs from parameters dictionary.
 
     Parameters
@@ -116,11 +115,11 @@ def _make_model_kwargs(
 
 
 def _model_run_func(
-    model_cls: Type[Model],
-    run: Tuple[int, int, Dict[str, Any]],
+    model_cls: type[Model],
+    run: tuple[int, int, dict[str, Any]],
     max_steps: int,
     data_collection_period: int,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Run a single model run and collect model and agent data.
 
     Parameters
@@ -185,7 +184,7 @@ def _model_run_func(
 def _collect_data(
     model: Model,
     step: int,
-) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Collect model and agent data from a model using mesas datacollector."""
     dc = model.datacollector
 

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -1,6 +1,6 @@
 import sys
 import threading
-from typing import List, Optional
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -317,7 +317,7 @@ def UserInputs(user_params, on_change=None):
 
 
 @solara.component
-def SpaceMatplotlib(model, agent_portrayal, dependencies: Optional[List[any]] = None):
+def SpaceMatplotlib(model, agent_portrayal, dependencies: Optional[list[any]] = None):
     space_fig = Figure()
     space_ax = space_fig.subplots()
     space = getattr(model, "grid", None)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -26,16 +26,14 @@ from numbers import Real
 from typing import (
     Any,
     Callable,
-    Iterable,
-    Iterator,
     List,
-    Sequence,
     Tuple,
     TypeVar,
     Union,
     cast,
     overload,
 )
+from collections.abc import Iterable, Iterator, Sequence
 from warnings import warn
 
 import networkx as nx
@@ -48,15 +46,15 @@ from .agent import Agent
 # for better performance, we calculate the tuple to use in the is_integer function
 _types_integer = (int, np.integer)
 
-Coordinate = Tuple[int, int]
+Coordinate = tuple[int, int]
 # used in ContinuousSpace
-FloatCoordinate = Union[Tuple[float, float], npt.NDArray[float]]
+FloatCoordinate = Union[tuple[float, float], npt.NDArray[float]]
 NetworkCoordinate = int
 
 Position = Union[Coordinate, FloatCoordinate, NetworkCoordinate]
 
 GridContent = Union[Agent, None]
-MultiGridContent = List[Agent]
+MultiGridContent = list[Agent]
 
 F = TypeVar("F", bound=Callable[..., Any])
 

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -24,14 +24,7 @@ import math
 import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from numbers import Real
-from typing import (
-    Any,
-    Callable,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Callable, TypeVar, Union, cast, overload
 from warnings import warn
 
 import networkx as nx

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -22,18 +22,16 @@ import inspect
 import itertools
 import math
 import warnings
+from collections.abc import Iterable, Iterator, Sequence
 from numbers import Real
 from typing import (
     Any,
     Callable,
-    List,
-    Tuple,
     TypeVar,
     Union,
     cast,
     overload,
 )
-from collections.abc import Iterable, Iterator, Sequence
 from warnings import warn
 
 import networkx as nx

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -28,9 +28,10 @@ from __future__ import annotations
 import heapq
 import warnings
 import weakref
+from collections.abc import Iterable
 
 # mypy
-from typing import Iterable, Union
+from typing import Union
 
 from mesa.agent import Agent, AgentSet
 from mesa.model import Model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "Mesa"
 description = "Agent-based modeling (ABM) in Python 3+"
 license = { text = "Apache 2.0" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
   { name = "Project Mesa Team", email = "projectmesa@googlegroups.com" },
 ]
@@ -28,7 +28,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "License :: OSI Approved :: Apache Software License",
@@ -58,13 +57,9 @@ dev = [
   "pytest-cov",
   "sphinx",
 ]
-# Explicitly install ipykernel for Python 3.8.
-# See https://stackoverflow.com/questions/28831854/how-do-i-add-python3-kernel-to-jupyter-ipython
-# Could be removed in the future
 docs = [
   "sphinx",
   "ipython",
-  "ipykernel",
   "pydata_sphinx_theme",
   "seaborn",
   "myst-nb",
@@ -134,6 +129,6 @@ extend-ignore = [
     "ISC001",  # ruff format asks to disable this feature
 ]
 extend-exclude = ["docs", "build"]
-# Hardcode to Python 3.8.
+# Hardcode to Python 3.9.
 # Reminder to update mesa-examples if the value below is changed.
-target-version = "py38"
+target-version = "py39"


### PR DESCRIPTION
NumPy had dropped it since Jan 31 2023: https://numpy.org/neps/nep-0029-deprecation_policy.html.

If this PR is merged, the next release needs to be 2.2.0 instead of 2.1.2.