### PR TITLE
Simplify solara code

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -1,6 +1,5 @@
 import threading
 
-import matplotlib.pyplot as plt
 import networkx as nx
 import reacton.ipywidgets as widgets
 import solara
@@ -9,48 +8,72 @@ from matplotlib.ticker import MaxNLocator
 
 import mesa
 
-# Avoid interactive backend
-plt.switch_backend("agg")
 
+@solara.component
+def JupyterViz(
+    model_class,
+    model_params,
+    measures=None,
+    name="Mesa Model",
+    agent_portrayal=None,
+    space_drawer=None,
+    play_interval=400,
+):
+    current_step, set_current_step = solara.use_state(0)
 
-class JupyterContainer:
-    def __init__(
-        self,
-        model_class,
-        model_params,
-        measures=None,
-        name="Mesa Model",
-        agent_portrayal=None,
-    ):
-        self.model_class = model_class
-        self.split_model_params(model_params)
-        self.measures = measures
-        self.name = name
-        self.agent_portrayal = agent_portrayal
-        self.thread = None
+    solara.Markdown(name)
 
-    def split_model_params(self, model_params):
-        self.model_params_input = {}
-        self.model_params_fixed = {}
-        for k, v in model_params.items():
-            if self.check_param_is_fixed(v):
-                self.model_params_fixed[k] = v
+    # 0. Split model params
+    model_params_input, model_params_fixed = split_model_params(model_params)
+
+    # 1. User inputs
+    user_inputs = {}
+    for k, v in model_params_input.items():
+        user_input = solara.use_reactive(v["value"])
+        user_inputs[k] = user_input.value
+        make_user_input(user_input, k, v)
+
+    # 2. Model
+    def make_model():
+        return model_class(**user_inputs, **model_params_fixed)
+
+    model = solara.use_memo(make_model, dependencies=list(user_inputs.values()))
+
+    # 3. Buttons
+    ModelController(model, play_interval, current_step, set_current_step)
+
+    with solara.GridFixed(columns=2):
+        # 4. Space
+        if space_drawer is None:
+            make_space(model, agent_portrayal)
+        else:
+            space_drawer(model, agent_portrayal)
+        # 5. Plots
+        for measure in measures:
+            if callable(measure):
+                # Is a custom object
+                measure(model)
             else:
-                self.model_params_input[k] = v
+                make_plot(model, measure)
 
-    def check_param_is_fixed(self, param):
-        if not isinstance(param, dict):
-            return True
-        if "type" not in param:
-            return True
 
-    def do_step(self):
-        self.model.step()
-        self.set_df(self.model.datacollector.get_model_vars_dataframe())
+@solara.component
+def ModelController(model, play_interval, current_step, set_current_step):
+    playing = solara.use_reactive(False)
+
+    def on_value_play(change):
+        if model.running:
+            do_step()
+        else:
+            playing.value = False
+
+    def do_step():
+        model.step()
+        set_current_step(model.schedule.steps)
 
     def do_play(self):
-        self.model.running = True
-        while self.model.running:
+        model.running = True
+        while model.running:
             self.do_step()
 
     def threaded_do_play(self):
@@ -65,72 +88,53 @@ class JupyterContainer:
         self.model.running = False
         self.thread.join()
 
