### PR TITLE
Quality of life: automatically fix ruff errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ci:
     autoupdate_schedule: 'monthly'
-    autofix_prs: false
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -10,6 +9,7 @@ repos:
     # Run the linter.
     - id: ruff
       types_or: [ python, pyi, jupyter ]
+      args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
       types_or: [ python, pyi, jupyter ]


### PR DESCRIPTION
Two small changes that should make it easier to contribute.

1. Run ruff pre-commit with the fix argument - I can't think why this shouldn't be desirable. Otherwise you just have to fix errors manually. Thanks @Aryan1Mahahjan for the inspiration
3. Run pre-commit.ci automatically. This makes it much easier for new contributors to not fail on formatting errors. The downside is that this might introduce an additional commit, but they are easy to spot and ignore while looking in the git history (there is no worry that features were changed in contrast to a commit that was just named "fix lint" manually)