### PR TITLE
Fixed batch_run accepting empty iterables

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -95,6 +95,9 @@ def _make_model_kwargs(
         if isinstance(values, str):
             # The values is a single string, so we shouldn't iterate over it.
             all_values = [(param, values)]
+        elif isinstance(values, Iterable) and len(values) == 0:
+            # The values is an empty iterable, so we shouldn't iterate over it.
+            all_values = [(param, values)]
         else:
             try:
                 all_values = [(param, value) for value in values]

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -21,6 +21,8 @@ def test_make_model_kwargs():
     ]
     # If the value is a single string, do not iterate over it.
     assert _make_model_kwargs({"a": "value"}) == [{"a": "value"}]
+    # If the values is an empty iterable, don't iterate over it.
+    assert _make_model_kwargs({"a": []}) == [{"a": []}]
 
 
 class MockAgent(Agent):
@@ -65,7 +67,8 @@ class MockModel(Model):
         else:
             agent_reporters = None
         self.datacollector = DataCollector(
-            model_reporters={"reported_model_param": self.get_local_model_param},
+            model_reporters={
+                "reported_model_param": self.get_local_model_param},
             agent_reporters=agent_reporters,
         )
         self.running = True

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -67,8 +67,7 @@ class MockModel(Model):
         else:
             agent_reporters = None
         self.datacollector = DataCollector(
-            model_reporters={
-                "reported_model_param": self.get_local_model_param},
+            model_reporters={"reported_model_param": self.get_local_model_param},
             agent_reporters=agent_reporters,
         )
         self.running = True


### PR DESCRIPTION
### Description
This PR addresses an issue in the batch_run method where parameters must be iterable and non-empty.

### Changes
Added iterable and non-empty checks in _make_model_kwargs.
Updated batch_run to handle only valid parameters.
### Issue Reference
Closes #2108 