-    def portray(self, g):
-        x = []
-        y = []
-        s = []  # size
-        c = []  # color
-        for i in range(g.width):
-            for j in range(g.height):
-                content = g._grid[i][j]
-                if not content:
-                    continue
-                if not hasattr(content, "__iter__"):
-                    # Is a single grid
-                    content = [content]
-                for agent in content:
-                    data = self.agent_portrayal(agent)
-                    x.append(i)
-                    y.append(j)
-                    if "size" in data:
-                        s.append(data["size"])
-                    if "color" in data:
-                        c.append(data["color"])
-        out = {"x": x, "y": y}
-        if len(s) > 0:
-            out["s"] = s
-        if len(c) > 0:
-            out["c"] = c
-        return out
+    with solara.Row():
+        solara.Button(label="Step", color="primary", on_click=do_step)
+        # This style is necessary so that the play widget has almost the same
+        # height as typical Solara buttons.
+        solara.Style(
+            """
+        .widget-play {
+            height: 30px;
+        }
+        """
+        )
+        widgets.Play(
+            value=0,
+            interval=play_interval,
+            repeat=True,
+            show_repeat=False,
+            on_value=on_value_play,
+            playing=playing.value,
+            on_playing=playing.set,
+        )
+        solara.Markdown(md_text=f"**Step:** {current_step}")
+        # threaded_do_play is not used for now because it
+        # doesn't work in Google colab. We use
+        # ipywidgets.Play until it is fixed. The threading
+        # version is definite a much better implementation,
+        # if it works.
+        # solara.Button(label="▶", color="primary", on_click=viz.threaded_do_play)
+        # solara.Button(label="⏸︎", color="primary", on_click=viz.do_pause)
+        # solara.Button(label="Reset", color="primary", on_click=do_reset)
 
 
-def _draw_network_grid(viz, space_ax):
-    graph = viz.model.grid.G
-    pos = nx.spring_layout(graph, seed=0)
-    nx.draw(
-        graph,
-        ax=space_ax,
-        pos=pos,
-        **viz.agent_portrayal(graph),
-    )
+def split_model_params(model_params):
+    model_params_input = {}
+    model_params_fixed = {}
+    for k, v in model_params.items():
+        if check_param_is_fixed(v):
+            model_params_fixed[k] = v
+        else:
+            model_params_input[k] = v
+    return model_params_input, model_params_fixed
 
 
-def make_space(viz):
-    space_fig = Figure()
-    space_ax = space_fig.subplots()
-    if isinstance(viz.model.grid, mesa.space.NetworkGrid):
-        _draw_network_grid(viz, space_ax)
-    else:
-        space_ax.scatter(**viz.portray(viz.model.grid))
-    space_ax.set_axis_off()
-    solara.FigureMatplotlib(space_fig, dependencies=[viz.model, viz.df])
-
-
-def make_plot(viz, measure):
-    fig = Figure()
-    ax = fig.subplots()
-    ax.plot(viz.df.loc[:, measure])
-    ax.set_ylabel(measure)
-    # Set integer x axis
-    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
-    solara.FigureMatplotlib(fig, dependencies=[viz.model, viz.df])
-
-
-def make_text(renderer):
-    def function(viz):
-        solara.Markdown(renderer(viz.model))
-
-    return function
+def check_param_is_fixed(param):
+    if not isinstance(param, dict):
+        return True
+    if "type" not in param:
+        return True
 
 
 def make_user_input(user_input, k, v):
@@ -158,94 +162,69 @@ def make_user_input(user_input, k, v):
         )
 
 
-@solara.component
-def MesaComponent(viz, space_drawer=None, play_interval=400):
-    solara.Markdown(viz.name)
+def make_space(model, agent_portrayal):
+    def portray(g):
+        x = []
+        y = []
+        s = []  # size
+        c = []  # color
+        for i in range(g.width):
+            for j in range(g.height):
+                content = g._grid[i][j]
+                if not content:
+                    continue
+                if not hasattr(content, "__iter__"):
+                    # Is a single grid
+                    content = [content]
+                for agent in content:
+                    data = agent_portrayal(agent)
+                    x.append(i)
+                    y.append(j)
+                    if "size" in data:
+                        s.append(data["size"])
+                    if "color" in data:
+                        c.append(data["color"])
+        out = {"x": x, "y": y}
+        if len(s) > 0:
+            out["s"] = s
+        if len(c) > 0:
+            out["c"] = c
+        return out
 
-    # 1. User inputs
-    user_inputs = {}
-    for k, v in viz.model_params_input.items():
-        user_input = solara.use_reactive(v["value"])
-        user_inputs[k] = user_input.value
-        make_user_input(user_input, k, v)
+    space_fig = Figure()
+    space_ax = space_fig.subplots()
+    if isinstance(model.grid, mesa.space.NetworkGrid):
+        _draw_network_grid(model, space_ax, agent_portrayal)
+    else:
+        space_ax.scatter(**portray(model.grid))
+    space_ax.set_axis_off()
+    solara.FigureMatplotlib(space_fig)
 
-    # 2. Model
-    def make_model():
-        return viz.model_class(**user_inputs, **viz.model_params_fixed)
 
