### PR TITLE
model: Move random seed and random to __init__

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -59,7 +59,7 @@ class Model:
         start the model. Always start with super().__init__() to initialize the
         model object properly.
         """
-
+        super().__init__(*args, **kwargs)
         self.running = True
         self.schedule = None
         self.steps: int = 0

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -59,7 +59,6 @@ class Model:
         start the model. Always start with super().__init__() to initialize the
         model object properly.
         """
-        super().__init__()
         self.running = True
         self.schedule = None
         self.steps: int = 0

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -73,9 +73,6 @@ class Model:
             self._seed = random.random()
         self.random = random.Random(self._seed)
 
-        self._steps: int = 0
-        self._time: TimeT = 0  # the model's clock
-
         # Wrap the user-defined step method
         self._user_step = self.step
         self.step = self._wrapped_step

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -59,7 +59,7 @@ class Model:
         start the model. Always start with super().__init__() to initialize the
         model object properly.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__()
         self.running = True
         self.schedule = None
         self.steps: int = 0

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -48,7 +48,7 @@ class Model:
         initialize_data_collector: Sets up the data collector for the model, requiring an initialized scheduler and agents.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, seed: float | None = None, **kwargs: Any) -> None:
         """Create a new model. Overload this method with the actual code to
         start the model. Always start with super().__init__() to initialize the
         model object properly.
@@ -59,7 +59,7 @@ class Model:
         self.current_id = 0
         self.agents_: defaultdict[type, dict] = defaultdict(dict)
 
-        self._seed = kwargs.get("seed")
+        self._seed = seed
         if self._seed is None:
             # We explicitly specify the seed here so that we know its value in
             # advance.

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -48,20 +48,6 @@ class Model:
         initialize_data_collector: Sets up the data collector for the model, requiring an initialized scheduler and agents.
     """
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> Any:
-        """Create a new model object and instantiate its RNG automatically."""
-        obj = object.__new__(cls)
-        obj._seed = kwargs.get("seed")
-        if obj._seed is None:
-            # We explicitly specify the seed here so that we know its value in
-            # advance.
-            obj._seed = random.random()
-        obj.random = random.Random(obj._seed)
-        # TODO: Remove these 2 lines just before Mesa 3.0
-        obj._steps = 0
-        obj._time = 0
-        return obj
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a new model. Overload this method with the actual code to
         start the model. Always start with super().__init__() to initialize the
@@ -72,6 +58,13 @@ class Model:
         self.schedule = None
         self.current_id = 0
         self.agents_: defaultdict[type, dict] = defaultdict(dict)
+
+        self._seed = kwargs.get("seed")
+        if self._seed is None:
+            # We explicitly specify the seed here so that we know its value in
+            # advance.
+            self._seed = random.random()
+        self.random = random.Random(self._seed)
 
         self._steps: int = 0
         self._time: TimeT = 0  # the model's clock

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -260,10 +260,8 @@ def ModelCreator(model, model_params, seed=1):
         set_model_parameters({**model_parameters, name: value})
 
     def create_model():
-        model.value = model.value.__class__.__new__(
-            model.value.__class__, **model_parameters, seed=reactive_seed.value
-        )
-        model.value.__init__(**model_parameters)
+        model.value = model.value.__class__(**model_parameters)
+        model.value._seed = reactive_seed.value
 
     solara.use_effect(create_model, [model_parameters, reactive_seed.value])
 

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -127,10 +127,8 @@ def SolaraViz(
     # 2. Set up Model
     def make_model():
         """Create a new model instance with current parameters and seed."""
-        model = model_class.__new__(
-            model_class, **model_parameters, seed=reactive_seed.value
-        )
-        model.__init__(**model_parameters)
+        model = model_class(**model_parameters)
+        model._seed = reactive_seed.value
         current_step.value = 0
         return model
 

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -89,7 +89,6 @@ def test_call_space_drawer(mocker):
     )
 
     model = mesa.Model()
-    mocker.patch.object(mesa.Model, "__new__", return_value=model)
     mocker.patch.object(mesa.Model, "__init__", return_value=None)
 
     agent_portrayal = {

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -71,7 +71,7 @@ class MockModel(Model):
                               'staged' creates a StagedActivation scheduler.
                               The default scheduler is a BaseScheduler.
         """
-        super().__init__()
+        super().__init__(seed=None)
         self.log = []
         self.enable_kill_other_agent = enable_kill_other_agent
 
@@ -114,12 +114,7 @@ class TestStagedActivation(TestCase):
         Testing the staged activation without shuffling.
         """
 
-        try:
-            model = MockModel(shuffle=False)
-        except TypeError as e:
-            print(f"what the f... {mesa.__version__}")
-            raise e
-
+        model = MockModel(shuffle=False)
         model.step()
         model.step()
         assert all(i == j for i, j in zip(model.log[:5], model.log[5:]))

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -116,8 +116,9 @@ class TestStagedActivation(TestCase):
 
         try:
             model = MockModel(shuffle=False)
-        except TypeError:
+        except TypeError as e:
             print(f"what the f... {mesa.__version__}")
+            raise e
 
         model.step()
         model.step()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -5,7 +5,9 @@ Test the advanced schedulers.
 import unittest
 from unittest import TestCase, mock
 
-from mesa import Agent, Model
+import mesa
+from mesa.agent import Agent
+from mesa.model import Model
 from mesa.time import (
     BaseScheduler,
     RandomActivation,
@@ -111,7 +113,12 @@ class TestStagedActivation(TestCase):
         """
         Testing the staged activation without shuffling.
         """
-        model = MockModel(shuffle=False)
+
+        try:
+            model = MockModel(shuffle=False)
+        except TypeError:
+            print(f"what the f... {mesa.__version__}")
+
         model.step()
         model.step()
         assert all(i == j for i, j in zip(model.log[:5], model.log[5:]))

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -5,7 +5,6 @@ Test the advanced schedulers.
 import unittest
 from unittest import TestCase, mock
 
-import mesa
 from mesa.agent import Agent
 from mesa.model import Model
 from mesa.time import (

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -70,7 +70,7 @@ class MockModel(Model):
                               'staged' creates a StagedActivation scheduler.
                               The default scheduler is a BaseScheduler.
         """
-        super().__init__(seed=None)
+        super().__init__()
         self.log = []
         self.enable_kill_other_agent = enable_kill_other_agent
 


### PR DESCRIPTION
Given that `super().__init__()` is now necessary for user's model class `__init__()`, the main motivation: this simplifies the `Model` construct.
And  `model.random` can be initialized with other RNG objects (`np.random.default_rng(...)`, or any other RNG).

Prior discussion https://github.com/projectmesa/mesa/discussions/1938.

This is a breaking change and should wait until Mesa 3.0.