### PR TITLE
check if positions values are tuples

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -68,10 +68,9 @@ def accept_tuple_argument(wrapped_function: F) -> F:
     single-item list rather than forcing user to do it."""
 
     def wrapper(grid_instance, positions) -> Any:
-        if isinstance(positions, tuple) and len(positions) == 2:
-            return wrapped_function(grid_instance, [positions])
-        else:
-            return wrapped_function(grid_instance, positions)
+        if len(positions) == 2 and not isinstance(positions[0], tuple):
+            positions = [positions]
+        return wrapped_function(grid_instance, positions)
 
     return cast(F, wrapper)
 

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -327,6 +327,28 @@ class TestSingleGrid(unittest.TestCase):
         assert self.space[initial_pos[0]][initial_pos[1]] is None
         assert self.space[final_pos[0]][final_pos[1]] == _agent
 
+    def test_iter_cell_list_contents(self):
+        """
+        Test neighborhood retrieval
+        """
+        cell_list_1 = list(self.space.iter_cell_list_contents(TEST_AGENTS_GRID[0]))
+        assert len(cell_list_1) == 1
+
+        cell_list_2 = list(
+            self.space.iter_cell_list_contents(
+                (TEST_AGENTS_GRID[0], TEST_AGENTS_GRID[1])
+            )
+        )
+        assert len(cell_list_2) == 2
+
+        cell_list_3 = list(self.space.iter_cell_list_contents(tuple(TEST_AGENTS_GRID)))
+        assert len(cell_list_3) == 3
+
+        cell_list_4 = list(
+            self.space.iter_cell_list_contents((TEST_AGENTS_GRID[0], (0, 0)))
+        )
+        assert len(cell_list_4) == 1
+
 
 class TestSingleNetworkGrid(unittest.TestCase):
     GRAPH_SIZE = 10


### PR DESCRIPTION
#1831 

Add extra check to the `accept_tuple_argument` wrapper. If `positions` is a tuple of tuples of length 2, then the `iter_cell_list_contents` raises a TypeError.

Example, given a cell_list of `((0, 98), (1, 99))`, this will unpack here `x, y in cell_list` as `x = (0, 98) and y = (1, 99)`.