### PR TITLE
feat: Display model seed & allow user to specify it in JupyterViz

### DIFF
--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -157,7 +157,7 @@ def JupyterViz(
         if measures:
             layout_types += [{"Measure": elem} for elem in range(len(measures))]
 
-        grid_layout_initial = get_initial_grid_layout(layout_types=layout_types)
+        grid_layout_initial = make_initial_grid_layout(layout_types=layout_types)
         grid_layout, set_grid_layout = solara.use_state(grid_layout_initial)
 
         with solara.Sidebar():
@@ -385,20 +385,15 @@ def make_text(renderer):
     return function
 
 
-def get_initial_grid_layout(layout_types):
-    grid_lay = []
-    y_coord = 0
-    for ii in range(len(layout_types)):
-        template_layout = {"h": 10, "i": 0, "moved": False, "w": 6, "y": 0, "x": 0}
-        if ii == 0:
-            grid_lay.append(template_layout)
-        else:
-            template_layout.update({"i": ii})
-            if ii % 2 == 0:
-                template_layout.update({"x": 0})
-                y_coord += 16
-            else:
-                template_layout.update({"x": 6})
-            template_layout.update({"y": y_coord})
-            grid_lay.append(template_layout)
-    return grid_lay
+def make_initial_grid_layout(layout_types):
+    return [
+        {
+            "i": i,
+            "w": 6,
+            "h": 10,
+            "moved": False,
+            "x": 6 * (i % 2),
+            "y": 16 * (i - i % 2),
+        }
+        for i in range(len(layout_types))
+    ]

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -88,7 +88,9 @@ def JupyterViz(
 
     # 2. Set up Model
     def make_model():
-        model = model_class.__new__(model_class, **model_parameters, seed=reactive_seed.value)
+        model = model_class.__new__(
+            model_class, **model_parameters, seed=reactive_seed.value
+        )
         model.__init__(**model_parameters)
         current_step.value = 0
         return model
@@ -171,9 +173,7 @@ def JupyterViz(
                 ModelController(model, play_interval, current_step, reset_counter)
                 solara.Button(label="Reseed", color="primary", on_click=do_reseed)
             with solara.Card("Information", margin=1, elevation=2):
-                solara.Markdown(
-                    md_text=f"Step - {current_step}"
-                )
+                solara.Markdown(md_text=f"Step - {current_step}")
 
         items = [
             Card(
@@ -259,7 +259,8 @@ def ModelController(model, play_interval, current_step, reset_counter):
         solara.Button(label="Step", color="primary", on_click=do_step)
         # This style is necessary so that the play widget has almost the same
         # height as typical Solara buttons.
-        solara.Style("""
+        solara.Style(
+            """
         .widget-play {
             height: 35px;
         }

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -17,7 +17,7 @@ plt.switch_backend("agg")
 # TODO: Turn this function into a Solara component once the current_step.value
 # dependency is passed to measure()
 def Card(
-    model, measures, agent_portrayal, space_drawer, current_step, color, layout_type
+    model, measures, agent_portrayal, space_drawer, dependencies, color, layout_type
 ):
     with rv.Card(
         style_=f"background-color: {color}; width: 100%; height: 100%"
@@ -27,11 +27,11 @@ def Card(
             if space_drawer == "default":
                 # draw with the default implementation
                 components_matplotlib.SpaceMatplotlib(
-                    model, agent_portrayal, dependencies=[current_step.value]
+                    model, agent_portrayal, dependencies=dependencies
                 )
             elif space_drawer == "altair":
                 components_altair.SpaceAltair(
-                    model, agent_portrayal, dependencies=[current_step.value]
+                    model, agent_portrayal, dependencies=dependencies
                 )
             elif space_drawer:
                 # if specified, draw agent space with an alternate renderer
@@ -44,7 +44,7 @@ def Card(
                 measure(model)
             else:
                 components_matplotlib.PlotMatplotlib(
-                    model, measure, dependencies=[current_step.value]
+                    model, measure, dependencies=dependencies
                 )
     return main
 
@@ -58,6 +58,7 @@ def JupyterViz(
     agent_portrayal=None,
     space_drawer="default",
     play_interval=150,
+    seed=None,
 ):
     """Initialize a component to visualize a model.
     Args:
@@ -71,6 +72,7 @@ def JupyterViz(
             simulations with no space to visualize should
             specify `space_drawer=False`
         play_interval: play interval (default: 150)
+        seed: the random seed used to initialize the model
     """
     if name is None:
         name = model_class.__name__
@@ -78,6 +80,7 @@ def JupyterViz(
     current_step = solara.use_reactive(0)
 
     # 1. Set up model parameters
+    reactive_seed = solara.use_reactive(0)
     user_params, fixed_params = split_model_params(model_params)
     model_parameters, set_model_parameters = solara.use_state(
         {**fixed_params, **{k: v.get("value") for k, v in user_params.items()}}
@@ -85,13 +88,18 @@ def JupyterViz(
 
     # 2. Set up Model
     def make_model():
-        model = model_class(**model_parameters)
+        model = model_class(**model_parameters, seed=reactive_seed.value)
         current_step.value = 0
         return model
 
     reset_counter = solara.use_reactive(0)
     model = solara.use_memo(
-        make_model, dependencies=[*list(model_parameters.values()), reset_counter.value]
+        make_model,
+        dependencies=[
+            *list(model_parameters.values()),
+            reset_counter.value,
+            reactive_seed.value,
+        ],
     )
 
     def handle_change_model_params(name: str, value: any):
@@ -103,8 +111,12 @@ def JupyterViz(
         solara.AppBarTitle(name)
 
     # render layout and plot
+    def do_reseed():
+        reactive_seed.value = model.random.random()
 
     # jupyter
+    dependencies = [current_step.value, reactive_seed.value]
+
     def render_in_jupyter():
         with solara.GridFixed(columns=2):
             UserInputs(user_params, on_change=handle_change_model_params)
@@ -116,11 +128,11 @@ def JupyterViz(
             if space_drawer == "default":
                 # draw with the default implementation
                 components_matplotlib.SpaceMatplotlib(
-                    model, agent_portrayal, dependencies=[current_step.value]
+                    model, agent_portrayal, dependencies=dependencies
                 )
             elif space_drawer == "altair":
                 components_altair.SpaceAltair(
-                    model, agent_portrayal, dependencies=[current_step.value]
+                    model, agent_portrayal, dependencies=dependencies
                 )
             elif space_drawer:
                 # if specified, draw agent space with an alternate renderer
@@ -134,7 +146,7 @@ def JupyterViz(
                     measure(model)
                 else:
                     components_matplotlib.PlotMatplotlib(
-                        model, measure, dependencies=[current_step.value]
+                        model, measure, dependencies=dependencies
                     )
 
     def render_in_browser():
@@ -149,10 +161,18 @@ def JupyterViz(
 
         with solara.Sidebar():
             with solara.Card("Controls", margin=1, elevation=2):
+                solara.InputText(
+                    label="Seed",
+                    value=reactive_seed,
+                    continuous_update=True,
+                )
                 UserInputs(user_params, on_change=handle_change_model_params)
                 ModelController(model, play_interval, current_step, reset_counter)
-            with solara.Card("Progress", margin=1, elevation=2):
-                solara.Markdown(md_text=f"####Step - {current_step}")
+                solara.Button(label="Reseed", color="primary", on_click=do_reseed)
+            with solara.Card("Information", margin=1, elevation=2):
+                solara.Markdown(
+                    md_text=f"Step - {current_step}"
+                )
 
         items = [
             Card(
@@ -160,7 +180,7 @@ def JupyterViz(
                 measures,
                 agent_portrayal,
                 space_drawer,
-                current_step,
+                dependencies,
                 color="white",
                 layout_type=layout_types[i],
             )

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -259,10 +259,13 @@ def ModelController(model, play_interval, current_step, reset_counter):
         solara.Button(label="Step", color="primary", on_click=do_step)
         # This style is necessary so that the play widget has almost the same
         # height as typical Solara buttons.
-        solara.Style(
-            """
+        solara.Style("""
         .widget-play {
-            height: 30px;
+            height: 35px;
+        }
+        .widget-play button {
+            color: white;
+            background-color: #1976D2;  // Solara blue color
         }
         """
         )

--- a/mesa/experimental/jupyter_viz.py
+++ b/mesa/experimental/jupyter_viz.py
@@ -88,7 +88,8 @@ def JupyterViz(
 
     # 2. Set up Model
     def make_model():
-        model = model_class(**model_parameters, seed=reactive_seed.value)
+        model = model_class.__new__(model_class, **model_parameters, seed=reactive_seed.value)
+        model.__init__(**model_parameters)
         current_step.value = 0
         return model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
   "pytest >= 4.6",
   "pytest-cov",
   "sphinx",
+  "pytest-mock",
 ]
 docs = [
   "sphinx",

--- a/tests/test_jupyter_viz.py
+++ b/tests/test_jupyter_viz.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import ipyvuetify as vw
 import solara
@@ -83,7 +83,9 @@ class TestMakeUserInput(unittest.TestCase):
 
 
 def test_call_space_drawer(mocker):
-    mock_space_matplotlib = mocker.patch("mesa.experimental.components.matplotlib.SpaceMatplotlib")
+    mock_space_matplotlib = mocker.patch(
+        "mesa.experimental.components.matplotlib.SpaceMatplotlib"
+    )
 
     model = mesa.Model()
     mocker.patch.object(mesa.Model, "__new__", return_value=model)
@@ -134,9 +136,7 @@ def test_call_space_drawer(mocker):
             space_drawer=altspace_drawer,
         )
     )
-    altspace_drawer.assert_called_with(
-        model, agent_portrayal
-    )
+    altspace_drawer.assert_called_with(model, agent_portrayal)
 
 
 def test_slider():

--- a/tests/test_jupyter_viz.py
+++ b/tests/test_jupyter_viz.py
@@ -91,7 +91,8 @@ class TestJupyterViz(unittest.TestCase):
             "color": "gray",
         }
         current_step = 0
-        dependencies = [current_step]
+        seed = 0
+        dependencies = [current_step, seed]
         # initialize with space drawer unspecified (use default)
         # component must be rendered for code to run
         solara.render(


### PR DESCRIPTION
Fixes: #1812. The motivation can be found in that issue. It looks like this
![2024-03-05T03:36:30,978108357-05:00](https://github.com/projectmesa/mesa/assets/395821/e2c1303b-e432-47a3-91f1-0f6114348b96)
The current behavior is that the seed is not changed even when you press the reset button. After all, it is now a user input param. However, if you force refresh the browser, the seed is still not changed. A more sustainable solution (so that user doesn't accidentally lose the seed) is to add a button to generate a new seed.