### PR TITLE
fix: Do render_in_jupyter on Colab env

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -152,7 +152,8 @@ def JupyterViz(
             on_grid_layout=set_grid_layout,
         )
 
-    if "ipykernel" in sys.argv[0]:
+    if ("ipykernel" in sys.argv[0]) or ("colab_kernel_launcher.py" in sys.argv[0]):
+        # When in Jupyter or Google Colab
         render_in_jupyter()
     else:
         render_in_browser()


### PR DESCRIPTION
Tested on a Colab instance, and confirmed that `("colab_kernel_launcher.py" in sys.argv[0])` evaluates to `True` in the Colab env, but I found that it does render_in_jupyter regardless of this conditional.