### PR TITLE
Add step count display to JupyterViz

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -177,7 +177,7 @@ def MesaComponent(viz, space_drawer=None, play_interval=400):
 
     # 4. Status indicators
     #: current round step count
-    step = solara.use_reactive(False)
+    step = solara.use_reactive(True)
 
     def on_value_play(change):
         if viz.model.running:
@@ -206,12 +206,7 @@ def MesaComponent(viz, space_drawer=None, play_interval=400):
             playing=playing.value,
             on_playing=playing.set,
         )
-        widgets.IntText(
-            value=step.value,
-            description="Step:",
-            disabled=True,
-            interval=play_interval,
-        )
+        solara.Markdown(md_text="**Step:** %d" % step.value)
         # threaded_do_play is not used for now because it
         # doesn't work in Google colab. We use
         # ipywidgets.Play until it is fixed. The threading

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -175,14 +175,9 @@ def MesaComponent(viz, space_drawer=None, play_interval=400):
     # 3. Buttons
     playing = solara.use_reactive(False)
 
-    # 4. Status indicators
-    #: current round step count
-    step = solara.use_reactive(True)
-
     def on_value_play(change):
         if viz.model.running:
             viz.do_step()
-            step.value = viz.model.schedule.steps
         else:
             playing.value = False
 
@@ -206,7 +201,7 @@ def MesaComponent(viz, space_drawer=None, play_interval=400):
             playing=playing.value,
             on_playing=playing.set,
         )
-        solara.Markdown(md_text="**Step:** %d" % step.value)
+        solara.Markdown(md_text=f"**Step:** {viz.model.schedule.steps}")
         # threaded_do_play is not used for now because it
         # doesn't work in Google colab. We use
         # ipywidgets.Play until it is fixed. The threading

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -175,9 +175,14 @@ def MesaComponent(viz, space_drawer=None, play_interval=400):
     # 3. Buttons
     playing = solara.use_reactive(False)
 
+    # 4. Status indicators
+    #: current round step count
+    step = solara.use_reactive(False)
+
     def on_value_play(change):
         if viz.model.running:
             viz.do_step()
+            step.value = viz.model.schedule.steps
         else:
             playing.value = False
 
@@ -200,6 +205,12 @@ def MesaComponent(viz, space_drawer=None, play_interval=400):
             on_value=on_value_play,
             playing=playing.value,
             on_playing=playing.set,
+        )
+        widgets.IntText(
+            value=step.value,
+            description="Step:",
+            disabled=True,
+            interval=play_interval,
         )
         # threaded_do_play is not used for now because it
         # doesn't work in Google colab. We use


### PR DESCRIPTION
addresses #1773 

I don't see any unit tests for the experimental JupyterViz code; I'd be game to add a test if/when there is existing testing infrastructure for this code, but not sure how to go about testing my contribution without examples for the other parts.

I'm not sure if there's any relevant documentation I need to update for this change. I could see if I can generate a new version of the [screenshot for the Schelling segregration model displayed on the docs overview page](https://mesa.readthedocs.io/en/stable/index.html) that includes the step count, if that would be helpful/desirable.