### PR TITLE
Fix pre-commit issues: Codespels and typecheck

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -6,3 +6,4 @@ inactivate
 ue
 fpr
 falsy
+assertIn

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, caste, color, religion, or sexual
 identity and orientation.
 

--- a/docs/tutorials/adv_tutorial_legacy.ipynb
+++ b/docs/tutorials/adv_tutorial_legacy.ipynb
@@ -158,7 +158,7 @@
     "\n",
     "![Redcircles Visualization](files/viz_redcircles.png)\n",
     "\n",
-    "Click `Step` to advance the model by one step, and the agents will move around. Click `Start` and the agents will keep moving around, at the rate set by the 'fps' (frames per second) slider at the top. Try moving it around and see how the speed of the model changes. Pressing `Stop` will pause the model; presing `Start` again will restart it. Finally, `Reset` will start a new instantiation of the model.\n",
+    "Click `Step` to advance the model by one step, and the agents will move around. Click `Start` and the agents will keep moving around, at the rate set by the 'fps' (frames per second) slider at the top. Try moving it around and see how the speed of the model changes. Pressing `Stop` will pause the model; pressing `Start` again will restart it. Finally, `Reset` will start a new instantiation of the model.\n",
     "\n",
     "To stop the visualization server, go back to the terminal where you launched it, and press Control+c."
    ]

--- a/mesa/visualization/UserParam.py
+++ b/mesa/visualization/UserParam.py
@@ -47,7 +47,7 @@ class Slider(UserParam):
         if dtype is None:
             self.is_float_slider = self._check_values_are_float(value, min, max, step)
         else:
-            self.is_float_slider = dtype == float
+            self.is_float_slider = dtype is float
 
     def _check_values_are_float(self, value, min, max, step):
         return any(isinstance(n, float) for n in (value, min, max, step))


### PR DESCRIPTION
Fixes two things pre-commit detected:
- Some codespell errors
- A case of E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks

After this PR all pre-commit checks are passing again.