### PR TITLE
2.2.x maint: Update version to 2.2.1-dev

### DIFF
--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 __title__ = "mesa"
-__version__ = "2.2.0"
+__version__ = "2.2.1-dev"
 __license__ = "Apache 2.0"
 _this_year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
 __copyright__ = f"Copyright {_this_year} Project Mesa Team"


### PR DESCRIPTION
Update the version number to `2.2.1-dev` for future development. This way, if users install from the [2.2.x-maintenance](https://github.com/projectmesa/mesa/tree/2.2.x-maintenance) branch., they know they have a development version installed.

Note that this PR doesn't target the `main` branch, but the `2.2.x-maintenance` branch.