### PR TITLE
 Make experimental cell spaces work with PropertyGrid 

### DIFF
--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -5,8 +5,8 @@ from itertools import product
 from random import Random
 from typing import Generic, TypeVar
 
-from mesa.space import PropertyLayer
 from mesa.experimental.cell_space import Cell, DiscreteSpace
+from mesa.space import PropertyLayer
 
 T = TypeVar("T", bound=Cell)
 
@@ -90,8 +90,7 @@ class Grid(DiscreteSpace, Generic[T]):
         for d_coord in offsets:
             n_coord = tuple(c + dc for c, dc in zip(coord, d_coord))
             if self.torus:
-                n_coord = tuple(nc % d for nc, d in zip(
-                    n_coord, self.dimensions))
+                n_coord = tuple(nc % d for nc, d in zip(n_coord, self.dimensions))
             if all(0 <= nc < d for nc, d in zip(n_coord, self.dimensions)):
                 cell.connect(self._cells[n_coord])
 
@@ -140,8 +139,13 @@ class _PropertyGrid(Grid, Generic[T]):
         cell_klass: type[T] = Cell,
         property_layers: None | PropertyLayer | list[PropertyLayer] = None,
     ) -> None:
-        super().__init__(dimensions=dimensions, torus=torus,
-                         capacity=capacity, random=random, cell_klass=cell_klass)
+        super().__init__(
+            dimensions=dimensions,
+            torus=torus,
+            capacity=capacity,
+            random=random,
+            cell_klass=cell_klass,
+        )
 
         self.properties = {}
 
@@ -166,9 +170,11 @@ class _PropertyGrid(Grid, Generic[T]):
             ValueError: If the dimensions of the property layer do not match the grid's dimensions.
         """
         if property_layer.name in self.properties:
-            raise ValueError(
-                f"Property layer {property_layer.name} already exists.")
-        if property_layer.width != self.dimensions[0] or property_layer.height != self.dimensions[1]:
+            raise ValueError(f"Property layer {property_layer.name} already exists.")
+        if (
+            property_layer.width != self.dimensions[0]
+            or property_layer.height != self.dimensions[1]
+        ):
             raise ValueError(
                 f"Property layer dimensions {property_layer.width}x{property_layer.height} do not match grid dimensions {self.dimensions[0]}x{self.dimensions[1]}."
             )

--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -194,13 +194,6 @@ class _PropertyGrid(Grid, Generic[T]):
             raise ValueError(f"Property layer {property_name} does not exist.")
         del self.properties[property_name]
 
-    def select_random_empty_cell(self) -> T:
-        """select random empty cell and add the property to the cell"""
-        cell = super().select_random_empty_cell()
-        for property in self.properties:
-            cell.properties[property] = self.properties[property].data[cell.coordinate]
-        return cell
-
 
 class OrthogonalMooreGrid(_PropertyGrid[T]):
     """Grid where cells are connected to their 8 neighbors.


### PR DESCRIPTION
This PR marks the initial stride towards addressing the issue of integrating experimental cell spaces with PropertyGrid functionality #2059. I have added the PropertyGrid class and kept two methods remove_property_layer, add_property_layer and improved select_random_empty_cell from parent class in experimental.cell_space.grid.py . 
The submitted changes represent the initial phase of the requested updates, and I am eager to refine them further based on any feedback received to ensure completion of the necessary modifications.

Sample code:
```Python
from mesa import Model
from mesa.experimental.cell_space import OrthogonalMooreGrid, CellAgent
from mesa.space import PropertyLayer


class MyAgent(CellAgent):
    def __init__(self, unique_id, model):
        super().__init__(unique_id, model)


# Initialize a model and grid
model = Model()
grid = OrthogonalMooreGrid(
    [10, 10], torus=True, capacity=1, random=model.random)

# add property layer
property_layer = PropertyLayer("weight", 10, 10, default_value=1)
grid.add_property_layer(property_layer)


# Create an agent and add it to a cell
agent = MyAgent(1, model)
cell = grid.select_random_empty_cell()
agent.move_to(cell)

# get the coordinates and weight layer of the cell
print(cell.coordinate)
print(cell.properties['weight'])
```