### PR TITLE
Native support for multiple agent types

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -42,11 +42,11 @@ class Agent:
         self.pos: Position | None = None
 
         # Register the agent with the model using defaultdict
-        self.model.agents[type(self)].add(self)
+        self.model.agents[type(self)].append(self)
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""
-        self.model.agents[type(self)].discard(self)
+        self.model.agents[type(self)].remove(self)
 
     def step(self) -> None:
         """A single step of the agent."""

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -20,18 +20,33 @@ if TYPE_CHECKING:
 
 
 class Agent:
-    """Base class for a model agent."""
+    """
+    Base class for a model agent in Mesa.
+
+    Attributes:
+        unique_id (int): A unique identifier for this agent.
+        model (Model): A reference to the model instance.
+        self.pos: Position | None = None
+    """
 
     def __init__(self, unique_id: int, model: Model) -> None:
-        """Create a new agent.
+        """
+        Create a new agent.
 
         Args:
-            unique_id (int): A unique numeric identified for the agent
-            model: (Model): Instance of the model that contains the agent
+            unique_id (int): A unique identifier for this agent.
+            model (Model): The model instance in which the agent exists.
         """
         self.unique_id = unique_id
         self.model = model
         self.pos: Position | None = None
+
+        # Register the agent with the model using defaultdict
+        self.model.agents[type(self)].add(self)
+
+    def remove(self) -> None:
+        """Remove and delete the agent from the model."""
+        self.model.agents[type(self)].discard(self)
 
     def step(self) -> None:
         """A single step of the agent."""

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -42,11 +42,11 @@ class Agent:
         self.pos: Position | None = None
 
         # Register the agent with the model using defaultdict
-        self.model.agents[type(self)].append(self)
+        self.model.agents[type(self)][self] = None
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""
-        self.model.agents[type(self)].remove(self)
+        self.model.agents[type(self)].pop(self)
 
     def step(self) -> None:
         """A single step of the agent."""

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -17,7 +17,18 @@ from mesa.datacollection import DataCollector
 
 
 class Model:
-    """Base class for models."""
+    """Base class for models in the Mesa ABM library.
+
+    This class serves as a foundational structure for creating agent-based models.
+    It includes the basic attributes and methods necessary for initializing and
+    running a simulation model.
+
+    Attributes:
+        running: A boolean indicating if the model should continue running.
+        schedule: An object to manage the order and execution of agent steps.
+        current_id: A counter for assigning unique IDs to agents.
+        agents: A defaultdict mapping each agent type to a set of its instances.
+    """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
         """Create a new model object and instantiate its RNG automatically."""
@@ -32,11 +43,8 @@ class Model:
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a new model. Overload this method with the actual code to
-        start the model.
-
-        Attributes:
-            schedule: schedule object
-            running: a bool indicating if the model should continue running
+        start the model. Always start with super().__init__() to initialize the
+        model object properly.
         """
 
         self.running = True

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -27,7 +27,8 @@ class Model:
         running: A boolean indicating if the model should continue running.
         schedule: An object to manage the order and execution of agent steps.
         current_id: A counter for assigning unique IDs to agents.
-        agents: A defaultdict mapping each agent type to a list of its instances.
+        agents: A defaultdict mapping each agent type to a dict of its instances.
+                Agent instances are saved in the nested dict keys, with the values being None.
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
@@ -50,7 +51,7 @@ class Model:
         self.running = True
         self.schedule = None
         self.current_id = 0
-        self.agents: defaultdict[type, list] = defaultdict(list)
+        self.agents: defaultdict[type, dict] = defaultdict(dict)
 
     @property
     def agent_types(self) -> list:

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -27,7 +27,7 @@ class Model:
         running: A boolean indicating if the model should continue running.
         schedule: An object to manage the order and execution of agent steps.
         current_id: A counter for assigning unique IDs to agents.
-        agents: A defaultdict mapping each agent type to a set of its instances.
+        agents: A defaultdict mapping each agent type to a list of its instances.
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
@@ -50,7 +50,7 @@ class Model:
         self.running = True
         self.schedule = None
         self.current_id = 0
-        self.agents: defaultdict[type, set] = defaultdict(set)
+        self.agents: defaultdict[type, list] = defaultdict(list)
 
     @property
     def agent_types(self) -> list:

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -8,6 +8,7 @@ Core Objects: Model
 from __future__ import annotations
 
 import random
+from collections import defaultdict
 
 # mypy
 from typing import Any
@@ -41,6 +42,12 @@ class Model:
         self.running = True
         self.schedule = None
         self.current_id = 0
