### PR TITLE
CI: Add weekly scheduled run to all CI workflows

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 # This will cancel previous run if a newer job that obsoletes the said previous
 # run, is started.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
       - '**.md'
       - '**.rst'
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 permissions:
   id-token: write


### PR DESCRIPTION
Adds a weekly scheduled run to all CI workflows, which run each Monday at 06:00 UTC. A periodically scheduled run can detect errors and warnings appearing in changes in upstream dependencies or the build environment. By having a scheduled run they can be traced back easier to a dependency or environment change, then if they would pop up in a random PR.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule for more details.

Also enabled triggering a run manually (the `workflow_dispatch`).