### PR TITLE
Remove JupyterViz Altair marker overlap for huge grid size

### DIFF
--- a/mesa/experimental/components/altair.py
+++ b/mesa/experimental/components/altair.py
@@ -56,5 +56,10 @@ def _draw_grid(space, agent_portrayal):
         .properties(width=280, height=280)
         # .configure_view(strokeOpacity=0)  # hide grid/chart lines
     )
+    # This is the default value for the marker size, which auto-scales
+    # according to the grid area.
+    if not has_size:
+        length = min(space.width, space.height)
+        chart = chart.mark_point(size=30000 / length**2, filled=True)
 
     return chart


### PR DESCRIPTION
This is #2049, but for the Altair visualization instead.
20x20
![20x20](https://github.com/projectmesa/mesa/assets/395821/f23fd155-3c3b-4d6e-8674-ed3c535390ac)
60x60
![60x60](https://github.com/projectmesa/mesa/assets/395821/136c2d88-d2dd-4843-9d70-4e629d0e2525)
100x100
![100x100](https://github.com/projectmesa/mesa/assets/395821/0864902c-5f98-454f-ae7e-06fc1432e0d3)
