### PR TITLE
Fix issue#1768. Change model_vars[var] from List to Dictionary in datacollector.py

### DIFF
--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -107,8 +107,8 @@ class TestDataCollector(unittest.TestCase):
             agent.write_final_values()
 
     def step_assertion(self, model_var):
-        for element in model_var:
-            if model_var.index(element) < 4:
+        for index, element in enumerate(model_var.values()):
+            if index <= 4:
                 assert element == 10
             else:
                 assert element == 9
@@ -129,12 +129,12 @@ class TestDataCollector(unittest.TestCase):
         assert len(data_collector.model_vars["model_calc"]) == length
         assert len(data_collector.model_vars["model_calc_comp"]) == length
         self.step_assertion(data_collector.model_vars["total_agents"])
-        for element in data_collector.model_vars["model_value"]:
+        for element in data_collector.model_vars["model_value"].values():
             assert element == 100
         self.step_assertion(data_collector.model_vars["model_calc"])
-        for element in data_collector.model_vars["model_calc_comp"]:
+        for element in data_collector.model_vars["model_calc_comp"].values():
             assert element == 75
-        for element in data_collector.model_vars["model_calc_fail"]:
+        for element in data_collector.model_vars["model_calc_fail"].values():
             assert element is None
 
     def test_agent_records(self):


### PR DESCRIPTION
As discussed in the issue, changed `model_vars[var]` in the datacollector from list to dictionary to keep the `step` column in `get_model_vars_dataframe()` and `get_agent_vars_dataframe()` synchronized.

Changed the `test_datacollector.py` accordingly to fit it to the new dictionary structure.

One point I'd need some suggestion is,
Previously in the `step_assertion` function of `test_datacollector.py`, [this](https://github.com/projectmesa/mesa/blob/51b4e9a4c98c9e242cbe7bbf3b61275719a3126a/tests/test_datacollector.py#L112) line was checking if the index of the currently selected element is less than 4. But actually the `index()` function returns the first occurrence of an item in the list. So because the `model_var` list actually contains 5 consecutive 10s the `index()` function always returns  0 for `element=10` but if i understand right, [line 133](https://github.com/projectmesa/mesa/blob/51b4e9a4c98c9e242cbe7bbf3b61275719a3126a/tests/test_datacollector.py#L113) is supposed to run only for 4 iterations but due to the `index()` function always returning zero Line 133 runs for 5 consecutive iterations. 

I assumed this was unintentional and lline 133 should actually run for 5 iterations so i wrote my test file accordingly. If my assumption was wrong or i need to make any modifications to the code please do let me know.