### PR TITLE
Rename links to internal .rst files to .md

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -7,11 +7,9 @@ on:
     - release**
     paths-ignore:
       - '**.md'
-      - '**.rst'
   pull_request:
     paths-ignore:
       - '**.md'
-      - '**.rst'
 
 # This will cancel previous run if a newer job that obsoletes the said previous
 # run, is started.

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ tutorials/adv_tutorial_legacy.ipynb
 - {ref}`modindex`
 - {ref}`search`
 
-[contributors guide]: https://github.com/projectmesa/mesa/blob/main/CONTRIBUTING.rst
+[contributors guide]: https://github.com/projectmesa/mesa/blob/main/CONTRIBUTING.md
 [email list]: https://groups.google.com/d/forum/projectmesa
 [github]: https://github.com/projectmesa/mesa/
 [github issue tracker]: https://github.com/projectmesa/mesa/issues

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -1144,7 +1144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note for Windows OS users:** If you are running this tutorial in Jupyter, make sure that you set `number_processes = 1` (single process). If `number_processes` is greater than 1, it is less straightforward to set up. You can read [Mesa's how-to guide](https://github.com/projectmesa/mesa/blob/main/docs/howto.rst), in 'Using multi-process `batch_run` on Windows' section for how to do it."
+    "**Note for Windows OS users:** If you are running this tutorial in Jupyter, make sure that you set `number_processes = 1` (single process). If `number_processes` is greater than 1, it is less straightforward to set up. You can read [Mesa's how-to guide](https://github.com/projectmesa/mesa/blob/main/docs/howto.md), in 'Using multi-process `batch_run` on Windows' section for how to do it."
    ]
   },
   {


### PR DESCRIPTION
This fixes the dead links. I have grepped for all the `.rst` occurrences in the repo, and these should be all of the internal ones.