### PR TITLE
Use Python 3.12 to build Readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ formats:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3"
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Newer Python versions are more performant and thus builds the docs faster, also allowing more notebooks to be rendered with batch runs and complex graphs within the allowed runtime.