### PR TITLE
benchmarks.yml: Fix PR branch checkout when triggered by comment

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,9 +44,33 @@ jobs:
           path: benchmarks/timings_1.pickle
       - name: Checkout PR branch
         uses: actions/checkout@v4
+        if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: false
+      - name: Checkout PR branch from issue comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const issue_number = context.issue.number;
+            const repository = context.repo.repo;
+            const owner = context.repo.owner;
+            const pr = await github.rest.pulls.get({ owner, repo: repository, pull_number: issue_number });
+            const ref = pr.data.head.ref;
+            const repoFullName = pr.data.head.repo.full_name;
+            console.log(`::set-output name=ref::${ref}`);
+            console.log(`::set-output name=repo::${repoFullName}`);
+          result-encoding: string
+      - name: Actual Checkout for Issue Comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.checkout-pr-branch-from-issue-comment.outputs.repo }}
+          ref: ${{ steps.checkout-pr-branch-from-issue-comment.outputs.ref }}
           fetch-depth: 0
           persist-credentials: false
           clean: false


### PR DESCRIPTION
This PR resolves an issue in our GitHub Actions workflow where the correct PR branch was not being checked out when the workflow was triggered by an 'issue_comment' event. Previously, the workflow was set up to handle the 'pull_request_target' event correctly, but it did not account for the different context provided by 'issue_comment'.

The fix involves adding conditional steps in the workflow to handle the 'issue_comment' event. When the workflow is triggered by an 'issue_comment', it now uses the GitHub API to extract the PR number from the comment context. This information is then used to retrieve the PR details, including the head branch and the repository name. With these details, the workflow can now correctly check out the PR branch associated with the issue comment. This ensures that our benchmarks and other PR-related checks run against the appropriate branch, regardless of the triggering event.

See https://github.com/projectmesa/mesa/pull/1994#issuecomment-1907017461 and https://github.com/projectmesa/mesa/pull/1983#issuecomment-1908039010.

Due to the issue arising with pull request from another fork and the workflow only being updated when merged into main, there is not convenient way to test this except for merging. So I propose we do that.