### PR TITLE
Fix AgentSet inplace shuffle (and thus RandomActivation), add tests

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -54,6 +54,7 @@ class Agent:
         except AttributeError:
             # model super has not been called
             self.model.agents_ = defaultdict(dict)
+            self.model.agents_[type(self)][self] = None
             self.model.agentset_experimental_warning_given = False
 
             warnings.warn(

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -143,8 +143,8 @@ class BaseScheduler:
 
     def do_each(self, method, shuffle=False):
         if shuffle:
-            self.agents.shuffle(inplace=True)
-        self.agents.do(method)
+            self._agents.shuffle(inplace=True)
+        self._agents.do(method)
 
 
 class RandomActivation(BaseScheduler):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -255,7 +255,7 @@ def test_agentset_select_by_type():
 
 def test_agentset_shuffle():
     model = Model()
-    test_agents = [TestAgent(model.next_id(), model) for _ in range(4)]
+    test_agents = [TestAgent(model.next_id(), model) for _ in range(12)]
 
     agentset = AgentSet(test_agents, model=model)
     agentset = agentset.shuffle()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -251,3 +251,15 @@ def test_agentset_select_by_type():
     # Test with no type specified (should select all agents)
     all_agents = agentset.select()
     assert len(all_agents) == len(mixed_agents)
+
+def test_agentset_shuffle():
+    model = Model()
+    test_agents = [TestAgent(model.next_id(), model) for _ in range(4)]
+    agentset = AgentSet(test_agents, model=model)
+
+    agentset = agentset.shuffle()
+    assert not all([a1==a2 for a1, a2 in zip(test_agents, agentset)])
+
+    agentset = AgentSet(test_agents, model=model)
+    agentset.shuffle(inplace=True)
+    assert not all([a1 == a2 for a1, a2 in zip(test_agents, agentset)])

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -258,8 +258,8 @@ def test_agentset_shuffle():
     agentset = AgentSet(test_agents, model=model)
 
     agentset = agentset.shuffle()
-    assert not all([a1==a2 for a1, a2 in zip(test_agents, agentset)])
+    assert not all(a1 == a2 for a1, a2 in zip(test_agents, agentset))
 
     agentset = AgentSet(test_agents, model=model)
     agentset.shuffle(inplace=True)
-    assert not all([a1 == a2 for a1, a2 in zip(test_agents, agentset)])
+    assert not all(a1 == a2 for a1, a2 in zip(test_agents, agentset))

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -224,6 +224,28 @@ class TestRandomActivation(TestCase):
         agent_ids = {agent.unique_id for agent in model.agents}
         assert all(entry in agent_ids for entry in keys)
 
+    def test_not_sequential(self):
+        model = MockModel(activation=RANDOM)
+        # Create 10 agents
+        for _ in range(10):
+            model.schedule.add(MockAgent(model.next_id(), model))
+        # Run 3 steps
+        for _ in range(3):
+            model.step()
+        # Filter out non-integer elements from the log
+        filtered_log = [item for item in model.log if isinstance(item, int)]
+
+        # Check that there are no 18 consecutive agents id's in the filtered log
+        total_agents = 10
+        assert not any(
+            all(
+                (filtered_log[(i + j) % total_agents] - filtered_log[i]) % total_agents
+                == j % total_agents
+                for j in range(18)
+            )
+            for i in range(len(filtered_log))
+        ), f"Agents are activated sequentially:\n{filtered_log}"
+
 
 class TestSimultaneousActivation(TestCase):
     """


### PR DESCRIPTION
Adds a test that checks if the `RandomActivation` doesn't trigger agents in a sequential order. This test now fails, because as noted in #2006, it currently does do it in sequential order.

In theory this could give false positives (a test passing when it shouldn't, but that chance is around ~0.1^18).