### PR TITLE
Add experimental features to documentation as per #2122

### DIFF
--- a/docs/apis/api_main.md
+++ b/docs/apis/api_main.md
@@ -9,4 +9,5 @@ space
 datacollection
 batchrunner
 visualization
+experimental
 ```

--- a/docs/apis/experimental.md
+++ b/docs/apis/experimental.md
@@ -1,0 +1,60 @@
+# Experimental
+
+```{eval-rst}
+.. automodule:: experimental.__init__
+   :members:
+```
+
+## Cell Space
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.__init__
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.cell
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.cell_agent
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.cell_collection
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.discrete_space
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.grid
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.network
+   :members:
+```
+
+## Devs
+
+```{eval-rst}
+.. automodule:: experimental.devs.__init__
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.devs.eventlist
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.devs.simulator
+   :members:
+```


### PR DESCRIPTION
Adding the objects from `experimental.cell_space` and `experimental.devs` to the ReadTheDocs documentation, as per issue #2122.

Tested locally using sphinx and seems to work fine.