### PR TITLE
HISTORY.rst: Correct neighbor_iter() replacement in 2.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -47,7 +47,7 @@ Mesa 2.0 includes:
     * `find_empty()`: convert this to `move_to_empty()`
     * `num_agents`: removed parameter from `move_to_empty()`
     * `position_agent()`: convert this to `place_agent`
-    * `neighbor_iter()`: convert this to `iter_neighborhood()`
+    * `neighbor_iter()`: convert this to `iter_neighbors()`
 * batchrunner: remove deprecations #1627
     * `class BatchRunner` and `class BatchRunnerMP`: convert these to `batch_run()`
     * Please see this `batch_run() example`_ if you would like to see an an implementation.


### PR DESCRIPTION
The 2.0.0 release notes said incorrectly to replace `neighbor_iter()` with `iter_neighborhood()` (which returns an iterator of Tuple coordinates) instead of the correct `iter_neighbors()` (which returns an iterator of Agents). This PR fixes this.