### PR TITLE
Issue1341

### DIFF
--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -1,11 +1,11 @@
-from configurations import configurations
-import gc
 import os
-import pickle
 import sys
+import gc
+import pickle
 import time
 import timeit
 
+from configurations import configurations
 
 # making sure we use this version of mesa and not one
 # also installed in site_packages or so.

--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -11,8 +11,6 @@ from configurations import configurations
 sys.path.insert(0, os.path.abspath(".."))
 
 
-
-
 # Generic function to initialize and run a model
 def run_model(model_class, seed, parameters):
     start_init = timeit.default_timer()

--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 from configurations import configurations  # noqa: E402
 
+
 # Generic function to initialize and run a model
 def run_model(model_class, seed, parameters):
     start_init = timeit.default_timer()

--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -4,12 +4,13 @@ import pickle
 import sys
 import time
 import timeit
+from configurations import configurations
 
 # making sure we use this version of mesa and not one
 # also installed in site_packages or so.
 sys.path.insert(0, os.path.abspath(".."))
 
-from configurations import configurations
+
 
 
 # Generic function to initialize and run a model

--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -1,7 +1,7 @@
-import os
-import sys
 import gc
+import os
 import pickle
+import sys
 import time
 import timeit
 

--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -1,10 +1,11 @@
+from configurations import configurations
 import gc
 import os
 import pickle
 import sys
 import time
 import timeit
-from configurations import configurations
+
 
 # making sure we use this version of mesa and not one
 # also installed in site_packages or so.

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -13,7 +13,7 @@ def batch_run(
     model_cls: type[Model],
     parameters: Mapping[str, Any | Iterable[Any]]],
     # We still retain the Optional[int] because users may set it to None (i.e. use all CPUs)
