### PR TITLE
CI: Add test job for Python 3.13

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -53,9 +53,12 @@ jobs:
         cache: 'pip'
     - name: Install uv
       run: pip install uv
-    - name: Install Mesa
-      # See https://github.com/astral-sh/uv/issues/1945
+    - name: Install Mesa with uv pip
       run: uv pip install --system .[dev]
+      if: matrix.python-version != '3.13'
+    - name: Install Mesa with pip
+      run: pip install .[dev]
+      if: matrix.python-version == '3.13'
     - name: Test with pytest
       run: pytest --durations=10 --cov=mesa tests/ --cov-report=xml
     - if: matrix.os == 'ubuntu'

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -34,6 +34,8 @@ jobs:
         python-version: ["3.12"]
         include:
           - os: ubuntu
+            python-version: "3.13"
+          - os: ubuntu
             python-version: "3.11"
           - os: ubuntu
             python-version: "3.10"
@@ -47,6 +49,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: 'pip'
     - name: Install uv
       run: pip install uv


### PR DESCRIPTION
Python 3.13 is now in beta, thus is might be useful to start testing what works and what doesn't.

This PR adds a Python 3.13 job on Ubuntu.

Dependency tracker
- [x] rpds (https://github.com/crate-py/rpds/pull/79)
- [x] watchfiles (https://github.com/samuelcolvin/watchfiles/issues/276, https://github.com/samuelcolvin/watchfiles/pull/287)
- [x] matplotlib (https://github.com/matplotlib/matplotlib/pull/28688, waiting on 3.9.2 release)