### PR TITLE
CI: Update GHA workflows to Python 3.12

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -30,8 +30,10 @@ jobs:
       fail-fast: False
       matrix:
         os: [windows, ubuntu, macos]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         include:
+          - os: ubuntu
+            python-version: "3.11"
           - os: ubuntu
             python-version: "3.10"
           - os: ubuntu
@@ -64,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - run: pip install ruff==0.0.275
     - name: Lint with ruff
       # Include `--format=github` to enable automatic inline annotations.
@@ -78,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - run: pip install black[jupyter]
     - name: Lint with black
       run: black --check --exclude=mesa/cookiecutter-mesa/* .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.12"
       - name: Install dependencies
         run: pip install -U pip wheel setuptools
       - name: Build package


### PR DESCRIPTION
Start testing Python 3.12 in CI