### PR TITLE
Make agent move to actual random closest position

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -461,7 +461,7 @@ class _Grid:
                 # Find the closest position without sorting all positions
                 closest_pos = None
                 min_distance = float("inf")
-                for p in pos:
+                for p in agent.random.shuffle(pos):
                     distance = self._distance_squared(p, current_pos)
                     if distance < min_distance:
                         min_distance = distance


### PR DESCRIPTION
This fixes a bug in which `move_agent_to_one_of` is deterministic when pos has multiple closest choices and `selection="closest"`.

Closes #2117.