### PR TITLE
Update version to 2.3.0-dev

### DIFF
--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 __title__ = "mesa"
-__version__ = "2.2.0"
+__version__ = "2.3.0-dev"
 __license__ = "Apache 2.0"
 _this_year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
 __copyright__ = f"Copyright {_this_year} Project Mesa Team"


### PR DESCRIPTION
Update the version number to `2.3.0-dev` for future development. This way, if users install a version from main, they know they have a development version installed.

For 2.2.x patch release I created the [`2.2.x-maintenance`](https://github.com/projectmesa/mesa/tree/2.2.x-maintenance) branch.