### PR TITLE
Migrate from setuptools to hatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install -U pip build wheel setuptools
+        run: pip install -U pip hatch
       - name: Build distributions
-        run: python -m build
+        run: hatch build
       - name: Upload package as artifact to GitHub
         if: github.repository == 'projectmesa/mesa' && startsWith(github.ref, 'refs/tags')
         uses: actions/upload-artifact@v3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-include MANIFEST.in
-include LICENSE
-include HISTORY.rst
-include setup.py
-graft mesa/cookiecutter-mesa
-global-exclude *.py[co]
-global-exclude __pycache__
-global-exclude *~
-global-exclude *.ipynb_checkpoints/*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage status](https://codecov.io/gh/projectmesa/mesa/branch/main/graph/badge.svg)](https://codecov.io/gh/projectmesa/mesa)
 [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![chat](https://img.shields.io/matrix/project-mesa:matrix.org?label=chat&logo=Matrix)](https://matrix.to/#/#project-mesa:matrix.org)
+[![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
 
 Mesa allows users to quickly create agent-based models using built-in
 core components (such as spatial grids and agent schedulers) or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
-requires = [
-    "setuptools",
-    "wheel",
-]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "Mesa"
@@ -73,12 +70,11 @@ repository = "https://github.com/projectmesa/mesa"
 [project.scripts]
 mesa = "mesa.main:cli"
 
-[tool.setuptools.packages.find]
-include = ["mesa*"]
-exclude = ["tests*"]
+[tool.hatch.build.targets.wheel]
+packages = ["mesa"]
 
-[tool.setuptools.dynamic]
-version = {attr = "mesa.__version__"}
+[tool.hatch.version]
+path = "mesa/__init__.py"
 
 [tool.ruff]
 # See https://github.com/charliermarsh/ruff#rules for error code definitions.


### PR DESCRIPTION
Depends on #1870 to be merged.

Several resources recommended to replace setuptools with either Flit, Hatch, Poetry, or PDM. Both Flit and Hatch are maintained by PyPA. Flit is restricted to pure Python projects. According to [pyOpenSci](https://www.pyopensci.org/python-package-guide/package-structure-code/python-package-build-tools.html), PDM's documentation can be confusing, and has only 1 maintainer. That leaves Hatch and Poetry. There was a discussion about dropping Pipenv and instead support Poetry. I wasn't able to find the thread from the issue search. However, it should be fine to go from setuptools to Hatch first, because the jump is much smaller: the diff for pyproject.toml in this PR is <10 LOC.