### PR TITLE
docs: Always link to stable version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -37,7 +37,7 @@ Mesa 2.0 includes:
     * an improved `datacollector` that allows collection by agent type
     * several breaking changes that provide significant improvements to Mesa.
 
-.. _visualization tutorial: https://mesa.readthedocs.io/en/latest/tutorials/visualization_tutorial.html
+.. _visualization tutorial: https://mesa.readthedocs.io/en/stable/tutorials/visualization_tutorial.html
 **Breaking Changes:**
 
 * space: change `coord_iter` to return `(content,(x,y))` instead of `(content, x,y)`; this reduces known errors of scheduler to grid mismatch #1566, #1723

--- a/README.rst
+++ b/README.rst
@@ -65,10 +65,10 @@ For resources or help on using Mesa, check out the following:
 * `Discussions`_ (GitHub threaded discussions about Mesa)
 * `Matrix Chat`_ (Chat Forum via Matrix to talk about Mesa)
 
-.. _`Intro to Mesa Tutorial` : http://mesa.readthedocs.org/en/main/tutorials/intro_tutorial.html
+.. _`Intro to Mesa Tutorial` : http://mesa.readthedocs.org/en/stable/tutorials/intro_tutorial.html
 .. _`Complexity Explorer Tutorial` : https://www.complexityexplorer.org/courses/172-agent-based-models-with-python-an-introduction-to-mesa
 .. _`Mesa Examples` : https://github.com/projectmesa/mesa-examples/tree/main/examples
-.. _`Docs` : http://mesa.readthedocs.org/en/main/
+.. _`Docs` : http://mesa.readthedocs.org/
 .. _`Discussions` : https://github.com/projectmesa/mesa/discussions
 .. _`Matrix Chat` : https://matrix.to/#/#project-mesa:matrix.org
 

--- a/docs/tutorials/adv_tutorial_legacy.ipynb
+++ b/docs/tutorials/adv_tutorial_legacy.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "#### Grid Visualization\n",
     "\n",
-    "To start with, let's have a visualization where we can watch the agents moving around the grid. For this, you will need to put your model code in a separate Python source file. For now, let us use the `MoneyModel` created in the [Introductory Tutorial](https://mesa.readthedocs.io/en/main/tutorials/intro_tutorial.html) saved to `MoneyModel.py` file provided.\n",
+    "To start with, let's have a visualization where we can watch the agents moving around the grid. For this, you will need to put your model code in a separate Python source file. For now, let us use the `MoneyModel` created in the [Introductory Tutorial](https://mesa.readthedocs.io/en/stable/tutorials/intro_tutorial.html) saved to `MoneyModel.py` file provided.\n",
     "Next, in a new source file (e.g. `MoneyModel_Viz.py`) include the code shown in the following cells to run and avoid Jupyter compatibility issue."
    ]
   },

--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "#### Grid Visualization\n",
     "\n",
-    "To start with, let's have a visualization where we can watch the agents moving around the grid. Let us use the same `MoneyModel` created in the [Introductory Tutorial](https://mesa.readthedocs.io/en/main/tutorials/intro_tutorial.html).\n"
+    "To start with, let's have a visualization where we can watch the agents moving around the grid. Let us use the same `MoneyModel` created in the [Introductory Tutorial](https://mesa.readthedocs.io/en/stable/tutorials/intro_tutorial.html).\n"
    ]
   },
   {


### PR DESCRIPTION
Switched all the links that were pointing to either `latest` or `main` branch of our docs to `stable`. This prevents situations such as in #1808 where to documentation becomes out of sync with the latest release of mesa. In my opinion this should be the default and users installing the git version of mesa are still able to switch the docs branch. 