### PR TITLE
Jupyter_viz: Allow measures to be None

### DIFF
--- a/mesa/visualization/jupyter_viz.py
+++ b/mesa/visualization/jupyter_viz.py
@@ -143,14 +143,15 @@ def JupyterViz(
             # otherwise, do nothing (do not draw space)
 
             # 5. Plots
-            for measure in measures:
-                if callable(measure):
-                    # Is a custom object
-                    measure(model)
-                else:
-                    components_matplotlib.PlotMatplotlib(
-                        model, measure, dependencies=dependencies
-                    )
+            if measures:
+                for measure in measures:
+                    if callable(measure):
+                        # Is a custom object
+                        measure(model)
+                    else:
+                        components_matplotlib.PlotMatplotlib(
+                            model, measure, dependencies=dependencies
+                        )
 
     def render_in_browser():
         # if space drawer is disabled, do not include it


### PR DESCRIPTION
Currently `measures` crashed when it's `None` (which is the default). The only way to circumvent this is adding `[]`, but that's non-ideal and not obvious.

This PR fixes that, so that `measures` can actually be the default value of `None`.

This also proves we need to test Jupyter viz in notebooks, not only in console, since both have different code paths.