### PR TITLE
Add experimental warning to DiscreteEventScheduler

### DIFF
--- a/mesa/time.py
+++ b/mesa/time.py
@@ -26,6 +26,7 @@ Key concepts:
 from __future__ import annotations
 
 import heapq
+import warnings
 from collections import defaultdict
 
 # mypy
@@ -378,6 +379,13 @@ class DiscreteEventScheduler(BaseScheduler):
         super().__init__(model)
         self.event_queue: list[tuple[TimeT, float, Agent]] = []
         self.time_step: TimeT = time_step  # Fixed time period for each step
+
+        warnings.warn(
+            "The DiscreteEventScheduler is experimental. It may be changed or removed in any and all future releases, including patch releases.\n"
+            "We would love to hear what you think about this new feature. If you have any thoughts, share them with us here: https://github.com/projectmesa/mesa/discussions/1923",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     def schedule_event(self, time: TimeT, agent: Agent) -> None:
         """Schedule an event for an agent at a specific time."""


### PR DESCRIPTION
Mark the DiscreteEventScheduler (added in #1890) as experimental for now. Feedback can be collected in discussion #1923.

![Screenshot_320](https://github.com/projectmesa/mesa/assets/15776622/c69e2151-facf-40f1-9b7a-449b761eb9ae)

@Corvince and @tpike3 please review and merge.