### PR TITLE
Update to Ruff 0.1.1

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Lint with ruff
       # Include `--format=github` to enable automatic inline annotations.
       # Use settings from pyproject.toml.
-      run: ruff . --format=github --extend-exclude 'mesa/cookiecutter-mesa/*'
+      run: ruff . --output-format=github --extend-exclude 'mesa/cookiecutter-mesa/*'
 
   lint-black:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-    - run: pip install ruff==0.0.275
+    - run: pip install "ruff>=0.1.1,<0.2.0"  # Update periodically
     - name: Lint with ruff
       # Include `--format=github` to enable automatic inline annotations.
       # Use settings from pyproject.toml.

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-    - run: pip install "ruff>=0.1.1,<0.2.0"  # Update periodically
+    - run: pip install ruff~=0.1.1  # Update periodically
     - name: Lint with ruff
       # Include `--format=github` to enable automatic inline annotations.
       # Use settings from pyproject.toml.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requires = [
 extras_require = {
     "dev": [
         "black",
-        "ruff>=0.1.1,<0.2.0",  # Update periodically
+        "ruff~=0.1.1",  # Update periodically
         "coverage",
         "pytest >= 4.6",
         "pytest-cov",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requires = [
 extras_require = {
     "dev": [
         "black",
-        "ruff==0.0.275",
+        "ruff>=0.1.1,<0.2.0",  # Update periodically
         "coverage",
         "pytest >= 4.6",
         "pytest-cov",


### PR DESCRIPTION
Note that Ruff has adopted a new version policy (https://docs.astral.sh/ruff/versioning/), similar to SemVer. So we can now do >=0.1.1,<0.2.0 to get bugfixes and deprecation warnings, but don't get new (syntax) features.