### PR TITLE
Make connections in experiment cell space named #2060 #features

### DIFF
--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -24,7 +24,7 @@ class Cell:
 
     __slots__ = [
         "coordinate",
-        "_connections",
+        "connections",
         "agents",
         "capacity",
         "properties",
@@ -56,7 +56,7 @@ class Cell:
         """
         super().__init__()
         self.coordinate = coordinate
-        self._connections: list[Cell] = []  # TODO: change to CellCollection?
+        self.connections: dict[str, Cell] = {}  # TODO: change to CellCollection?
         self.agents = []  # TODO:: change to AgentSet or weakrefs? (neither is very performant, )
         self.capacity = capacity
         self.properties: dict[str, object] = {}
@@ -69,7 +69,7 @@ class Cell:
             other (Cell): other cell to connect to
 
         """
-        self._connections.append(other)
+        self.connections.append(other)
 
     def disconnect(self, other: Cell) -> None:
         """Disconnects this cell from another cell.
@@ -78,7 +78,7 @@ class Cell:
             other (Cell): other cell to remove from connections
 
         """
-        self._connections.remove(other)
+        self.connections.remove(other)
 
     def add_agent(self, agent: CellAgent) -> None:
         """Adds an agent to the cell.


### PR DESCRIPTION
The proposed feature resolves the limitation in the current representation of cell connections. By replacing the existing list of connections with a dictionary containing named connections, the code enables more expressive and flexible movement over the cell space. Specifically, this change allows for easy retrieval of neighboring cells in different directions, such as left, right, top, or bottom in the context of a von Neumann grid. The enhanced structure opens the door to straightforward expression of various movements and relationships within the cell space.

```python
self.connections: dict[str, Cell] = {}