### PR TITLE
benchmarks.yml: Another attempt at fixing PR branch checkout

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,29 +57,35 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           clean: false
-      - name: Checkout PR branch from issue comment
+      - name: Get PR info for Issue Comment
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v5
+        id: get-pr-info
+        uses: actions/github-script@v7
         with:
           script: |
             const issue_number = context.issue.number;
             const repository = context.repo.repo;
             const owner = context.repo.owner;
-            const pr = await github.rest.pulls.get({ owner, repo: repository, pull_number: issue_number });
-            const ref = pr.data.head.ref;
-            const repoFullName = pr.data.head.repo.full_name;
-            console.log(`::set-output name=ref::${ref}`);
-            console.log(`::set-output name=repo::${repoFullName}`);
-          result-encoding: string
-      - name: Actual Checkout for Issue Comment
+            const pr = await github.rest.pulls.list({
+              owner,
+              repo: repository,
+              head: owner + ":" + issue_number
+            });
+            if (pr.data.length === 0) {
+              throw new Error('No PR found for issue number ' + issue_number);
+            }
+            const headRepo = pr.data[0].head.repo.full_name;
+            const headRef = pr.data[0].head.ref;
+            return { headRepo, headRef };
+      - name: Checkout PR branch for Issue Comment
         if: github.event_name == 'issue_comment'
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.checkout-pr-branch-from-issue-comment.outputs.repo }}
-          ref: ${{ steps.checkout-pr-branch-from-issue-comment.outputs.ref }}
+          repository: ${{ steps.get-pr-info.outputs.headRepo }}
+          ref: ${{ steps.get-pr-info.outputs.headRef }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           persist-credentials: false
-          clean: false
       - name: Download benchmark results
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Let's try passing the information though a `step.id.outputs` [context](https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context). Maybe it helps, maybe not.

> This commit addresses the issue where GitHub Actions incorrectly checked out the main branch of the base repository when triggered by `issue_comment` events, instead of the correct branch from a forked repository. The solution involves using a GitHub script to fetch the pull request details associated with the issue comment, extracting the branch and repository information of the head (fork). This data is then used to explicitly checkout the correct branch from the forked repository. This ensures that the workflow operates on the intended branch, regardless of whether it's triggered by `pull_request_target` or `issue_comment` events, thereby maintaining the correct workflow context and enhancing security.