### PR TITLE
devs/eventlist: Add str and repr methods to print EventList

### DIFF
--- a/mesa/experimental/devs/eventlist.py
+++ b/mesa/experimental/devs/eventlist.py
@@ -157,7 +157,13 @@ class EventList:
 
     def __str__(self) -> str:
         """Return a string representation of the event list"""
-        events_str = ', '.join([f"Event(time={e.time}, priority={e.priority}, id={e.unique_id})" for e in self._events if not e.CANCELED])
+        events_str = ", ".join(
+            [
+                f"Event(time={e.time}, priority={e.priority}, id={e.unique_id})"
+                for e in self._events
+                if not e.CANCELED
+            ]
+        )
         return f"EventList([{events_str}])"
 
     def __repr__(self) -> str:

--- a/mesa/experimental/devs/eventlist.py
+++ b/mesa/experimental/devs/eventlist.py
@@ -155,7 +155,7 @@ class EventList:
     def __len__(self) -> int:
         return len(self._events)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return a string representation of the event list"""
         events_str = ", ".join(
             [
@@ -165,9 +165,6 @@ class EventList:
             ]
         )
         return f"EventList([{events_str}])"
-
-    def __repr__(self) -> str:
-        return self.__str__()
 
     def remove(self, event: SimulationEvent) -> None:
         """remove an event from the event list"""

--- a/mesa/experimental/devs/eventlist.py
+++ b/mesa/experimental/devs/eventlist.py
@@ -155,6 +155,14 @@ class EventList:
     def __len__(self) -> int:
         return len(self._events)
 
+    def __str__(self) -> str:
+        """Return a string representation of the event list"""
+        events_str = ', '.join([f"Event(time={e.time}, priority={e.priority}, id={e.unique_id})" for e in self._events if not e.CANCELED])
+        return f"EventList([{events_str}])"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
     def remove(self, event: SimulationEvent) -> None:
         """remove an event from the event list"""
         # we cannot simply remove items from _eventlist because this breaks


### PR DESCRIPTION
Add `__str__` and `__repr__` methods to print `EventList` objects in a useful format.

In models, this allows doing things like `print(self.simulator.event_list)` to validate the events queued in your simulator.

Output of `print(self.simulator.event_list)`:
- Before: `<mesa.experimental.devs.eventlist.EventList object at 0x00000186E42AF830>`
- After: `EventList([Event(time=7.046389752627814, priority=5, id=0), Event(time=8.305480965357855, priority=5, id=9), Event(time=10.904561103085891, priority=5, id=6)])`