### PR TITLE
Quality of Life: Make codecov less meticulous

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+
+ignore:
+  - "**experimental/"
+
+comment: off


### PR DESCRIPTION
If you currently look at the open PRs there is not a single PR that passes all our checks. For most PRs I found that at least Codecov is failing. I think the current settings are a bit too agressive. For example take #1964 . In this This PR restructures some code. Everything is still covered, but because its a single line of code more the overall % of covered lines decreased by 0.07% and the check failed.

In this PR I set the target value for the project to 80% with a 1% threshold. We are currently just above 79% so if this decreases significantly the checks will fail.

I also set it to ignore experimental folders (jupyterviz)

And finally I disabled comments on PR. This might be debatable, but I found myself just ignoring those comments after having seen too many. For me its very similar for checks. I don't notice failed checks sometimes because I am so used to the red cross on Mesa. I hope this will get better with this PR. Additionally it would be great if we could setup pre-commit autoupdating PRs, but this would be in contrast to the ideas proposed in #1963 