### PR TITLE
Ensure mesa_viz_tornado>=0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requires = [
     "click",
     "cookiecutter",
     "matplotlib",
-    "mesa_viz_tornado",
+    "mesa_viz_tornado~=0.1.0,>=0.1.2",
     "networkx",
     "numpy",
     "pandas",


### PR DESCRIPTION
Fixes #1859. Depends on mesa_viz_tornado 0.1.2 to be released on PyPI.