### PR TITLE
tests: Speed up test_batch_run

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Install Mesa
       run: pip install --no-deps .
     - name: Test with pytest
-      run: pytest --cov=mesa tests/ --cov-report=xml
+      run: pytest --durations=10 --cov=mesa tests/ --cov-report=xml
     - if: matrix.os == 'ubuntu'
       name: Codecov
       uses: codecov/codecov-action@v4

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -124,8 +124,8 @@ def test_batch_run_with_params():
     mesa.batch_run(
         MockModel,
         {
-            "variable_model_params": range(5),
-            "variable_agent_params": ["H", "E", "L", "L", "O"],
+            "variable_model_params": range(3),
+            "variable_agent_params": ["H", "E", "Y"],
         },
         number_processes=2,
     )
@@ -148,7 +148,7 @@ def test_batch_run_no_agent_reporters():
 
 
 def test_batch_run_single_core():
-    mesa.batch_run(MockModel, {}, number_processes=1, iterations=10)
+    mesa.batch_run(MockModel, {}, number_processes=1, iterations=6)
 
 
 def test_batch_run_unhashable_param():


### PR DESCRIPTION
This is an attempt to speed up overall CI testing time, as much as possible without reducing comprehensiveness. Currently, it takes 12s on Python 3.12 on Ubuntu.