### PR TITLE
feat: Implement experimental DataCollector API 2

### DIFF
--- a/mesa/experimental/measure.py
+++ b/mesa/experimental/measure.py
@@ -72,11 +72,13 @@ class DataCollector:
     def __init__(self, model, attributes):
         self.model = model
         self.attributes = attributes
-        self.data_collection = defaultdict(list)
+        self.data_collection = defaultdict(lambda: defaultdict(list))
 
     def collect(self):
         for name in self.attributes:
             attribute = getattr(self.model, name)
+            group = "model"
             if isinstance(attribute, Measure):
+                group = attribute.group
                 attribute = attribute.value
-            self.data_collection[name] = attribute
+            self.data_collection[group][name].append(attribute)

--- a/mesa/experimental/measure.py
+++ b/mesa/experimental/measure.py
@@ -1,0 +1,82 @@
+from collections import defaultdict
+
+
+class Group:
+    def __init__(self, model, fn):
+        self.model = model
+        self.fn = fn
+
+    @property
+    def value(self):
+        return self.fn(self.model)
+
+
+class Measure:
+    def __init__(self, group, measurer):
+        self.group = group
+        self.measurer = measurer
+
+    def _measure_group(self, group, measurer):
+        # get an attribute
+        if isinstance(measurer, str):
+            return getattr(group, measurer)
+        # apply
+        return measurer(group)
+
+    @property
+    def value(self):
+        group_object = self.group
+        if isinstance(self.group, Group):
+            group_object = self.group.value
+        return self._measure_group(group_object, self.measurer)
+
+
+class DataCollector:
+    """
+    Example: a model consisting of a hybrid of Boltzmann wealth model and
+    Epstein civil violence.
+
+    class EpsteinBoltzmannModel:
+        def __init__(self):
+            # Groups
+            self.quiescents = Group(
+                lambda model: model.agents.select(
+                    agent_type=Citizen, filter_func=lambda a: a.condition == "Quiescent"
+                )
+            )
+            self.citizens = Group(lambda model: model.get_agents_of_type(Citizen))
+
+            # Measurements
+            self.num_quiescents = Measure(self.quiescents, len)
+            self.gini = Measure(
+                self.agents, lambda agents: calculate_gini(agents.get("wealth"))
+            )
+            self.gini_quiescents = Measure(
+                self.quiescents, lambda agents: calculate_gini(agents.get("wealth"))
+            )
+            self.condition = Measure(self.citizens, "condition")
+            self.wealth = Measure(self.agents, "wealth")
+
+
+    def run():
+        model = EpsteinBoltzmannModel()
+        datacollector = DataCollector(
+            model, ["num_quiescents", "gini_quiescents", "wealth"]
+        )
+
+        for _ in range(10):
+            model.step()
+            datacollector.collect()
+    """
+
+    def __init__(self, model, attributes):
+        self.model = model
+        self.attributes = attributes
+        self.data_collection = defaultdict(list)
+
+    def collect(self):
+        for name in self.attributes:
+            attribute = getattr(self.model, name)
+            if isinstance(attribute, Measure):
+                attribute = attribute.value
+            self.data_collection[name] = attribute


### PR DESCRIPTION
This is a sketch of another data collector API as discussed on [Matrix.org](https://matrix.to/#/#project-mesa:matrix.org). The implementation is very short, so as to give an idea of how it works, and to experiment with it.

Highlights:
- Everything is an attribute, including the custom groups (custom groups are needed to avoid repetition of specifying a particular group)
- The data collector object now tracks only attributes of `model`, and so its implementation is very simple

~~Downside: to group-by the data collection by group is not automatic, since the organization is completely flat, with no information about the group. OTOH, doing group-by in #2013 is very trivial.~~ no longer the case. Already implemented.