### PR TITLE
Add tooltip option to Altair chart

### DIFF
--- a/mesa/experimental/components/altair.py
+++ b/mesa/experimental/components/altair.py
@@ -34,7 +34,6 @@ def _draw_grid(space, agent_portrayal):
                 all_agent_data.append(agent_data)
         return all_agent_data
 
-
     all_agent_data = portray(space)
     invalid_tooltips = ["color", "size", "x", "y"]
 
@@ -44,9 +43,12 @@ def _draw_grid(space, agent_portrayal):
         # no y-axis label
         "y": alt.Y("y", axis=None, type="ordinal"),
         "tooltip": [
-            alt.Tooltip(key, type=alt.utils.infer_vegalite_type([all_agent_data[0][key]])) 
-                for key in all_agent_data[0] if key not in invalid_tooltips
-        ]
+            alt.Tooltip(
+                key, type=alt.utils.infer_vegalite_type([all_agent_data[0][key]])
+            )
+            for key in all_agent_data[0]
+            if key not in invalid_tooltips
+        ],
     }
     has_color = "color" in all_agent_data[0]
     if has_color:

--- a/mesa/experimental/components/altair.py
+++ b/mesa/experimental/components/altair.py
@@ -43,10 +43,8 @@ def _draw_grid(space, agent_portrayal):
         # no y-axis label
         "y": alt.Y("y", axis=None, type="ordinal"),
         "tooltip": [
-            alt.Tooltip(
-                key, type=alt.utils.infer_vegalite_type([all_agent_data[0][key]])
-            )
-            for key in all_agent_data[0]
+            alt.Tooltip(key, type=alt.utils.infer_vegalite_type([value]))
+            for key, value in all_agent_data[0].items()
             if key not in invalid_tooltips
         ],
     }

--- a/mesa/experimental/components/altair.py
+++ b/mesa/experimental/components/altair.py
@@ -1,6 +1,6 @@
 import contextlib
-from typing import Optional
 import datetime
+from typing import Optional
 
 import solara
 
@@ -38,9 +38,9 @@ def _draw_grid(space, agent_portrayal):
     def detect_type(key):
         key_type = type(all_agent_data[0][key])
         tooltip_type = ""
-        if (key_type == int):
+        if key_type == int:
             tooltip_type = "quantitative"
-        elif (key_type == datetime.datetime):
+        elif key_type == datetime.datetime:
             tooltip_type = "temporal"
         else:
             tooltip_type = "nominal"
@@ -49,7 +49,6 @@ def _draw_grid(space, agent_portrayal):
             # change tooltip_type to "temporal"
 
         return tooltip_type
-
 
     all_agent_data = portray(space)
     invalid_tooltips = ["color", "size", "x", "y"]
@@ -65,8 +64,10 @@ def _draw_grid(space, agent_portrayal):
         # no y-axis label
         "y": alt.Y("y", axis=None, type="ordinal"),
         "tooltip": [
-            alt.Tooltip(key, type=tooltip_types[key]) for key in all_agent_data[0].keys() if key not in invalid_tooltips
-        ]
+            alt.Tooltip(key, type=tooltip_types[key])
+            for key in all_agent_data[0].keys()
+            if key not in invalid_tooltips
+        ],
     }
     has_color = "color" in all_agent_data[0]
     if has_color:

--- a/mesa/experimental/components/altair.py
+++ b/mesa/experimental/components/altair.py
@@ -1,5 +1,6 @@
 import contextlib
 from typing import Optional
+import datetime
 
 import solara
 
