### PR TITLE
Add system state tracking

### DIFF
--- a/mesa/system_state.py
+++ b/mesa/system_state.py
@@ -1,0 +1,119 @@
+import functools
+from weakref import finalize
+
+
+def accessor_method(column_name, self):
+    return {k: v.value for k, v in self.columnsdict[column_name].items()}
+
+
+class SystemState:
+    # in principle are all columns knowable upfront
+    # they are declared as part of the class definition
+    # so __set_name__ could be used to register them as
+    # column labels as well
+
+    def __init__(self):
+        self.rowsdict = {}
+        self.columnsdict = {}
+        self.datadict = {}
+
+    def get_column(self, column_label):
+        return self.columnsdict[column_label]
+
+    def get_row(self, row_label):
+        return self.rowsdict[row_label]
+
+    def get_field(self, row_label, column_label):
+        try:
+            return self.datadict[(row_label, column_label)]
+        except KeyError:
+            return self._add_field(row_label, column_label)
+
+
+    def _add_field(self, row_label, column_label):
+
+        if row_label not in self.rowsdict:
+            self.rowsdict[row_label] = {}
+
+        if column_label not in self.columnsdict:
+            self.columnsdict[column_label] = {}
+
+            # nerdy trick to allow attribute access to columns
+            # while returns the values of the fields instead the fields
+            # itself.
+            m = functools.partial(accessor_method, column_label)
+            setattr(SystemState, column_label, property(fget=m))
+
+        field = Field()
+        self.rowsdict[row_label][column_label] = field
+        self.columnsdict[column_label][row_label] = field
+        self.datadict[(row_label, column_label)] = field
+        return field
+
+    def remove_row(self, row_label):
+        row = self.rowsdict.pop(row_label)
+        for column_label in row:
+            try:
+                del self.columnsdict[row_label][column_label]
+                del self.datadict[(row_label, column_label)]
+            except KeyError:
+                pass
+
+    def remove_column(self, column_label):
+        column = self.columnsdict.pop(column_label)
+        for row_label in column:
+            del self.rowsdict[row_label][column_label]
+            del self.datadict[(row_label, column_label)]
+
+class Field:
+    def __init__(self):
+        self.value = None
+
+
+class State:
+
+    def __get__(self, instance, owner):
+        return getattr(instance, self.private_name)
+
+    def __set_name__(self, owner, name):
+        self.public_name = name
+        self.private_name = f"_{name}"
+        self.private_field = f"_{name}_field"
+
+
+def remover(key, system_state):
+    system_state.remove_row(key)
+
+
+class AgentState(State):
+    def __set__(self, instance, value):
+        key = instance.unique_id
+
+        try:
+            field = getattr(instance, self.private_field)
+        except AttributeError:
+            system_state = instance.model.system_state
+            field = system_state.get_field(key, self.public_name)
+            setattr(instance, self.private_field, field)
+
+            if not hasattr(instance, "_finalizer_set"):
+                finalize(instance, remover, instance.unique_id, system_state)
+                instance._finalizer_set = True
+
+        field.value = value
+        setattr(instance, self.private_name, value)
+
+
+class ModelState(State):
+    def __set__(self, instance, value):
+        key = "model"
+
+        try:
+            field = getattr(instance, self.private_field)
+        except AttributeError:
+            system_state = instance.system_state
+            field = system_state.get_field(key, self.public_name)
+            setattr(instance, self.private_field, field)
+
+        field.value = value
+        setattr(instance, self.private_name, value)


### PR DESCRIPTION
This PR adds functionality for tracking the overall system state. It builds on discussions in #574 and #1930. A key design choice is that only attributes that are explicitly declared to be part of the system state are being tracked. This can be done using the `AgentState` and `ModelState` descriptors. It is at the moment fully backward compatible: it just adds a new optional feature.

This PR is a first draft implementation and open for feedback, suggestions, and improvements. 

