### PR TITLE
Implement experimental DataCollector API v3

### DIFF
--- a/mesa/experimental/__init__.py
+++ b/mesa/experimental/__init__.py
@@ -1,3 +1,4 @@
 from mesa.experimental import cell_space
+from mesa.experimental.datacollector import DataCollector
 
-__all__ = ["cell_space"]
+__all__ = ["cell_space", "DataCollector"]

--- a/mesa/experimental/datacollector.py
+++ b/mesa/experimental/datacollector.py
@@ -1,0 +1,42 @@
+from collections import defaultdict
+
+import pandas as pd
+
+
+class DataCollector:
+    def __init__(self, model, group_reporters, groups=None):
+        self.model = model
+        self.group_reporters = group_reporters
+        self.groups = groups
+        self.data = defaultdict(lambda: defaultdict(list))
+
+    def get_group(self, group_name):
+        if group_name == "model":
+            return self.model
+        elif group_name == "agents":
+            return self.model.agents
+        else:
+            try:
+                return getattr(self.model, group_name)
+            except AttributeError as e:
+                raise Exception(f"Unknown group: {group_name}") from e
+
+    def report(self, reporter, group):
+        if group is self.model:
+            return reporter(group)
+        if isinstance(reporter, str):
+            if hasattr(group, "get"):
+                return group.get(reporter)
+            else:
+                raise Exception()
+        return reporter(group)
+
+    def collect(self):
+        for group_name, reporters in self.group_reporters.items():
+            group = self.get_group(group_name)
+            for name, reporter in reporters.items():
+                value = self.report(reporter, group)
+                self.data[group_name][name].append(value)
+
+    def to_df(self, group_name):
+        return pd.DataFrame(self.data[group_name])

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -117,7 +117,7 @@ def _draw_continuous_space(space, space_ax, agent_portrayal):
 def PlotMatplotlib(model, measure, dependencies: list[any] | None = None):
     fig = Figure()
     ax = fig.subplots()
-    df = model.datacollector.get_model_vars_dataframe()
+    df = model.datacollector.to_df("model")
     if isinstance(measure, str):
         ax.plot(df.loc[:, measure])
         ax.set_ylabel(measure)


### PR DESCRIPTION
Given that the fall semester is starting soon, there is not enough time to build a comprehensive new data collection API. So this is what I have cooked this afternoon.
It addresses https://github.com/projectmesa/mesa/discussions/1944#discussioncomment-8364109:
1. You can collect based on agent types using custom groups
2. Also via custom groups
3. Single-use measure is not yet addressed
4. Not yet measured for performance
5. There is `to_df` in this PR, and this feature is actually used in visualization
6. TODO
7. TODO, but this doesn't affect the API
8. I prefer 2-level grouping instead of flat dictionary. This allows for easy export to DF
9. TODO

and https://github.com/projectmesa/mesa/discussions/1944#discussioncomment-8439418:
1. same as 2 above
2. already implemented
3. already implemented in `to_df`

TODO:
- [ ] error handling
- [ ] documentation
- [ ] testing
- [ ] examples