-    viz.model = solara.use_memo(make_model, dependencies=list(user_inputs.values()))
-    viz.df, viz.set_df = solara.use_state(
-        viz.model.datacollector.get_model_vars_dataframe()
+def _draw_network_grid(model, space_ax, agent_portrayal):
+    graph = model.grid.G
+    pos = nx.spring_layout(graph, seed=0)
+    nx.draw(
+        graph,
+        ax=space_ax,
+        pos=pos,
+        **agent_portrayal(graph),
     )
 
-    # 3. Buttons
-    playing = solara.use_reactive(False)
 
-    def on_value_play(change):
-        if viz.model.running:
-            viz.do_step()
-        else:
-            playing.value = False
-
-    with solara.Row():
-        solara.Button(label="Step", color="primary", on_click=viz.do_step)
-        # This style is necessary so that the play widget has almost the same
-        # height as typical Solara buttons.
-        solara.Style(
-            """
-        .widget-play {
-            height: 30px;
-        }
-        """
-        )
-        widgets.Play(
-            value=0,
-            interval=play_interval,
-            repeat=True,
-            show_repeat=False,
-            on_value=on_value_play,
-            playing=playing.value,
-            on_playing=playing.set,
-        )
-        solara.Markdown(md_text=f"**Step:** {viz.model.schedule.steps}")
-        # threaded_do_play is not used for now because it
-        # doesn't work in Google colab. We use
-        # ipywidgets.Play until it is fixed. The threading
-        # version is definite a much better implementation,
-        # if it works.
-        # solara.Button(label="▶", color="primary", on_click=viz.threaded_do_play)
-        # solara.Button(label="⏸︎", color="primary", on_click=viz.do_pause)
-        # solara.Button(label="Reset", color="primary", on_click=do_reset)
-
-    with solara.GridFixed(columns=2):
-        # 4. Space
-        if space_drawer is None:
-            make_space(viz)
-        else:
-            space_drawer(viz)
-        # 5. Plots
-        for measure in viz.measures:
-            if callable(measure):
-                # Is a custom object
-                measure(viz)
-            else:
-                make_plot(viz, measure)
+def make_plot(model, measure):
+    fig = Figure()
+    ax = fig.subplots()
+    df = model.datacollector.get_model_vars_dataframe()
+    ax.plot(df.loc[:, measure])
+    ax.set_ylabel(measure)
+    # Set integer x axis
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+    solara.FigureMatplotlib(fig)
 
 
-# JupyterViz has to be a Solara component, so that each browser tabs runs in
-# their own, separate simulation thread. See https://github.com/projectmesa/mesa/issues/856.
-@solara.component
-def JupyterViz(
-    model_class,
-    model_params,
-    measures=None,
-    name="Mesa Model",
-    agent_portrayal=None,
-    space_drawer=None,
-    play_interval=400,
-):
-    return MesaComponent(
-        JupyterContainer(model_class, model_params, measures, name, agent_portrayal),
-        space_drawer=space_drawer,
-        play_interval=play_interval,
-    )
+def make_text(renderer):
+    def function(model):
+        solara.Markdown(renderer(model))
+
+    return function

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -1,5 +1,6 @@
 import threading
 
+import matplotlib.pyplot as plt
 import networkx as nx
 import reacton.ipywidgets as widgets
 import solara
@@ -7,6 +8,9 @@ from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
 
 import mesa
+
+# Avoid interactive backend
+plt.switch_backend("agg")
 
 
 @solara.component
@@ -60,6 +64,7 @@ def JupyterViz(
 @solara.component
 def ModelController(model, play_interval, current_step, set_current_step):
     playing = solara.use_reactive(False)
+    thread = solara.use_reactive(None)
 
     def on_value_play(change):
         if model.running:
@@ -71,22 +76,22 @@ def ModelController(model, play_interval, current_step, set_current_step):
         model.step()
         set_current_step(model.schedule.steps)
 
-    def do_play(self):
+    def do_play():
         model.running = True
         while model.running:
-            self.do_step()
+            do_step()
 
-    def threaded_do_play(self):
-        if self.thread is not None and self.thread.is_alive():
+    def threaded_do_play():
+        if thread is not None and thread.is_alive():
             return
-        self.thread = threading.Thread(target=self.do_play)
-        self.thread.start()
+        thread.value = threading.Thread(target=do_play)
+        thread.start()
 
-    def do_pause(self):
-        if (self.thread is None) or (not self.thread.is_alive()):
+    def do_pause():
+        if (thread is None) or (not thread.is_alive()):
             return
-        self.model.running = False
-        self.thread.join()
+        model.running = False
+        thread.join()
 
     with solara.Row():
         solara.Button(label="Step", color="primary", on_click=do_step)


### PR DESCRIPTION

Over the past weeks, I've had the opportunity to delve into the Solara frontend and experiment with different ideas. A big thank you to @rht for laying the foundation of the Solara frontend. 

I'm experimenting with exciting concepts for the frontend and am eager to incorporate my React knowledge.

However, with this PR, my primary aim is to streamline the codebase before introducing any additional modifications.

At present, the frontend code is organized across three functions/classes:
  - `JupyterContainer`: This contains model control functions, grid plotting features, and logic to segregate model parameters into fixed and user-configurable ones.
  - `MesaComponent`: This establishes user-configurable controls, sets up the model, contains some model control functions, performs `JupyterContainer` manipulations, and holds the plotting logic.
  - `JupyterViz`: This Solara component essentially returns the MesaComponent and initiates the Container.

I've reorganized and simplified the structure. Now, `JupyterViz` stands as the primary component, managing user input (subject to further enhancement in an upcoming PR), initializing the model, and handling the plotting logic. The model control has been externalized to a separate component named `ModelController`.

While this PR might seem extensive, it's mainly due to the code repositioning to achieve a more intuitive flow. The actual modifications are minimal. Key changes include:
  - Removal of `FigureMatplotlib` dependencies. Presently, we're free from unnecessary re-renders, so this optimization isn't required.
  - Elimination of `df` from the container. Previously, I believe this was used to trigger re-renders. Now, we track the current step to achieve this. This approach also supports models without a data collector and is essential for upcoming enhancements to the model controller.
  - The `split_model_params` function has been made top-level and devoid of side effects.

I think that sums it up.
