### PR TITLE
fix: Render agent marker radius correctly

### DIFF
--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -48,7 +48,7 @@ def _draw_grid(space, space_ax, agent_portrayal):
         out = {"x": x, "y": y}
         # This is the default value for the marker size, which auto-scales
         # according to the grid area.
-        out["s"] = (180 / min(g.width, g.height)) ** 2
+        out["s"] = (180 / max(g.width, g.height)) ** 2
         if len(s) > 0:
             out["s"] = s
         if len(c) > 0:


### PR DESCRIPTION
Previously, on a 2x20 Schelling grid (extremely tall on the vertical direction, but thin on horizontal direction)
![before](https://github.com/user-attachments/assets/8b487c7d-ce76-4d9b-bc9e-d941cfcc7704)
With this PR
![after](https://github.com/user-attachments/assets/a3616376-0341-4737-8dc4-eef0dc1cd03a)
