### PR TITLE
Remove mesa.flat namespace

### DIFF
--- a/mesa/flat/__init__.py
+++ b/mesa/flat/__init__.py
@@ -1,6 +1,0 @@
-from mesa import *  # noqa
-from mesa.time import *  # noqa
-from mesa.space import *  # noqa
-from mesa.datacollection import *  # noqa
-from .visualization import *  # noqa
-from mesa.batchrunner import batch_run  # noqa

--- a/mesa/flat/visualization.py
+++ b/mesa/flat/visualization.py
@@ -1,5 +1,0 @@
-# This collects all of Mesa visualization components under a flat namespace.
-from mesa_viz_tornado.ModularVisualization import *  # noqa
-from mesa_viz_tornado.modules import *  # noqa
-from mesa_viz_tornado.UserParam import *  # noqa
-from mesa_viz_tornado.TextVisualization import *  # noqa

--- a/tests/test_import_namespace.py
+++ b/tests/test_import_namespace.py
@@ -2,30 +2,25 @@ def test_import():
     # This tests the new, simpler Mesa namespace. See
     # https://github.com/projectmesa/mesa/pull/1294.
     import mesa
-    import mesa.flat as mf
     from mesa.time import RandomActivation
 
     _ = mesa.time.RandomActivation
     _ = RandomActivation
-    _ = mf.RandomActivation
 
     from mesa.space import MultiGrid
 
     _ = mesa.space.MultiGrid
     _ = MultiGrid
-    _ = mf.MultiGrid
 
     from mesa.visualization_old.ModularVisualization import ModularServer
 
     _ = mesa.visualization_old.ModularServer
     _ = ModularServer
-    _ = mf.ModularServer
 
     from mesa.datacollection import DataCollector
 
     _ = DataCollector
     _ = mesa.DataCollector
-    _ = mf.DataCollector
 
     from mesa.batchrunner import batch_run
 


### PR DESCRIPTION
This doesn't seem to be used as often as the current simple namespace.