### PR TITLE
flocking benchmark: Remove unneeded passing of pos

### DIFF
--- a/benchmarks/Flocking/flocking.py
+++ b/benchmarks/Flocking/flocking.py
@@ -139,7 +139,6 @@ class BoidFlockers(mesa.Model):
             boid = Boid(
                 unique_id=i,
                 model=self,
-                pos=pos,
                 speed=speed,
                 direction=direction,
                 vision=vision,


### PR DESCRIPTION
`pos` is not a part of the Boid init, which is causing an error. It can be safely removed, because it's already initialized the line below with:
```Python
self.space.place_agent(boid, pos)
```
Thanks to @rht for suggesting the fix.

Closes #2124.