### PR TITLE
new feature: AgentSet.get can retrieve one or more then one attribute

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -274,6 +274,10 @@ class AgentSet(MutableSet, Sequence):
         Returns:
             list[Any]: A list with the attribute value for each agent in the set if attr_names is a str
             List[List[Any]]: A list with a list of attribute values for each agent in the set if attr_names is a list of str
+
+        Raises:
+            AttributeError if an agent does not have the specified attribute(s)
+
         """
 
         if isinstance(attr_names, str):

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -269,7 +269,7 @@ class AgentSet(MutableSet, Sequence):
         Retrieve the specified attribute(s) from each agent in the AgentSet.
 
         Args:
-            attr_names (str | List[str]): The name(s) of the attribute(s) to retrieve from each agent.
+            attr_names (str | list[str]): The name(s) of the attribute(s) to retrieve from each agent.
 
         Returns:
             list[Any]: A list with the attribute value for each agent in the set if attr_names is a str

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -272,7 +272,8 @@ class AgentSet(MutableSet, Sequence):
             attr_names (str | List[str]): The name(s) of the attribute(s) to retrieve from each agent.
 
         Returns:
-            list[Any]: A list of attribute values for each agent in the set.
+            list[Any]: A list with the attribute value for each agent in the set if attr_names is a str
+            List[List[Any]]: A list with a list of attribute values for each agent in the set if attr_names is a list of str
         """
 
         if isinstance(attr_names, str):

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -273,7 +273,7 @@ class AgentSet(MutableSet, Sequence):
 
         Returns:
             list[Any]: A list with the attribute value for each agent in the set if attr_names is a str
-            List[List[Any]]: A list with a list of attribute values for each agent in the set if attr_names is a list of str
+            list[list[Any]]: A list with a list of attribute values for each agent in the set if attr_names is a list of str
 
         Raises:
             AttributeError if an agent does not have the specified attribute(s)

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Iterator, MutableSet, Sequence
 from random import Random
 
 # mypy
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, List
 
 if TYPE_CHECKING:
     # We ensure that these are not imported during runtime to prevent cyclic
@@ -264,17 +264,21 @@ class AgentSet(MutableSet, Sequence):
 
         return res if return_results else self
 
-    def get(self, attr_name: str) -> list[Any]:
+    def get(self, attr_names: str | List[str]) -> list[Any]:
         """
-        Retrieve a specified attribute from each agent in the AgentSet.
+        Retrieve the specified attribute(s) from each agent in the AgentSet.
 
         Args:
-            attr_name (str): The name of the attribute to retrieve from each agent.
+            attr_names (str | List[str]): The name(s) of the attribute(s) to retrieve from each agent.
 
         Returns:
-            list[Any]: A list of attribute values from each agent in the set.
+            list[Any]: A list of attribute values for each agent in the set.
         """
-        return [getattr(agent, attr_name) for agent in self._agents]
+
+        if isinstance(attr_names, str):
+            return [getattr(agent, attr_names) for agent in self._agents]
+        else:
+            return [[getattr(agent, attr_name) for attr_name in attr_names] for agent in self._agents]
 
     def __getitem__(self, item: int | slice) -> Agent:
         """

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Iterator, MutableSet, Sequence
 from random import Random
 
 # mypy
-from typing import TYPE_CHECKING, Any, Callable, List
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     # We ensure that these are not imported during runtime to prevent cyclic

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -264,7 +264,7 @@ class AgentSet(MutableSet, Sequence):
 
         return res if return_results else self
 
-    def get(self, attr_names: str | List[str]) -> list[Any]:
+    def get(self, attr_names: str | list[str]) -> list[Any]:
         """
         Retrieve the specified attribute(s) from each agent in the AgentSet.
 
@@ -278,7 +278,10 @@ class AgentSet(MutableSet, Sequence):
         if isinstance(attr_names, str):
             return [getattr(agent, attr_names) for agent in self._agents]
         else:
-            return [[getattr(agent, attr_name) for attr_name in attr_names] for agent in self._agents]
+            return [
+                [getattr(agent, attr_name) for attr_name in attr_names]
+                for agent in self._agents
+            ]
 
     def __getitem__(self, item: int | slice) -> Agent:
         """

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -222,6 +222,23 @@ def test_agentset_get_attribute():
         agentset.get("non_existing_attribute")
 
 
+    model = Model()
+    agents = []
+    for i in range(10):
+        agent = TestAgent(model.next_id(), model)
+        agent.i = i**2
+        agents.append(agent)
+    agentset = AgentSet(agents, model)
+
+    values = agentset.get(["unique_id", "i"])
+
+    for value, agent in zip(values, agents):
+        unique_id, i, = value
+        assert agent.unique_id == unique_id
+        assert agent.i == i
+
+
+
 class OtherAgentType(Agent):
     def get_unique_identifier(self):
         return self.unique_id

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -221,7 +221,6 @@ def test_agentset_get_attribute():
     with pytest.raises(AttributeError):
         agentset.get("non_existing_attribute")
 
-
     model = Model()
     agents = []
     for i in range(10):
@@ -233,10 +232,12 @@ def test_agentset_get_attribute():
     values = agentset.get(["unique_id", "i"])
 
     for value, agent in zip(values, agents):
-        unique_id, i, = value
+        (
+            unique_id,
+            i,
+        ) = value
         assert agent.unique_id == unique_id
         assert agent.i == i
-
 
 
 class OtherAgentType(Agent):


### PR DESCRIPTION
This adds a small additional feature to AgentSet. The get method now takes a string or list of strings. This allows you to retrieve multiple attributes in one go. I also added a test to cover this new feature. 