### PR TITLE
Work around for initializing model._agent

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -11,6 +11,7 @@ import contextlib
 import operator
 import warnings
 import weakref
+from collections import defaultdict
 from collections.abc import MutableSet, Sequence
 from random import Random
 
@@ -47,12 +48,25 @@ class Agent:
         self.pos: Position | None = None
 
         # register agent
-        self.model._agents[type(self)][self] = None
+        try:
+            self.model._agents[type(self)][self] = None
+        except AttributeError:
+            # model super has not been called
+            self.model._agents = defaultdict(dict)
+            self.model.agentset_experimental_warning_given = False
+
+            warnings.warn(
+                "In the future, you need to explicitly initialize the model by calling super().__init__",
+                FutureWarning,
+                stacklevel=2,
+            )
+
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""
         with contextlib.suppress(KeyError):
             self.model._agents[type(self)].pop(self)
+
 
     def step(self) -> None:
         """A single step of the agent."""

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -56,7 +56,7 @@ class Agent:
             self.model.agentset_experimental_warning_given = False
 
             warnings.warn(
-                "In the future, you need to explicitly initialize the model by calling super().__init__",
+                "The Mesa Model class wasn’t initialized. In the future, you need to explicitly initialize the Model by calling super().__init__() on initialization.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -85,7 +85,7 @@ class Model:
 
     def get_agents_of_type(self, agenttype: type) -> AgentSet:
         """Retrieves an AgentSet containing all agents of the specified type."""
-        return AgentSet(self._agents[agenttype].values(), self)
+        return AgentSet(self._agents[agenttype].keys(), self)
 
     def run_model(self) -> None:
         """Run the model until the end condition is reached. Overload as


### PR DESCRIPTION
In response to the discussion in #1917, this PR contains a simple workaround if model._agent has not been set up because `super().__init__` was not called when subclassing `Model`. 

It also fixes the bug mentioned in #1917 regarding `model.get_agents_of_type`.