### PR TITLE
docs/conf.py: Use modern `intersphinx_mapping` format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,4 +279,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"http://docs.python.org/": None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
With Sphinx 8.0 they [removed](https://github.com/sphinx-doc/sphinx/pull/12083) the old `intersphinx_mapping` format we were still using, which was introduced in Sphinx 0.5. This means an 10 year old line of code got our docs failing.

This commit updates the `docs/conf.py` file to use the new `intersphinx_mapping` format, as [described here](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping).

Resolves #2205.