### PR TITLE
feat: Implement experimental DataCollector API

### DIFF
--- a/mesa/experimental/observer.py
+++ b/mesa/experimental/observer.py
@@ -1,0 +1,77 @@
+from collections import defaultdict
+
+import pandas as pd
+
+
+class DataCollector:
+    """
+    Example: a model consisting of a hybrid of Boltzmann wealth model and
+    Epstein civil violence.
+    ```
+    def get_citizen():
+        return model.get_agents_of_type(Citizen)
+
+    collectors = {
+        model: {
+            "n_quiescent": lambda model: len(
+                model.agents.select(
+                    agent_type=Citizen,
+                    filter_func=lambda a: a.condition == "Quiescent"
+                )
+            ),
+            "gini": lambda model: calculate_gini(model.agents.get("wealth"))
+        },
+        get_citizen: {"condition": condition},
+        # This is a string, because model.agents may refer to a different
+        # object, over time.
+        "agents": {"wealth": "wealth"}
+    }
+    # Then finally
+    model.datacollector = DataCollector(model, collectors=collectors).collect()
+    ```
+    """
+
+    def __init__(self, model, collectors=None) -> "DataCollector":
+        self.model = model
+        self.collectors = collectors
+        self.data_collection = defaultdict(list)
+        return self
+
+    def collect(self) -> "DataCollector":
+        for group, group_collector in self.collectors.items():
+            group_object = group
+            if group == "agents":
+                group_object = self.model.agents
+            elif callable(group):
+                group_object = group()
+            data = {
+                name: self._collect_element(group_object, collector)
+                for name, collector in group_collector.items()
+            }
+            self.data_collection[group].append(data)
+        return self
+
+    def _collect_element(self, group, collector):
+        def _get_or_apply(obj, value):
+            # get
+            if isinstance(value, str):
+                return getattr(obj, value)
+            # apply
+            return value(obj)
+
+        if group is self.model:
+            return {
+                name: _get_or_apply(group, value) for name, value in collector.items()
+            }
+        return {
+            name: [_get_or_apply(e, value) for e in group]
+            for name, value in collector.items()
+        }
+
+    def to_df(self, group=None):
+        if group is None:
+            return {
+                group: pd.DataFrame(data_list)
+                for group, data_list in self.data_collection.items()
+            }
+        return pd.DataFrame(self.data_collection[group])

--- a/mesa/experimental/observer.py
+++ b/mesa/experimental/observer.py
@@ -45,13 +45,13 @@ class DataCollector:
             elif callable(group):
                 group_object = group()
             data = {
-                name: self._collect_element(group_object, collector)
+                name: self._collect_group(group_object, collector)
                 for name, collector in group_collector.items()
             }
             self.data_collection[group].append(data)
         return self
 
-    def _collect_element(self, group, collector):
+    def _collect_group(self, group, collector):
         def _get_or_apply(obj, value):
             # get
             if isinstance(value, str):


### PR DESCRIPTION
This is an attempt to implement the API as discussed in https://github.com/projectmesa/mesa/discussions/1944. I figure it is easier to comment on a PR than on a linear GH thread.

I have constrained the implementation to be as simple as possible, as such, feature like retrieving multiple attributes
```python
"pos":collect(model.agents, ["x", "y"],), # retrieve multiple attributes
```
is not implemented, because the API then unnecessarily gets bigger, needs more testing, and has bigger surface area for bugs and gotchas. Edit1: at least not until the initial small API has become well tested.

In this implementation, instead of `{name1: collect(collection, func1), name2: collect(collection, func2)`, it is `{collection: {name1: func1, name2: func2}}`.

Note: has edit1.