-    number_processes: Optional[int] = 1,
+    number_processes: Optional[int]= 1,
     iterations: int = 1,
     data_collection_period: int = -1,
     max_steps: int = 1000,

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -13,7 +13,7 @@ def batch_run(
     model_cls: type[Model],
     parameters: Mapping[str, Any | Iterable[Any]],
     # We still retain the Optional[int] because users may set it to None (i.e. use all CPUs)
-    number_processes: Optional[int]= 1,
+    number_processes: Optional[int] = 1,
     iterations: int = 1,
     data_collection_period: int = -1,
     max_steps: int = 1000,

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -2,7 +2,7 @@ import itertools
 from collections.abc import Iterable, Mapping
 from functools import partial
 from multiprocessing import Pool
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from tqdm.auto import tqdm
 
@@ -25,7 +25,7 @@ def batch_run(
     ----------
     model_cls : Type[Model]
         The model class to batch-run
-    parameters : Mapping[str, Union[Any, Iterable[Any]]],
+    parameters : Mapping[str, Any | Iterable[Any]],
         Dictionary with model parameters over which to run the model. You can either pass single values or iterables.
     number_processes : int, optional
         Number of processes used, by default 1. Set this to None if you want to use all CPUs.
@@ -76,13 +76,13 @@ def batch_run(
 
 
 def _make_model_kwargs(
-    parameters: Mapping[str, Union[Any, Iterable[Any]]],
+    parameters: Mapping[str, Any | Iterable[Any]],
 ) -> list[dict[str, Any]]:
     """Create model kwargs from parameters dictionary.
 
     Parameters
     ----------
-    parameters : Mapping[str, Union[Any, Iterable[Any]]]
+    parameters : Mapping[str, [Any | Iterable[Any]]
         Single or multiple values for each model parameter name
 
     Returns

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -11,7 +11,7 @@ from mesa.model import Model
 
 def batch_run(
     model_cls: type[Model],
-    parameters: Mapping[str, Any | Iterable[Any]]],
+    parameters: Mapping[str, Any | Iterable[Any]],
     # We still retain the Optional[int] because users may set it to None (i.e. use all CPUs)
     number_processes: Optional[int]= 1,
     iterations: int = 1,

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -11,7 +11,7 @@ from mesa.model import Model
 
 def batch_run(
     model_cls: type[Model],
-    parameters: Mapping[str, Union[Any, Iterable[Any]]],
+    parameters: Mapping[str, Any | Iterable[Any]]],
     # We still retain the Optional[int] because users may set it to None (i.e. use all CPUs)
     number_processes: Optional[int] = 1,
     iterations: int = 1,

--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -1,4 +1,4 @@
-from typing import Optional
+
 
 import networkx as nx
 import solara
@@ -93,12 +93,12 @@ def _draw_continuous_space(space, space_ax, agent_portrayal):
         return out
 
     # Determine border style based on space.torus
-    border_style = 'solid' if not space.torus else (0, (5, 10))
+    border_style = "solid" if not space.torus else (0, (5, 10))
 
     # Set the border of the plot
     for spine in space_ax.spines.values():
         spine.set_linewidth(1.5)
-        spine.set_color('black')
+        spine.set_color("black")
         spine.set_linestyle(border_style)
 
     width = space.x_max - space.x_min

--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -1,5 +1,3 @@
-
-
 import networkx as nx
 import solara
 from matplotlib.figure import Figure
@@ -9,7 +7,7 @@ import mesa
 
 
 @solara.component
-def SpaceMatplotlib(model, agent_portrayal, dependencies: list[any]|None = None):
+def SpaceMatplotlib(model, agent_portrayal, dependencies: list[any] | None = None):
     space_fig = Figure()
     space_ax = space_fig.subplots()
     space = getattr(model, "grid", None)

--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -9,7 +9,7 @@ import mesa
 
 
 @solara.component
-def SpaceMatplotlib(model, agent_portrayal, dependencies: Optional[list[any]] = None):
+def SpaceMatplotlib(model, agent_portrayal, dependencies: list[any]|None = None):
     space_fig = Figure()
     space_ax = space_fig.subplots()
     space = getattr(model, "grid", None)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -25,7 +25,7 @@ import math
 import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from numbers import Real
-from typing import Any, Callable, TypeVar, Union, cast, overload
+from typing import Any, Callable, TypeVar, cast, overload
 from warnings import warn
 
 with contextlib.suppress(ImportError):
@@ -905,7 +905,7 @@ class _PropertyGrid(_Grid):
             return_list (bool, optional): If True, return a list of coordinates, otherwise return a mask.
 
         Returns:
-            Union[list[Coordinate], np.ndarray]: Coordinates where conditions are satisfied or the combined mask.
+            list[Coordinate] | np.ndarray: Coordinates where conditions are satisfied or the combined mask.
         """
         # Initialize the combined mask
         combined_mask = np.ones((self.width, self.height), dtype=bool)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -42,12 +42,12 @@ _types_integer = (int, np.integer)
 
 Coordinate = tuple[int, int]
 # used in ContinuousSpace
-FloatCoordinate = Union[tuple[float, float], npt.NDArray[float]]
+FloatCoordinate = tuple[float, float] | npt.NDArray[float]
 NetworkCoordinate = int
 
-Position = Union[Coordinate, FloatCoordinate, NetworkCoordinate]
+Position = Coordinate | FloatCoordinate | NetworkCoordinate
 
-GridContent = Union[Agent, None]
+GridContent = Agent | None
 MultiGridContent = list[Agent]
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -31,7 +31,6 @@ import weakref
 from collections import defaultdict
 from collections.abc import Iterable
 
-
 from mesa.agent import Agent, AgentSet
 from mesa.model import Model
 

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -39,7 +39,7 @@ from mesa.model import Model
 
 # BaseScheduler has a self.time of int, while
 # StagedActivation has a self.time of float
-TimeT = Union[float, int]
+TimeT = float | int
 
 
 class BaseScheduler:

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -23,7 +23,7 @@ Key concepts:
 
 # Mypy; for the `|` operator purpose
 # Remove this __future__ import once the oldest supported Python is 3.10
-from __future__ import annotations
+
 
 import heapq
 import warnings

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -31,8 +31,6 @@ import weakref
 from collections import defaultdict
 from collections.abc import Iterable
 
-# mypy
-
 
 from mesa.agent import Agent, AgentSet
 from mesa.model import Model

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -32,7 +32,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 
 # mypy
-from typing import Union
+
 
 from mesa.agent import Agent, AgentSet
 from mesa.model import Model


### PR DESCRIPTION

solving the issue of replacing Union[a, b] with a | b and Optional[a] with a | None in type annotations:

Replacing Union[a, b] with a | b:

Improves readability and clarity of type hints.
Makes it easier to understand what types are allowed for a variable or function parameter.
Provides better type checking by the static type checker.
Replacing Optional[a] with a | None:

Similar benefits to replacing Union[a, b] with a | b.
More concise and idiomatic way to represent optional types in Python 3.8+

Aryan1Mahajahn
