### PR TITLE
Visualisation: Allow different shapes agent portrayals#2164 

### DIFF
--- a/mesa/visualization/components/altair.py
+++ b/mesa/visualization/components/altair.py
@@ -55,10 +55,10 @@ def _draw_grid(space, agent_portrayal):
         encoding_dict["size"] = alt.Size("size", type="quantitative")
     has_shape = "shape" in all_agent_data[0]
     if has_shape:
-        encoding_dict["shape"] = agent_data["shape"]
+        encoding_dict["shape"] = all_agent_data["shape"]
     has_fill = "fill" in all_agent_data[0]
-    if has_shape:
-        encoding_dict["fill"] = agent_data["fill"]
+    if has_fill:
+        encoding_dict["fill"] = all_agent_data["fill"]
 
     chart = (
         alt.Chart(

--- a/mesa/visualization/components/altair.py
+++ b/mesa/visualization/components/altair.py
@@ -53,6 +53,12 @@ def _draw_grid(space, agent_portrayal):
     has_size = "size" in all_agent_data[0]
     if has_size:
         encoding_dict["size"] = alt.Size("size", type="quantitative")
+    has_shape = "shape" in all_agent_data[0]
+    if has_shape:
+        encoding_dict["shape"] = agent_data["shape"]
+    has_fill = "fill" in all_agent_data[0]
+    if has_shape:
+        encoding_dict["fill"] = agent_data["fill"]
 
     chart = (
         alt.Chart(


### PR DESCRIPTION

Hi, this is Draft Solution to #2164.

I was thinking about using the below, which use the Encode function attribute 

The added code snippet checks for shape and fill keys in agent data. If present, it adds them to the encoding_dict using the corresponding keys shape and fill. This allows you to define visual properties like circle shapes and filled elements for agents in your visualization.



Draft: Addition of 2 keys in enconding_dict: shape(str) and fill(bool)