### PR TITLE
solara_viz: Add borders around ContinuousSpace

### DIFF
--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -93,14 +93,26 @@ def _draw_continuous_space(space, space_ax, agent_portrayal):
             out["c"] = c
         return out
 
+    # Set light grey background
+    space_ax.set_facecolor('lightgrey')
+
+    # Determine border style based on space.torus
+    border_style = 'solid' if not space.torus else 'dotted'
+
+    # Set the border of the plot
+    for spine in space_ax.spines.values():
+        spine.set_linewidth(1.5)
+        spine.set_color('black')
+        spine.set_linestyle(border_style)
+
     width = space.x_max - space.x_min
     x_padding = width / 20
     height = space.y_max - space.y_min
     y_padding = height / 20
     space_ax.set_xlim(space.x_min - x_padding, space.x_max + x_padding)
     space_ax.set_ylim(space.y_min - y_padding, space.y_max + y_padding)
-    space_ax.scatter(**portray(space))
 
+    # Portray and scatter the agents in the space
     space_ax.scatter(**portray(space))
 
 

--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -96,7 +96,7 @@ def _draw_continuous_space(space, space_ax, agent_portrayal):
     space_ax.set_facecolor('lightgrey')
 
     # Determine border style based on space.torus
-    border_style = 'solid' if not space.torus else 'dotted'
+    border_style = 'solid' if not space.torus else (0, (5, 10))
 
     # Set the border of the plot
     for spine in space_ax.spines.values():

--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -22,7 +22,6 @@ def SpaceMatplotlib(model, agent_portrayal, dependencies: Optional[list[any]] = 
         _draw_continuous_space(space, space_ax, agent_portrayal)
     else:
         _draw_grid(space, space_ax, agent_portrayal)
-    space_ax.set_axis_off()
     solara.FigureMatplotlib(space_fig, format="png", dependencies=dependencies)
 
 

--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -92,9 +92,6 @@ def _draw_continuous_space(space, space_ax, agent_portrayal):
             out["c"] = c
         return out
 
-    # Set light grey background
-    space_ax.set_facecolor('lightgrey')
-
     # Determine border style based on space.torus
     border_style = 'solid' if not space.torus else (0, (5, 10))
 


### PR DESCRIPTION
For all intents and purposes, this should work. However, on my systems, I can't get it to visualise 

It should looks something like this:

![Screenshot_355](https://github.com/projectmesa/mesa/assets/15776622/5c3345b9-5773-4151-8248-393bfdc1fcaf)

But in reality, on my system, it keeps looking like this:

![Screenshot_356](https://github.com/projectmesa/mesa/assets/15776622/126d1268-064b-4d84-bb9a-8aaa7d4326e8)

I can add a title for some reason, but can't add borders or a background color.

Could it be that the background color and spines are overwritten later? @rht @quaquel @ankitk50, if one of you can explain or find the source of this madness, please.