### PR TITLE
Make RandomActivationByType.agents_by_type backward compatible

### DIFF
--- a/mesa/time.py
+++ b/mesa/time.py
@@ -292,7 +292,7 @@ class RandomActivationByType(BaseScheduler):
     def agents_by_type(self):
         warnings.warn(
             "Because of the shift to using AgentSet, in the future this attribute will return a dict with"
-            "type as key as AgentSet as value",
+            "type as key as AgentSet as value. Future behavior is available via RandomActivationByType._agents_by_type",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -303,7 +303,6 @@ class RandomActivationByType(BaseScheduler):
 
         return agentsbytype
 
-
     def __init__(self, model: Model, agents: Iterable[Agent] | None = None) -> None:
         super().__init__(model, agents)
         """


### PR DESCRIPTION
As #pointed out by @Corvince, `RandomActivationByType.agents_by_typ`e in 2.2 behaved differently from 2.1.5. This is a simple fix for this, with a warning added to raise awareness of future changes. 