### PR TITLE
fix: Apply default value to slider

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -286,6 +286,7 @@ def UserInputs(user_params, on_change=None):
             )
             slider_class(
                 options.label,
+                value=options.value,
                 on_value=change_handler,
                 min=options.min,
                 max=options.max,


### PR DESCRIPTION
Without this, the slider value always defaults to being leftmost.