### PR TITLE
frontend: Add experimental VegaGrid

### DIFF
--- a/mesa/experimental/VegaGrid.py
+++ b/mesa/experimental/VegaGrid.py
@@ -1,0 +1,56 @@
+import json
+
+import altair as alt
+import solara
+
+
+def get_agent_data_from_coord_iter(data):
+    for agent, (x, y) in data:
+        if agent:
+            agent_data = json.loads(
+                json.dumps(agent.__dict__, skipkeys=True, default=str)
+            )
+            agent_data["x"] = x
+            agent_data["y"] = y
+            agent_data.pop("model", None)
+            agent_data.pop("pos", None)
+            yield agent_data
+
+
+def make_vega_grid(color=None, click_handler=None):
+    return lambda model, _: VegaGrid(model, _, color, click_handler)
+
+
+def VegaGrid(model, _agent_portrayal, color=None, on_click=None):
+    if color is None:
+        color = "unique_id:N"
+
+    data = solara.reactive(
+        list(get_agent_data_from_coord_iter(model.grid.coord_iter()))
+    )
+
+    def update_data():
+        data.value = list(get_agent_data_from_coord_iter(model.grid.coord_iter()))
+
+    def click_handler(datum):
+        if datum is None:
+            return
+        agent = model.schedule._agents[tuple(datum["unique_id"])]
+        on_click(agent)
+        update_data()
+
+    default_tooltip = [f"{key}:N" for key in data.value[0]]
+    chart = (
+        alt.Chart(alt.Data(values=data.value))
+        .mark_rect()
+        .encode(
+            x=alt.X("x:N", scale=alt.Scale(domain=list(range(model.grid.width)))),
+            y=alt.Y(
+                "y:N",
+                scale=alt.Scale(domain=list(range(model.grid.height - 1, -1, -1))),
+            ),
+            color=color,
+            tooltip=default_tooltip,
+        )
+    )
+    return solara.FigureAltair(chart, on_click=click_handler)

--- a/mesa/experimental/__init__.py
+++ b/mesa/experimental/__init__.py
@@ -1,1 +1,2 @@
 from .jupyter_viz import JupyterViz, make_text  # noqa
+from .VegaGrid import VegaGrid, make_vega_grid  # noqa

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ requires = [
     "click",
     "cookiecutter",
     "matplotlib",
+    "altair",
     "mesa_viz_tornado",
     "networkx",
     "numpy",


### PR DESCRIPTION
Added an experimental VegaGrid via vega-altair. Here is a quick screencast of whats possible with this:

[screen-capture (3).webm](https://github.com/projectmesa/mesa/assets/13568919/efd86066-22ad-431a-8b97-862f0b43a75b)

So, we have the following unique features

- Tooltip for agent data - defaults to all JSON serializable agent data
- declaratively describe chart features instead of imperative portrayal functions
- Interactivity via click-handlers! 

The last one is made possible by vega-altair allowing to define an on_click handler. I than only had to wrap the click handler by first finding the corresponding agent by its unique_id and after any interactions updating the data values.

This means the example shown can be achieved with a simple click_handler that acts upon the clicked agent. That is we only have to define 
```python
def click_handler(agent):
    agent.type = 1 - agent.type
```

to achieve interactivity for changing the agent type!

Then we run the example with 

```python
page = JupyterViz(
    Schelling,
    model_params,
    measures=["happy", make_text(get_happy_agents)],
    space_drawer=make_vega_grid("type:N", click_handler=click_handler),
    name="Schelling",
    agent_portrayal=agent_portrayal,
)
page  # noqa
```

In total I would say the current implementation might be a bit rough, but I think a lot can be improved over time, adding more functions and allowing more customizations. This is just a start. 