### PR TITLE
JupyterViz: Automatically deduce display name from model class

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -17,7 +17,7 @@ def JupyterViz(
     model_class,
     model_params,
     measures=None,
-    name="Mesa Model",
+    name=None,
     agent_portrayal=None,
     space_drawer="default",
     play_interval=150,
@@ -35,6 +35,9 @@ def JupyterViz(
             specify `space_drawer=False`
         play_interval: play interval (default: 150)
     """
+    if name is None:
+        name = model_class.__name__
+
     current_step = solara.use_reactive(0)
 
     # 1. Set up model parameters

--- a/tests/test_jupyter_viz.py
+++ b/tests/test_jupyter_viz.py
@@ -85,6 +85,7 @@ class TestJupyterViz(unittest.TestCase):
     @patch("mesa.experimental.components.matplotlib.SpaceMatplotlib")
     def test_call_space_drawer(self, mock_space_matplotlib):
         mock_model_class = Mock()
+        mock_model_class.__name__ = "MockModelClass"
         agent_portrayal = {
             "Shape": "circle",
             "color": "gray",


### PR DESCRIPTION
From
```python
page = JupyterViz(
    Schelling,
    model_params,
    measures=["happy", make_text(get_happy_agents)],
    name="Schelling",
    agent_portrayal=agent_portrayal,
)
```
to
```python
page = JupyterViz(
    Schelling,
    model_params,
    measures=["happy", make_text(get_happy_agents)],
    agent_portrayal=agent_portrayal,
)

```