@@ -20,7 +21,7 @@ def SpaceAltair(model, agent_portrayal, dependencies: Optional[list[any]] = None
 def _draw_grid(space, agent_portrayal):
     def portray(g):
         all_agent_data = []
-        for content, (x, y) in space.coord_iter():
+        for content, (x, y) in g.coord_iter():
             if not content:
                 continue
             if not hasattr(content, "__iter__"):
@@ -34,12 +35,38 @@ def _draw_grid(space, agent_portrayal):
                 all_agent_data.append(agent_data)
         return all_agent_data
 
+    def detect_type(key):
+        key_type = type(all_agent_data[0][key])
+        tooltip_type = ""
+        if (key_type == int):
+            tooltip_type = "quantitative"
+        elif (key_type == datetime.datetime):
+            tooltip_type = "temporal"
+        else:
+            tooltip_type = "nominal"
+            # TODO: check if the string can be considered
+            # as a date time object and, if so,
+            # change tooltip_type to "temporal"
+
+        return tooltip_type
+
+
     all_agent_data = portray(space)
+    invalid_tooltips = ["color", "size", "x", "y"]
+
+    tooltip_types = {}
+    for key in all_agent_data[0].keys():
+        if key not in invalid_tooltips:
+            tooltip_types[key] = detect_type(key)
+
     encoding_dict = {
         # no x-axis label
         "x": alt.X("x", axis=None, type="ordinal"),
         # no y-axis label
         "y": alt.Y("y", axis=None, type="ordinal"),
+        "tooltip": [
+            alt.Tooltip(key, type=tooltip_types[key]) for key in all_agent_data[0].keys() if key not in invalid_tooltips
+        ]
     }
     has_color = "color" in all_agent_data[0]
     if has_color:

--- a/mesa/experimental/components/altair.py
+++ b/mesa/experimental/components/altair.py
@@ -1,5 +1,4 @@
 import contextlib
-import datetime
 from typing import Optional
 
 import solara
@@ -35,28 +34,9 @@ def _draw_grid(space, agent_portrayal):
                 all_agent_data.append(agent_data)
         return all_agent_data
 
-    def detect_type(key):
-        key_type = type(all_agent_data[0][key])
-        tooltip_type = ""
-        if key_type == int:
-            tooltip_type = "quantitative"
-        elif key_type == datetime.datetime:
-            tooltip_type = "temporal"
-        else:
-            tooltip_type = "nominal"
-            # TODO: check if the string can be considered
-            # as a date time object and, if so,
-            # change tooltip_type to "temporal"
-
-        return tooltip_type
 
     all_agent_data = portray(space)
     invalid_tooltips = ["color", "size", "x", "y"]
-
-    tooltip_types = {}
-    for key in all_agent_data[0].keys():
-        if key not in invalid_tooltips:
-            tooltip_types[key] = detect_type(key)
 
     encoding_dict = {
         # no x-axis label
@@ -64,10 +44,9 @@ def _draw_grid(space, agent_portrayal):
         # no y-axis label
         "y": alt.Y("y", axis=None, type="ordinal"),
         "tooltip": [
-            alt.Tooltip(key, type=tooltip_types[key])
-            for key in all_agent_data[0].keys()
-            if key not in invalid_tooltips
-        ],
+            alt.Tooltip(key, type=alt.utils.infer_vegalite_type([all_agent_data[0][key]])) 
+                for key in all_agent_data[0] if key not in invalid_tooltips
+        ]
     }
     has_color = "color" in all_agent_data[0]
     if has_color:


### PR DESCRIPTION
I added in the altair.py experimental script the option to see a tooltip on each agent in the canvas when hovering on them. The logic is to see every option described by the agent_portrayal function, except for the x, y, color and size properties.
When defining the type of each tooltip, I didn't manage to find an optimal algorithm to check if a string can be considered a date object, in order to change its type from "nominal" to "temporal", without using an external library called [dateutil](https://pypi.org/project/python-dateutil/), which contains the function parser.parse() that returns a boolean if the string is a right date format.

Here is an example:
```Python
import mesa
import solara
from matplotlib.figure import Figure
from mesa.experimental import JupyterViz
from money_model.agent import MoneyAgent
from money_model.model import MoneyModel


def agent_portrayal(MoneyAgent):
    size = 10
    color = "tab:red"
    if MoneyAgent.wealth > 0:
        size = 50
        color = "tab:blue"
    if MoneyAgent.unique_id == 0:
        size = 60
        color = "yellow"
    return {"size": size, "color": color, "Unique_id": MoneyAgent.unique_id}


def make_histogram(model):
    # ...

model_params = {
    # ...
}

page = JupyterViz(
    model_class=MoneyModel,
    model_params=model_params,
    measures=[make_histogram],
    name="Money Model",
    agent_portrayal=agent_portrayal,
    space_drawer="altair"
)
# This is required to render the visualization in the Jupyter notebook
page
```

In the agent_portrayal function, I set that every agent will have a tooltip to see their unique_id.
If we run this script using solara:

![image](https://github.com/projectmesa/mesa/assets/74419371/692f7b74-f380-4c0e-bef9-df8d280e8b76)

If I click on "View Source" in the altair chart, the content is:
```
{
  "config": {"view": {"continuousWidth": 300, "continuousHeight": 300}},
  "data": {
    "values": [
      {"size": 50, "color": "tab:blue", "Unique_id": 3, "x": 0, "y": 1},
      {"size": 50, "color": "tab:blue", "Unique_id": 48, "x": 0, "y": 3},
      {"size": 50, "color": "tab:blue", "Unique_id": 26, "x": 0, "y": 5},
      {"size": 50, "color": "tab:blue", "Unique_id": 12, "x": 1, "y": 0},
     // ...
      {"size": 50, "color": "tab:blue", "Unique_id": 27, "x": 9, "y": 8}
    ]
  },
  "mark": {"type": "point", "filled": true},
  "encoding": {
    "color": {"field": "color", "type": "nominal"},
    "size": {"field": "size", "type": "quantitative"},
    "tooltip": [{"field": "Unique_id", "type": "quantitative"}],
    "x": {"axis": null, "field": "x", "type": "ordinal"},
    "y": {"axis": null, "field": "y", "type": "ordinal"}
  },
  "height": 280,
  "width": 280,
  "$schema": "https://vega.github.io/schema/vega-lite/v5.16.3.json"
}
```
What's new is the tooltip array element and the unique_id value on each agent.