### PR TITLE
Fix: Remove dict merge operator, python 3.8 compat

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -42,7 +42,7 @@ def JupyterViz(
     # 1. Set up model parameters
     user_params, fixed_params = split_model_params(model_params)
     model_parameters, set_model_parameters = solara.use_state(
-        fixed_params | {k: v["value"] for k, v in user_params.items()}
+        {**fixed_params, **{k: v["value"] for k, v in user_params.items()}}
     )
 
     # 2. Set up Model
@@ -54,7 +54,7 @@ def JupyterViz(
     model = solara.use_memo(make_model, dependencies=list(model_parameters.values()))
 
     def handle_change_model_params(name: str, value: any):
-        set_model_parameters(model_parameters | {name: value})
+        set_model_parameters({**model_parameters, name: value})
 
     # 3. Set up UI
     solara.Markdown(name)


### PR DESCRIPTION
Fixed Python 3.8 compatibility 

> It turns out that there is a failed CI test on Python 3.8. I didn't realize it happening because I'm used to the coverage often giving "x". The reason is that `|` is not supported on 3.8.

_Originally posted by @rht in https://github.com/projectmesa/mesa/issues/1788#issuecomment-1710192883_