### PR TITLE
Docker: Update to use Solara viz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-FROM python:3.10-slim
+# We can't use slim because we need either git/wget/curl to
+# download mesa-examples, and so installing them requires
+# updating the system anyway.
+# We can't use alpine because NumPy doesn't support musllinux yet.
+# But it's in the RC version https://github.com/numpy/numpy/issues/20089.
+FROM python:bookworm
 LABEL maintainer="rht <rhtbot@protonmail.com>"
 
 # To use this Dockerfile:
 # 1. `docker build . -t mymesa_image`
-# 2. `docker run --name mymesa_instance -p 8521:8521 -it mymesa_image`
-# 3. In your browser, visit http://127.0.0.1:8521
+# 2. `docker run --name mymesa_instance -p 8765:8765 -it mymesa_image`
+# 3. In your browser, visit http://127.0.0.1:8765
 #
-# Currently, this Dockerfile defaults to running the Wolf-Sheep model, as an
+# Currently, this Dockerfile defaults to running the Schelling model, as an
 # illustration. If you want to run a different example, simply change the
 # MODEL_DIR variable below to point to another model, e.g.
-# examples/sugarscape_cg or path to your custom model.
+# /mesa-examples/examples/sugarscape_cg or path to your custom model.
 # You specify the MODEL_DIR (relative to this Git repo) by doing:
-# `docker run --name mymesa_instance -p 8521:8521 -e MODEL_DIR=examples/sugarscape_cg -it mymesa_image`
-# Note: the model directory MUST contain a run.py file.
+# `docker run --name mymesa_instance -p 8765:8765 -e MODEL_DIR=/mesa-examples/examples/sugarscape_cg -it mymesa_image`
+# Note: the model directory MUST contain an app.py file.
 
-ENV MODEL_DIR=examples/wolf_sheep
+ENV MODEL_DIR=/mesa-examples/examples/schelling_experimental
 
 # Don't buffer output:
 # https://docs.python.org/3.10/using/cmdline.html?highlight=pythonunbuffered#envvar-PYTHONUNBUFFERED
@@ -24,21 +29,10 @@ WORKDIR /opt/mesa
 
 COPY . /opt/mesa
 
-EXPOSE 8521/tcp
+RUN cd / && git clone https://github.com/projectmesa/mesa-examples.git
 
-# Important: we don't install python3-dev, python3-pip and so on because doing
-# so will install Python 3.9 instead of the already available Python 3.10 from
-# the base image.
-# The following RUN command is still provided for context.
-# RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \
-#    && apt-get install -y --no-install-recommends \
-#    build-essential \
-#    python3-dev \
-#    python3-pip \
-#    python3-setuptools \
-#    python3-wheel \
-#    && rm -rf /var/lib/apt/lists/*
+EXPOSE 8765/tcp
 
 RUN pip3 install -e /opt/mesa
 
-CMD ["sh", "-c", "cd $MODEL_DIR && python3 run.py"]
+CMD ["sh", "-c", "cd $MODEL_DIR && solara run app.py --host=0.0.0.0"]

--- a/README.rst
+++ b/README.rst
@@ -85,21 +85,21 @@ If you are a Mesa developer, first `install Docker Compose <https://docs.docker.
     # If you want to make it run in the background, you instead run
     $ docker compose up -d
 
-This runs the wolf-sheep predation model, as an example.
+This runs the Schelling model, as an example.
 
 With the docker-compose.yml file in this Git repository, the `docker compose up` command does two important things:
 
 * It mounts the mesa root directory (relative to the docker-compose.yml file) into /opt/mesa and runs pip install -e on that directory so your changes to mesa should be reflected in the running container.
-* It binds the docker container's port 8521 to your host system's port 8521 so you can interact with the running model as usual by visiting localhost:8521 on your browser
+* It binds the docker container's port 8765 to your host system's port 8765 so you can interact with the running model as usual by visiting localhost:8765 on your browser
 
 
 If you are a model developer that wants to run Mesa on a model, you need to:
 
 * make sure that your model folder is inside the folder containing the docker-compose.yml file
 * change the ``MODEL_DIR`` variable in docker-compose.yml to point to the path of your model
-* make sure that the model folder contains a run.py file
+* make sure that the model folder contains an app.py file
 
-Then, you just need to run `docker compose up -d` to make it accessible from ``localhost:8521``.
+Then, you just need to run `docker compose up -d` to have it accessible from ``localhost:8765``.
 
 Contributing to Mesa
 ----------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     volumes:
       - .:/opt/mesa
     environment:
-      MODEL_DIR: examples/wolf_sheep
+      # You may replace this with any model directory located
+      # within the current directory.
+      # E.g. if it is at my-model, then you specify it as
+      # /opt/mesa/my-model.
+      MODEL_DIR: /mesa-examples/examples/schelling_experimental
     ports:
-      - "127.0.0.1:8521:8521"
+      - 8765:8765


### PR DESCRIPTION
Not yet tested. Note that the current Docker setup is broken because the examples folder is now gone (moved to mesa-examples repo).