# Key changes
To be able to track the overall system state, this PR adds 4 new classes: `SystemState`, `AgentState`, `ModelState`, and the helper class `Field`. `SystemState` is to be used within the model instance and is a singleton (not explicitly enforced). `SystemState` is in essence a sparse matrix with object identifiers (`"model"` or `agent.unique_id` at the moment) for rows, and the attribute names for columns. A given object identifier and attribute name point to a `Field` instance. This is a helper class with only a value attribute (see implementation details below). AgentState and ModelState are [descriptors](https://realpython.com/python-descriptors/). Only attributes declared as AgenState or ModelState are tracked in the SystemState. 

# Usage examples

**1. Initialize the system state object**

The current implementation leaves SystemState as optional, but assumes that if used it is assigned to `self.system_state`. I would, in the future, make this default behavior and just move `self.system_state = SystemState()` to `Model.__init__`.

```python
class MoneyModel(Model):
    """A model with some number of agents.

    Parameters
    N : int
        the number of agents in the space
    width : int
            the width of the space
    height : int
             the height of the space
    """

    def __init__(self, N, width, height):
        super().__init__()
        self.system_state = SystemState()

```


**2. declare an agent state or model state as observable**

To enable state variables to be tracked in the system state, the relevant attribute has to de declared as an `AgentState` or `ModelState`. This assigns the relevant descriptor to this attribute. Any object can be assigned to the attribute. Tracking of the state starts with the first assignment to the attribute. So, `wealth = AgentState()` makes `wealth` observable, but tracking only starts once `self.wealth = 1` is executed. This triggers the `__set__` method on the descriptor, which registers the agent with the system state and retrieves the relevant field in which to store the state. Any new assignment to `self.wealth` results in an update in the system state as well. If an agent is garbage collected, the agent is automatically removed from the system state (using `weakref.finalize`). 

```python
class MoneyAgent(Agent):
    """ An agent with fixed initial wealth."""
    wealth = AgentState()

    def __init__(self, unique_id, model):
        super().__init__(unique_id, model)
        self.wealth = 1


class MoneyModel(Model):
	gini = ModelState()

```


**3. fast querying of system state**

The system state is designed for rapid access by both row and column. This is particularly useful for data collection. For example, below, we have `compute_gini` from the Boltzman wealth model. Rather than having to get the wealth from all agents, we can simply get the relevant wealth column from the system state. Note also how we can access the column in an attribute-like manner (i.e., `system_state.wealth`). This returns a dict with object identifiers as keys and the states (so not the Fields) as values.

```python

def compute_gini(model):
    x = sorted(model.system_state.wealth.values())

```

# implementation details, choices, and assumptions
The basic structure of this PR rests on the use of descriptors for tracking state attributes. Descriptors offer a highly performant way to control accessing and setting attributes. It also offers users full control over which attributes should be tracked as part of the system state and which ones can be ignored. Thus, there is no need to make any assumptions about this within MESA itself (contra #574). In the current implementation, declaring that a given attribute is observable (i.e., to be tracked) happens at the class level. So in principle the specified attribute is observable for all instances of the class. However, because tracking only starts with the first assignment to the attribute within the instance, it is possible to have more fine grained control over what is being tracked and when. Also, tracking is automatically stopped once an instance is garbage collected, preventing memory leaks. 

SystemState is currently implemented as a sparse matrix using a bunch of dictionaries. The key design consideration was to have rapid access to both individual rows (i.e., all object attributes being tracked) and individual columns (i.e., a given attribute being tracked for Class). I briefly looked at the sparse matrices in SciPy, but those won't work because you cannot have `dtype=object`. I later discovered that there is a sparse dataframe in pandas. I haven't tested this yet but I am happy to do so if desired. 

The current implementation uses the `Field` helper class. Each active cell in the SystemState is a `Field` instance. `Field` only has a `value ` attribute which is the value of the instance state attribute we want to track. I chose to do it this way, because it allows for rapid updating of values in the system state. Below, you see the `__set___` method for `AgentState`. As you can see, first, we try to retrieve the relevant Field instance from the Agent instance (`field = getattr(instance, self.private_field)`). If this succeeds, the agent attribute combination is actively being tracked, so we can just assign the new value directly ('field.value = value'). Otherwise, the agent attribute combination needs to be added to the system state. 

```python
    def __set__(self, instance, value):
        key = instance.unique_id

        try:
            field = getattr(instance, self.private_field)
        except AttributeError:
            system_state = instance.model.system_state
            field = system_state.get_field(key, self.public_name)
            setattr(instance, self.private_field, field)

            if not hasattr(instance, "_finalizer_set"):
                finalize(instance, remover, instance.unique_id, system_state)
                instance._finalizer_set = True

        field.value = value
        setattr(instance, self.private_name, value)

```
An alternative implementation could be to just store the row and column identifier and set the value on the relevant dicts in the `SystemState`. However this requires a lookup in 3 dicts each time you do so. Lookup in dicts are an order of magnitude slower than setting a value on an object. 

In #1930, there was a short discussion on event tracking using the Observer design pattern. This PR does not yet add this. However, it would be quite easy to built on this PR if you want to track SystemStateChange events. For example, you could modify Field to fire such an event each time `Field.value` is set to a new value. 


## performance implications
some quick tests on the Boltzman wealth model suggests that there is a performance penalty for adding the system state. The model is about 16% slower with just the system state and the rest kept the same. However, once  system state is used in data collection, it is actually about 10% faster. To fully realize this performance gain, however, requires a more elaborate rewrite and rethink of the `DataCollector`. The Boltzman wealth model is a bit of worst case model for testing the system state, because it can have many updates to `agent.wealth` within a single tick while there is no further expensive logic within the model. 

