### PR TITLE
space: Let move_agent choose from multiple positions

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -431,6 +431,54 @@ class _Grid:
         self.remove_agent(agent)
         self.place_agent(agent, pos)
 
+    def move_agent_to_one_of(
+        self,
+        agent: Agent,
+        pos: list[Coordinate],
+        selection: str = "random",
+    ) -> None:
+        """
+        Move an agent to one of the given positions.
+
+        Args:
+            agent: Agent object to move. Assumed to have its current location stored in a 'pos' tuple.
+            pos: List of possible positions.
+            selection: String, either "random" (default) or "closest". If "closest" is selected and multiple
+                       cells are the same distance, one is chosen randomly.
+        """
+        # Handle list of positions
+        if selection == "random":
+            chosen_pos = agent.random.choice(pos)
+        elif selection == "closest":
+            current_pos = agent.pos
+            # Find the closest position without sorting all positions
+            closest_pos = None
+            min_distance = float("inf")
+            for p in pos:
+                distance = self._distance_squared(p, current_pos)
+                if distance < min_distance:
+                    min_distance = distance
+                    closest_pos = p
+            chosen_pos = closest_pos
+        else:
+            raise ValueError(
+                f"Invalid selection method {selection}. Choose 'random' or 'closest'."
+            )
+
+        # Move agent
+        self.move_agent(agent, chosen_pos)
+
+    def _distance_squared(self, pos1: Coordinate, pos2: Coordinate) -> float:
+        """
+        Calculate the squared Euclidean distance between two points for performance.
+        """
+        # Use squared Euclidean distance to avoid sqrt operation
+        dx, dy = abs(pos1[0] - pos2[0]), abs(pos1[1] - pos2[1])
+        if self.torus:
+            dx = min(dx, self.width - dx)
+            dy = min(dy, self.height - dy)
+        return dx**2 + dy**2
+
     def swap_pos(self, agent_a: Agent, agent_b: Agent) -> None:
         """Swap agents positions"""
         agents_no_pos = []

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -408,6 +408,30 @@ class TestSingleGridTorus(unittest.TestCase):
                 agent, possible_positions, selection="invalid_option"
             )
 
+    def test_move_agent_empty_list(self):
+        agent = self.agents[0]
+        possible_positions = []
+        agent.pos = (3, 3)
+        self.space.move_agent_to_one_of(agent, possible_positions, selection="random")
+        assert agent.pos == (3, 3)
+
+    def test_move_agent_empty_list_warning(self):
+        agent = self.agents[0]
+        possible_positions = []
+        # Should assert RuntimeWarning
+        with self.assertWarns(RuntimeWarning):
+            self.space.move_agent_to_one_of(
+                agent, possible_positions, selection="random", handle_empty="warning"
+            )
+
+    def test_move_agent_empty_list_error(self):
+        agent = self.agents[0]
+        possible_positions = []
+        with self.assertRaises(ValueError):
+            self.space.move_agent_to_one_of(
+                agent, possible_positions, selection="random", handle_empty="error"
+            )
+
     def test_distance_squared_torus(self):
         pos1 = (0, 0)
         pos2 = (49, 49)

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -327,6 +327,33 @@ class TestSingleGrid(unittest.TestCase):
         assert self.space[initial_pos[0]][initial_pos[1]] is None
         assert self.space[final_pos[0]][final_pos[1]] == _agent
 
+    def test_move_agent_random_selection(self):
+        agent = self.agents[0]
+        possible_positions = [(10, 10), (20, 20), (30, 30)]
+        self.space.move_agent_to_one_of(agent, possible_positions, selection="random")
+        assert agent.pos in possible_positions
+
+    def test_move_agent_closest_selection(self):
+        agent = self.agents[0]
+        agent.pos = (5, 5)
+        possible_positions = [(6, 6), (10, 10), (20, 20)]
+        self.space.move_agent_to_one_of(agent, possible_positions, selection="closest")
+        assert agent.pos == (6, 6)
+
+    def test_move_agent_invalid_selection(self):
+        agent = self.agents[0]
+        possible_positions = [(10, 10), (20, 20), (30, 30)]
+        with self.assertRaises(ValueError):
+            self.space.move_agent_to_one_of(
+                agent, possible_positions, selection="invalid_option"
+            )
+
+    def test_distance_squared(self):
+        pos1 = (3, 4)
+        pos2 = (0, 0)
+        expected_distance_squared = 3**2 + 4**2
+        assert self.space._distance_squared(pos1, pos2) == expected_distance_squared
+
     def test_iter_cell_list_contents(self):
         """
         Test neighborhood retrieval
@@ -348,6 +375,44 @@ class TestSingleGrid(unittest.TestCase):
             self.space.iter_cell_list_contents((TEST_AGENTS_GRID[0], (0, 0)))
         )
         assert len(cell_list_4) == 1
+
+
+class TestSingleGridTorus(unittest.TestCase):
+    def setUp(self):
+        self.space = SingleGrid(50, 50, True)  # Torus is True here
+        self.agents = []
+        for i, pos in enumerate(TEST_AGENTS_GRID):
+            a = MockAgent(i, None)
+            self.agents.append(a)
+            self.space.place_agent(a, pos)
+
+    def test_move_agent_random_selection(self):
+        agent = self.agents[0]
+        possible_positions = [(49, 49), (1, 1), (25, 25)]
+        self.space.move_agent_to_one_of(agent, possible_positions, selection="random")
+        assert agent.pos in possible_positions
+
+    def test_move_agent_closest_selection(self):
+        agent = self.agents[0]
+        agent.pos = (0, 0)
+        possible_positions = [(3, 3), (49, 49), (25, 25)]
+        self.space.move_agent_to_one_of(agent, possible_positions, selection="closest")
+        # Expecting (49, 49) to be the closest in a torus grid
+        assert agent.pos == (49, 49)
+
+    def test_move_agent_invalid_selection(self):
+        agent = self.agents[0]
+        possible_positions = [(10, 10), (20, 20), (30, 30)]
+        with self.assertRaises(ValueError):
+            self.space.move_agent_to_one_of(
+                agent, possible_positions, selection="invalid_option"
+            )
+
+    def test_distance_squared_torus(self):
+        pos1 = (0, 0)
+        pos2 = (49, 49)
+        expected_distance_squared = 1**2 + 1**2  # In torus, these points are close
+        assert self.space._distance_squared(pos1, pos2) == expected_distance_squared
 
 
 class TestSingleNetworkGrid(unittest.TestCase):


### PR DESCRIPTION
This PR enables the `move_agent` method to take a list of potential positions and offering two selection strategies: random and closest.

This allows any subset of potential positions to be inputted, like an neighborhood, list of empty cells, etc.

Furthermore, it will help with #1898 when cells are selected based on properties.

### New features

1. **Flexible Position Handling**: The `move_agent` method can now accept a single position or a list of possible positions for agent movement.

2. **Selection Strategies**: 
    - `random`: Selects a position randomly from the provided list.
    - `closest`: Chooses the position closest to the agent's current location. In case of ties, a position is selected randomly from the closest ones.

### Usage examples

1. **Moving to a Random Position**:
   ```python
   space.move_agent(agent, possible_positions, selection='random')
   ```

2. **Moving to the Closest Position**:
   ```python
   space.move_agent(agent, possible_positions, selection='closest')
   ```

### Limitations
- This currently only works for Grids, not for ContiniousSpace.