### PR TITLE
fix: Remove JupyterViz grid marker overlap for huge grid size

### DIFF
--- a/mesa/experimental/components/matplotlib.py
+++ b/mesa/experimental/components/matplotlib.py
@@ -48,6 +48,9 @@ def _draw_grid(space, space_ax, agent_portrayal):
                     if "color" in data:
                         c.append(data["color"])
         out = {"x": x, "y": y}
+        # This is the default value for the marker size, which auto-scales
+        # according to the grid area.
+        out["s"] = (180 / min(g.width, g.height)) ** 2
         if len(s) > 0:
             out["s"] = s
         if len(c) > 0:


### PR DESCRIPTION
Fixes #1741. I have said several times in #1820 that the fix to the overlap problem is simple. I don't want to delay the simple fix for 5 months+ anymore, and so I made this PR.
20x20
![20x20](https://github.com/projectmesa/mesa/assets/395821/3f13208e-f70d-4e94-9285-9f2c9e38f2e6)
60x60
![60x60](https://github.com/projectmesa/mesa/assets/395821/71799b7e-652e-499f-8b54-377838ce4fc2)
100x100
![100x100](https://github.com/projectmesa/mesa/assets/395821/612e3a78-70bf-4c5c-8232-9b01943428fc)
