### PR TITLE
Only run benchmark bot on actual code changes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,8 +5,14 @@ on:
     types: [opened, ready_for_review]
     branches:
       - main
+    paths:
+      - '**.py'
+      - '.github/workflows/benchmarks.yml'
   issue_comment:
     types: [created]
+    paths:
+      - '**.py'
+      - '.github/workflows/benchmarks.yml'
 
 permissions:
   issues: write


### PR DESCRIPTION
Only run if either an Python file has changed or if the benchmark workflow itself is changed.

It can be more fine-grained, but this should catch most docs-only cases.