### PR TITLE
chore: Remove unused direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
   "ruff~=0.1.1",   # Update periodically
-  "coverage",
   "pytest >= 4.6",
   "pytest-cov",
   "sphinx",


### PR DESCRIPTION
This dependency isn't used directly, because there is already pytest-cov.