### PR TITLE
JupyterViz: Simplify SliderInt and SliderFloat specification using slice

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -282,22 +282,30 @@ def UserInputs(user_params, on_change=None):
             on_change(name, value)
 
         if input_type == "SliderInt":
+            values = options.get("values")
+            min, max, step = None, None, None
+            if values:
+                min, max, step = values.start, values.stop, values.step
             solara.SliderInt(
                 label,
                 value=options.get("value"),
                 on_value=change_handler,
-                min=options.get("min"),
-                max=options.get("max"),
-                step=options.get("step"),
+                min=min,
+                max=max,
+                step=step,
             )
         elif input_type == "SliderFloat":
+            values = options.get("values")
+            min, max, step = None, None, None
+            if values:
+                min, max, step = values.start, values.stop, values.step
             solara.SliderFloat(
                 label,
                 value=options.get("value"),
                 on_value=change_handler,
-                min=options.get("min"),
-                max=options.get("max"),
-                step=options.get("step"),
+                min=min,
+                max=max,
+                step=step,
             )
         elif input_type == "Select":
             solara.Select(

--- a/tests/test_jupyter_viz.py
+++ b/tests/test_jupyter_viz.py
@@ -31,9 +31,7 @@ class TestMakeUserInput(unittest.TestCase):
             "type": "SliderInt",
             "value": 10,
             "label": "number of agents",
-            "min": 10,
-            "max": 20,
-            "step": 1,
+            "values": slice(10, 20, 1),
         }
         user_params = {"num_agents": options}
         _, rc = solara.render(Test(user_params), handle_error=False)
@@ -41,9 +39,9 @@ class TestMakeUserInput(unittest.TestCase):
 
         assert slider_int.v_model == options["value"]
         assert slider_int.label == options["label"]
-        assert slider_int.min == options["min"]
-        assert slider_int.max == options["max"]
-        assert slider_int.step == options["step"]
+        assert slider_int.min == options["values"].start
+        assert slider_int.max == options["values"].stop
+        assert slider_int.step == options["values"].step
 
     def test_checkbox(self):
         @solara.component


### PR DESCRIPTION
With this PR, instead of the lengthy [`model_params`](https://github.com/projectmesa/mesa-examples/blob/8f6e0437541e66f247b34c97bb732b4cbb73a254/examples/schelling_experimental/app.py#L17-L44)

```python
model_params = {
    "density": {
        "type": "SliderFloat",
        "value": 0.8,
        "label": "Agent density",
        "min": 0.1,
        "max": 1.0,
        "step": 0.1,
    },
    "minority_pc": {
        "type": "SliderFloat",
        "value": 0.2,
        "label": "Fraction minority",
        "min": 0.0,
        "max": 1.0,
        "step": 0.05,
    },
    "homophily": {
        "type": "SliderInt",
        "value": 3,
        "label": "Homophily",
        "min": 0,
        "max": 8,
        "step": 1,
    },
    "width": 20,
    "height": 20,
}
```
This becomes
```python
model_params = {
    "density": {
        "type": "SliderFloat",
        "value": 0.8,
        "label": "Agent density",
        "values": slice(0.1, 1.0, 0.1),
    },
    "minority_pc": {
        "type": "SliderFloat",
        "value": 0.2,
        "label": "Fraction minority",
        "values": slice(0.0, 1.0, 0.05),
    },
    "homophily": {
        "type": "SliderInt",
        "value": 3,
        "label": "Homophily",
        "values": slice(0, 8, 1),
    },
    "width": 20,
    "height": 20,
}
```