### PR TITLE
Update release.yml for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
   release:
     name: Deploy release to PyPI
     runs-on: ubuntu-latest
+    permissions: 
+      id-token: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -40,5 +42,3 @@ jobs:
       - name: Publish package to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This uses [trusted publishing](https://docs.pypi.org/trusted-publishers/) to use auto-generated short-lived tokens exchanged directly between PyPi and GitHub. This is the currently recommended way to upload releases from Github Actions to PyPi. With this in place we don't need to generate and deploy api keys to GitHub, but someone with access to mesa on PyPi has to follow [this guide](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) (I think that is either @jackiekazil or @tpike3 )