### PR TITLE
Fix image on landing page of docs.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,11 +20,9 @@
 
 Mesa allows users to quickly create agent-based models using built-in core components (such as spatial grids and agent schedulers) or customized implementations; visualize them using a browser-based interface; and analyze their results using Python's data analysis tools. Its goal is to be the Python-based counterpart to NetLogo, Repast, or MASON.
 
-```{image} https://raw.githubusercontent.com/projectmesa/mesa/main/docs/images/Mesa_Screenshot.png
-:alt: A screenshot of the Schelling Model in Mesa
-:scale: 100%
-:width: 100%
-```
+
+![A screenshot of the Schelling Model in Mesa|100%](https://raw.githubusercontent.com/projectmesa/mesa/main/docs/images/Mesa_Screenshot.png)
+
 
 *Above: A Mesa implementation of the Schelling segregation model,
 being visualized in a browser window and analyzed in a Jupyter


### PR DESCRIPTION
This error was on the homepage of the docs. 

<img width="723" alt="Screenshot 2024-05-20 at 11 41 40 AM" src="https://github.com/projectmesa/mesa/assets/166734/d195129c-e6d9-461c-9b8a-cf2dc70b9b9b">

You can see it here: https://mesa.readthedocs.io/en/latest/

This PR fixes is & can be seen here: 
https://mesa.readthedocs.io/en/doc_builds/
