### PR TITLE
model: Ensure the seed is initialized with current timestamp when it is None

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -21,7 +21,11 @@ class Model:
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
         """Create a new model object and instantiate its RNG automatically."""
         obj = object.__new__(cls)
-        obj._seed = kwargs.get("seed", None)
+        obj._seed = kwargs.get("seed")
+        if obj._seed is None:
+            # We explicitly specify the seed here so that we know its value in
+            # advance.
+            obj._seed = random.random()  # noqa: S311
         obj.random = random.Random(obj._seed)
         return obj
 


### PR DESCRIPTION
This is a precursor to #1812, and is useful info for debugging purpose, because apparently there is no way to get a `random.Random()` object's seed once it is initialized. At best, you can have its state instead.