### PR TITLE
fix: Reverse dict key and value for agents_by_type

### DIFF
--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -9,7 +9,7 @@ import timeit
 # also installed in site_packages or so.
 sys.path.insert(0, os.path.abspath(".."))
 
-from configurations import configurations
+from configurations import configurations  # noqa: E402
 
 
 # Generic function to initialize and run a model

--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -93,12 +93,12 @@ def _draw_continuous_space(space, space_ax, agent_portrayal):
         return out
 
     # Determine border style based on space.torus
-    border_style = 'solid' if not space.torus else (0, (5, 10))
+    border_style = "solid" if not space.torus else (0, (5, 10))
 
     # Set the border of the plot
     for spine in space_ax.spines.values():
         spine.set_linewidth(1.5)
-        spine.set_color('black')
+        spine.set_color("black")
         spine.set_linestyle(border_style)
 
     width = space.x_max - space.x_min

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -299,7 +299,7 @@ class RandomActivationByType(BaseScheduler):
 
         agentsbytype = defaultdict(dict)
         for k, v in self._agents_by_type.items():
-            agentsbytype[k] = {agent: agent.unique_id for agent in v}
+            agentsbytype[k] = {agent.unique_id: agent for agent in v}
 
         return agentsbytype
 


### PR DESCRIPTION
This change is so that the agents_by_type API is compatible with Mesa 2.1.5 again.