### PR TITLE
CI: Let pytest treat warnings as errors for examples

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -80,4 +80,4 @@ jobs:
     - name: Test examples
       run: |
         cd mesa-examples
-        pytest test_examples.py
+        pytest -rA -Werror test_examples.py


### PR DESCRIPTION
When running the examples, let pytest treat warnings as errors for examples. After https://github.com/projectmesa/mesa-examples/pull/153 got merged, there shouldn't be any warnings left when testing the examples.

Also print a summary of tests using the `-rA` flag.