### PR TITLE
perf: Speed up Solara space render

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -270,7 +270,7 @@ def make_space(model, agent_portrayal):
     else:
         space_ax.scatter(**portray(model.grid))
     space_ax.set_axis_off()
-    solara.FigureMatplotlib(space_fig)
+    solara.FigureMatplotlib(space_fig, format="png")
 
 
 def _draw_network_grid(model, space_ax, agent_portrayal):

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -21,7 +21,7 @@ def JupyterViz(
     name="Mesa Model",
     agent_portrayal=None,
     space_drawer="default",
-    play_interval=400,
+    play_interval=150,
 ):
     """Initialize a component to visualize a model.
     Args:
@@ -34,7 +34,7 @@ def JupyterViz(
             the model; default implementation is :meth:`make_space`;
             simulations with no space to visualize should
             specify `space_drawer=False`
-        play_interval: play interval (default: 400)
+        play_interval: play interval (default: 150)
     """
 
     current_step, set_current_step = solara.use_state(0)


### PR DESCRIPTION
This speeds up space render for Schelling with 80x80 grid size from 1.2 s to 80 ms.