### PR TITLE
ci: Use uv pip for faster build

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -46,30 +46,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - if: ${{ runner.os == 'Windows' }}
-      # This is needed so that restoring cache on Windows is fast.
-      # See until https://github.com/actions/cache/issues/752 is resolved.
-      name: Use GNU tar
-      shell: cmd
-      run: |
-        echo "Adding GNU tar to PATH"
-        echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pip-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
-    - name: Install dependencies
-      # Only if the cache misses
-      # Based on https://github.com/pypa/pip/issues/8049#issuecomment-633845028
-      # read_requirements.py should be removed once
-      # https://github.com/pypa/pip/issues/11440 is resolved.
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install toml
-        python tests/read_requirements.py > requirements.txt
-        pip install -r requirements.txt
+        cache: 'pip'
+    - name: Install uv
+      run: pip install uv
     - name: Install Mesa
-      run: pip install --no-deps .
+      # See https://github.com/astral-sh/uv/issues/1945
+      run: uv pip install --system .[dev]
     - name: Test with pytest
       run: pytest --durations=10 --cov=mesa tests/ --cov-report=xml
     - if: matrix.os == 'ubuntu'
@@ -84,22 +66,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.pythonLocation }}
-        key: test-examples-pip-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
-    - name: Install dependencies
-      # Only if the cache misses
-      # Based on https://github.com/pypa/pip/issues/8049#issuecomment-633845028
-      # read_requirements.py should be removed once
-      # https://github.com/pypa/pip/issues/11440 is resolved.
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install toml
-        python tests/read_requirements.py > requirements.txt
-        pip install -r requirements.txt
+        cache: 'pip'
+    - name: Install uv
+      run: pip install uv
     - name: Install Mesa
-      run: pip install --no-deps .
+      run: uv pip install --system .[dev]
     - name: Checkout mesa-examples
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
       - name: Install dependencies
         run: pip install -U pip hatch
       - name: Build distributions


### PR DESCRIPTION
[`uv`](https://astral.sh/blog/uv) is a fast drop-in `pip`, `pip-compile`, `virtualenv` etc replacement created by the creator of Ruff.