### PR TITLE
Add support for select input type

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -150,6 +150,12 @@ def make_user_input(user_input, k, v):
             max=v.get("max"),
             step=v.get("step"),
         )
+    elif v["type"] == "Select":
+        solara.Select(
+            v.get("label", "label"),
+            value=v.get("value"),
+            values=v.get("values"),
+        )
 
 
 @solara.component


### PR DESCRIPTION
Add support for `solara.Select` for model input parameters, per #1777 

I'd be glad to draft documentation or add more detail to one of the tutorials about supported input types, but not sure where to add that.