### PR TITLE
Jupyter Viz: Don't avoid interactive backend

### DIFF
--- a/mesa/visualization/jupyter_viz.py
+++ b/mesa/visualization/jupyter_viz.py
@@ -26,7 +26,6 @@ See the Visualization Tutorial and example models for more details.
 import sys
 import threading
 
-import matplotlib.pyplot as plt
 import reacton.ipywidgets as widgets
 import solara
 from solara.alias import rv

--- a/mesa/visualization/jupyter_viz.py
+++ b/mesa/visualization/jupyter_viz.py
@@ -35,9 +35,6 @@ import mesa.visualization.components.altair as components_altair
 import mesa.visualization.components.matplotlib as components_matplotlib
 from mesa.visualization.UserParam import Slider
 
-# Avoid interactive backend
-plt.switch_backend("agg")
-
 
 # TODO: Turn this function into a Solara component once the current_step.value
 # dependency is passed to measure()


### PR DESCRIPTION
We were avoiding the interactive backend, but that isn't recommended anymore and Solara should take care of that itself.

Removing this resolves this bug:

> For some reason, regular matplotlib and seaborn plots don't show anymore *after* a Solara page has been initiated. In the code below you can see the first seaborn plot showing well, but the second not showing.
> 
> In PyCharm, the first plot is also shown fine, but instead of just not showing the second plot anymore, but gives an error:
> 
> ```
> ipykernel_29332\2165788151.py:2: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
>   plt.show()
> ```

For details, see https://github.com/widgetti/solara/issues/703, which this PR resolves.