### PR TITLE
fix: Use model.schedule only when it is not None

### DIFF
--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -184,7 +184,9 @@ class DataCollector:
 
         agent_records = map(
             get_reports,
-            model.schedule.agents if hasattr(model, "schedule") else model.agents,
+            model.schedule.agents
+            if hasattr(model, "schedule") and model.schedule is not None
+            else model.agents,
         )
         return agent_records
 


### PR DESCRIPTION
This fixes the error that shows up in https://github.com/projectmesa/mesa-examples/pull/79 and https://github.com/projectmesa/mesa-examples/pull/99,
```
        agent_records = map(
            get_reports,
>           model.schedule.agents if hasattr(model, "schedule") else model.agents,
        )
E       AttributeError: 'NoneType' object has no attribute 'agents'
```