### PR TITLE
Run release workflow on the creation of a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 on:
   push:
+    tags:
+    - '*'
     branches:
     - main
     - release**


### PR DESCRIPTION
Currently the release workflow doesn't run on the creation of a tag, and therefore the wheel isn't deployed to PyPI. This PR should fix that.