### PR TITLE
Fix render output in render_in_jupyter

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -92,7 +92,7 @@ def JupyterViz(
 
     # jupyter
     def render_in_jupyter():
-        with solara.Columns([3, 2]):
+        with solara.GridFixed(columns=2):
             UserInputs(user_params, on_change=handle_change_model_params)
             ModelController(
                 model, play_interval, current_step, set_current_step, reset_counter

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -99,7 +99,7 @@ def JupyterViz(
             )
             solara.Markdown(md_text=f"###Step - {current_step}")
 
-        with solara.Columns([1, 1]):
+        with solara.GridFixed(columns=2):
             # 4. Space
             if space_drawer == "default":
                 # draw with the default implementation


### PR DESCRIPTION
Currently, the model controller has a truncated view, and the measures are displayed in fixed width that doesn't expand to the screen width.
Before:
![2023-11-07T18:37:18,629912096-05:00](https://github.com/projectmesa/mesa/assets/395821/95a6ac76-7065-494f-9da3-75f4bdd3a978)

After:
![2023-11-07T18:54:17,289497949-05:00](https://github.com/projectmesa/mesa/assets/395821/ba3613fd-07af-42d0-b994-9c97e5e0b905)