+        self.agents: defaultdict[type, set] = defaultdict(set)
+
+    @property
+    def agent_types(self) -> list:
+        """Return a list of different agent types."""
+        return list(self.agents.keys())
 
     def run_model(self) -> None:
         """Run the model until the end condition is reached. Overload as

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,16 @@
+from mesa.agent import Agent
+from mesa.model import Model
+
+
+def test_agent_removal():
+    class TestAgent(Agent):
+        pass
+
+    model = Model()
+    agent = TestAgent(model.next_id(), model)
+    # Check if the agent is added
+    assert agent in model.agents[type(agent)]
+
+    agent.remove()
+    # Check if the agent is removed
+    assert agent not in model.agents[type(agent)]

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -55,6 +55,7 @@ class MockModel(Model):
     schedule = BaseScheduler(None)
 
     def __init__(self):
+        super().__init__()
         self.schedule = BaseScheduler(self)
         self.model_val = 100
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,4 @@
+from mesa.agent import Agent
 from mesa.model import Model
 
 
@@ -40,3 +41,13 @@ def test_reset_randomizer(newseed=42):
     assert model._seed == oldseed
     model.reset_randomizer(seed=newseed)
     assert model._seed == newseed
+
+
+def test_agent_types():
+    class TestAgent(Agent):
+        pass
+
+    model = Model()
+    test_agent = TestAgent(model.next_id(), model)
+    assert test_agent in model.agents[type(test_agent)]
+    assert type(test_agent) in model.agent_types

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -71,6 +71,7 @@ class MockModel(Model):
                               'staged' creates a StagedActivation scheduler.
                               The default scheduler is a BaseScheduler.
         """
+        super().__init__()
         self.log = []
         self.enable_kill_other_agent = enable_kill_other_agent
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -33,6 +33,7 @@ class MockModel(Model):
     """Test model for testing"""
 
     def __init__(self, width, height, key1=103, key2=104):
+        super().__init__()
         self.width = width
         self.height = height
         self.key1 = (key1,)


### PR DESCRIPTION
_On 2023-12-17 this PR was fully updated based on all feedback._

This PR adds a new `agents` dictionary to the Mesa `Model` class, enabling native support for handling multiple agent types within models. This way all modules can know which agents and agents type are in the model at any given time, by calling `model.agents`.

#### Motivation
NetLogo has had agent types, called [`breeds`](https://ccl.northwestern.edu/netlogo/docs/dict/breed.html), built-in from the start. It works perfectly in all NetLogo components, because it's a first class citizen and all components need to be designed to consider different breeds.

In Mesa, agent types are an afterthought at best. Almost nothing is currently designed with multiple agent types in mind. That has caused several issues and limitations over the years, including:

- https://github.com/projectmesa/mesa/pull/348
- https://github.com/projectmesa/mesa/pull/1142
- https://github.com/projectmesa/mesa/pull/1162

Especially in scheduling, space and datacollection, lack of a native, consistent construct for agent types severely limits the possibilities. With the discussion about patches and "empty" this discussion done again. You might want empty to refer to all agents or only a subset of types or single type. That's currently cumbersome to implement.

Basically, by always having dictionary available of which agents of which types are in the model, you can always trust on a consistent construct to iterate over agents and agent types.

#### Conceptualisation
@tpike3 has made a really nice conceptual overview how Mesa now looks with this construct:

![Screenshot_312](https://github.com/projectmesa/mesa/assets/15776622/a72417ff-c401-4cfd-9af3-b8e471e4fd51)

#### Implementation Details
- The `Model` class now uses a `defaultdict(list)` to manage agents. This eliminates the need for explicit checks when adding new agent types.
- Updated the `Agent` class to automatically register itself with the model upon creation, leveraging the `defaultdict` functionality.
- Modified the `remove` method in the `Agent` class, ensuring safe removal of agents.

#### Advantages
In the agent initialization, the agent gets added to the Model's `agents` dictionary. Thereby, you can always, from everywhere:
- Acces the available agent types (using the `model.agent_types` property)
- Iterate over the different agent types, by:
  ```Python
  for agent_type, agents in self.agents.items():
      yield agent_type, agents
  ```
- Get all the agents of a certain type by `model.agents_by_type[AgentType]`

This will make proper multiple agent support in all Mesa components (the scheduler, grid, datacollector and visualisation) easier, because there is now a consistent model variable they can access.

#### Backwards compatibility
This PR itself breaks nothing, it just adds a dictionary to the model.

If you have a single agent, looping over the agents will just mean that only one agent type is iterated over (since there is always at least one agent type). So this work well with both model with a single and multiple agent types.

#### Future implications
While this PR itself won't break current models, if we modify the scheduler, datacollector or grids to use this construct, it might start breaking models. By using weak references ([`weakref`](https://docs.python.org/3/library/weakref.html)), we might be able to limit backwards breaking changes.

#### Review
Since this is a very important change to the core of Mesa, I recommend really critically reviewing this PR, both conceptually (what are the implications for users) and implementation wise (is this the most efficient, scalable and flexible solution).

Any feedback is appreciated!