### PR TITLE
Perf agentset

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -326,8 +326,10 @@ class _Grid:
             at most 9 if Moore, 5 if Von-Neumann
             (8 and 4 if not including the center).
         """
-        neighborhood = self.get_neighborhood(pos, moore, include_center, radius)
-        return self.iter_cell_list_contents(neighborhood)
+        default_val = self.default_val()
+        for x, y in self.get_neighborhood(pos, moore, include_center, radius):
+            if (cell := self._grid[x][y]) != default_val:
+                yield cell
 
     def get_neighbors(
         self,
@@ -385,11 +387,10 @@ class _Grid:
             An iterator of the agents contained in the cells identified in `cell_list`.
         """
         # iter_cell_list_contents returns only non-empty contents.
-        return (
-            cell
-            for x, y in cell_list
-            if (cell := self._grid[x][y]) != self.default_val()
-        )
+        default_val = self.default_val()
+        for x, y in cell_list:
+            if (cell := self._grid[x][y]) != default_val:
+                yield cell
 
     @accept_tuple_argument
     def get_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> list[Agent]:
@@ -1045,6 +1046,17 @@ class MultiGrid(_PropertyGrid):
             self._empty_mask[agent.pos] = False
         agent.pos = None
 
+    def iter_neighbors(
+        self,
+        pos: Coordinate,
+        moore: bool,
+        include_center: bool = False,
+        radius: int = 1,
+    ) -> Iterator[Agent]:
+        return itertools.chain.from_iterable(
+            super().iter_neighbors(pos, moore, include_center, radius)
+        )
+
     @accept_tuple_argument
     def iter_cell_list_contents(
         self, cell_list: Iterable[Coordinate]
@@ -1058,10 +1070,9 @@ class MultiGrid(_PropertyGrid):
         Returns:
             An iterator of the agents contained in the cells identified in `cell_list`.
         """
+        default_val = self.default_val()
         return itertools.chain.from_iterable(
-            cell
-            for x, y in cell_list
-            if (cell := self._grid[x][y]) != self.default_val()
+            cell for x, y in cell_list if (cell := self._grid[x][y]) != default_val
         )
 
 


### PR DESCRIPTION
I fell into a rabbit hole this weekend that I didn't want to fall in anymore, but here we are: I was looking at mesa performance and noticed that the new AgentSet feature took quite some burden on run times. Here are the results on my local machine, manually running 3 model runs for each (so not completely accurate, but indicative enough). I also included the results for this PR

| Mesa Version| Schelling 100x100 for 100 steps |
| --- | --- |
| Mesa 2.1.5 | ~11.8 sec |
| Mesa 2.2.0 | ~18.2 sec|
| Mesa-PR | ~8.9 sec | 

So I think AgentSet had some noticable effect, but through some modifications to AgentSet and also some stuff in Space.py I was able to increase overall performance. 

I think the changes are non-intrusive, but here they are

## Agentset 
I first inherit the weakref from a normal dict instead of adding all agents sequentially
I also added a short-cut for the select function. If you call `AgentSet.select()` you immediately receive a copy the agentset, without triggering any logic for filter-func, etc. The scheduler does this, so it applies to all models using the scheduler.

## Space
I modified iter_cell_list_contents to retrieve the default_val of the space only once. I also rewrote the generator expression to a normal generator, because perfomance is about the same, but it is easier to understand.
Additionally iter_neighbors now returns the content directly instead of the call to iter_cell_list_contents, which is annotated by accept_tuple_arguments, which costed some performance even though we knew its a list of positions. The difference might appear small, but in my model run this generator gets called 6 million times, so even a microsecond faster execution translates to a whole second. 

## Observation: Weakref
With these modifications the use of Weakref became the new bottleneck. Since weakKeyDictionaries are implemented in pure python and not in C, they considerable slower than Agent dictionaries. But I think it is still manageable. 