### PR TITLE
enhance AgentSet.do to accept a callable

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -227,7 +227,7 @@ class AgentSet(MutableSet, Sequence):
         return self
 
     def do(
-        self, callable: str|Callable, *args, return_results: bool = False, **kwargs
+        self, callable: str | Callable, *args, return_results: bool = False, **kwargs
     ) -> AgentSet | list[Any]:
         """
         Invoke a method or function on each agent in the AgentSet.
@@ -258,7 +258,6 @@ class AgentSet(MutableSet, Sequence):
                 for agentref in self._agents.keyrefs()
                 if (agent := agentref()) is not None
             ]
-
 
         return res if return_results else self
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -389,7 +389,7 @@ class AgentSet(MutableSet, Sequence):
         else:
             raise ValueError(f"axis should be `agent` or `agentset` not {axis}")
 
-    def group_by(self, by: Callable | str) -> dict[str, AgentSet]:
+    def group_by(self, by: Callable | str, return_agentset=False) -> dict[str, list] | dict[str, AgentSet]:
         """
         Group agents by the specified attribute
 
@@ -400,8 +400,19 @@ class AgentSet(MutableSet, Sequence):
                                   for grouping
                                 * if ``by`` is a str, it should refer to an attribute on the agent and the value
                                   of this attribute will be used for grouping
+
+            return_agentset (bool, optional): Controls the datatype of the values in the return dictionary. Given
+                                              the performance overhead of creating an AgentSet, it defaults to
+                                              returning a list. Only set to true if you need the advanced
+                                              functionality of AgentSet.
+
+                                                * If False, values will be a list
+                                                * If True, values will be an AgentSet
+
+
         Returns:
-            dictionary with the group identifier (i.e., attribute value) as key and an AgentSet as value
+            dictionary with the group identifier (i.e., callable return or attribute value) as key and an AgentSet as
+            value
 
         """
         groups = defaultdict(list)
@@ -413,7 +424,9 @@ class AgentSet(MutableSet, Sequence):
             for agent in self:
                 groups[getattr(agent, by)].append(agent)
 
-        return {k: AgentSet(v) for k, v in groups.items()}
+        if return_agentset:
+            return {k: AgentSet(v) for k, v in groups.items()}
+        return groups
 
 
 # consider adding for performance reasons

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -127,11 +127,11 @@ class AgentSet(MutableSet, Sequence):
         return agent in self._agents
 
     def select(
-        self,
-        filter_func: Callable[[Agent], bool] | None = None,
-        n: int = 0,
-        inplace: bool = False,
-        agent_type: type[Agent] | None = None,
+            self,
+            filter_func: Callable[[Agent], bool] | None = None,
+            n: int = 0,
+            inplace: bool = False,
+            agent_type: type[Agent] | None = None,
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
@@ -154,7 +154,7 @@ class AgentSet(MutableSet, Sequence):
             count = 0
             for agent in self:
                 if (not filter_func or filter_func(agent)) and (
-                    not agent_type or isinstance(agent, agent_type)
+                        not agent_type or isinstance(agent, agent_type)
                 ):
                     yield agent
                     count += 1
@@ -191,10 +191,10 @@ class AgentSet(MutableSet, Sequence):
             )
 
     def sort(
-        self,
-        key: Callable[[Agent], Any] | str,
-        ascending: bool = False,
-        inplace: bool = False,
+            self,
+            key: Callable[[Agent], Any] | str,
+            ascending: bool = False,
+            inplace: bool = False,
     ) -> AgentSet:
         """
         Sort the agents in the AgentSet based on a specified attribute or custom function.
@@ -227,7 +227,7 @@ class AgentSet(MutableSet, Sequence):
         return self
 
     def do(
-        self, method_name: str, *args, return_results: bool = False, **kwargs
+            self, method_name: str, *args, return_results: bool = False, **kwargs
     ) -> AgentSet | list[Any]:
         """
         Invoke a method on each agent in the AgentSet.
@@ -357,7 +357,7 @@ class AgentSet(MutableSet, Sequence):
         return self.model.random
 
     def apply(
-        self, func: Callable, axis: str = "agent", args=(), result_type=None, **kwargs
+            self, func: Callable, axis: str = "agent", args=(), result_type=None, **kwargs
     ) -> list[Any] | Any:
         """
         Apply a function to all agents in the AgentSet either to each agent individually or to the entire agentset.
@@ -389,6 +389,31 @@ class AgentSet(MutableSet, Sequence):
         else:
             raise ValueError(f"axis should be `agent` or `agentset` not {axis}")
 
+    def group_by(self, by: Callable | str) -> dict[str, AgentSet]:
+        """
+        Group agents by the specified attribute
+
+        Args:
+            by (Callable, str): used to determine what to group agents by
+
+                                * if ``by`` is a callable, it will be called for each agent and the return is used
+                                  for grouping
+                                * if ``by`` is a str, it should refer to an attribute on the agent and the value
+                                  of this attribute will be used for grouping
+        Returns:
+            dictionary with the group identifier (i.e., attribute value) as key and an AgentSet as value
+
+        """
+        groups = defaultdict(list)
+
+        if isinstance(by, Callable):
+            for agent in self:
+                groups[by(agent)].append(agent)
+        else:
+            for agent in self:
+                groups[getattr(agent, by)].append(agent)
+
+        return {k: AgentSet(v) for k, v in groups.items()}
 
 # consider adding for performance reasons
 # for Sequence: __reversed__, index, and count

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -127,11 +127,11 @@ class AgentSet(MutableSet, Sequence):
         return agent in self._agents
 
     def select(
-            self,
-            filter_func: Callable[[Agent], bool] | None = None,
-            n: int = 0,
-            inplace: bool = False,
-            agent_type: type[Agent] | None = None,
+        self,
+        filter_func: Callable[[Agent], bool] | None = None,
+        n: int = 0,
+        inplace: bool = False,
+        agent_type: type[Agent] | None = None,
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
@@ -154,7 +154,7 @@ class AgentSet(MutableSet, Sequence):
             count = 0
             for agent in self:
                 if (not filter_func or filter_func(agent)) and (
-                        not agent_type or isinstance(agent, agent_type)
+                    not agent_type or isinstance(agent, agent_type)
                 ):
                     yield agent
                     count += 1
@@ -191,10 +191,10 @@ class AgentSet(MutableSet, Sequence):
             )
 
     def sort(
-            self,
-            key: Callable[[Agent], Any] | str,
-            ascending: bool = False,
-            inplace: bool = False,
+        self,
+        key: Callable[[Agent], Any] | str,
+        ascending: bool = False,
+        inplace: bool = False,
     ) -> AgentSet:
         """
         Sort the agents in the AgentSet based on a specified attribute or custom function.
@@ -227,7 +227,7 @@ class AgentSet(MutableSet, Sequence):
         return self
 
     def do(
-            self, method_name: str, *args, return_results: bool = False, **kwargs
+        self, method_name: str, *args, return_results: bool = False, **kwargs
     ) -> AgentSet | list[Any]:
         """
         Invoke a method on each agent in the AgentSet.
@@ -357,7 +357,7 @@ class AgentSet(MutableSet, Sequence):
         return self.model.random
 
     def apply(
-            self, func: Callable, axis: str = "agent", args=(), result_type=None, **kwargs
+        self, func: Callable, axis: str = "agent", args=(), result_type=None, **kwargs
     ) -> list[Any] | Any:
         """
         Apply a function to all agents in the AgentSet either to each agent individually or to the entire agentset.
@@ -414,6 +414,7 @@ class AgentSet(MutableSet, Sequence):
                 groups[getattr(agent, by)].append(agent)
 
         return {k: AgentSet(v) for k, v in groups.items()}
+
 
 # consider adding for performance reasons
 # for Sequence: __reversed__, index, and count

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -394,9 +394,7 @@ class AgentSet(MutableSet, Sequence):
             for agent in self:
                 groups[getattr(agent, by)].append(agent)
 
-        if return_agentset:
-            return {k: AgentSet(v) for k, v in groups.items()}
-        return groups
+        return AgentSetGroupBy(groups)
 
 
 class AgentSetGroupBy:
@@ -413,6 +411,7 @@ class AgentSetGroupBy:
             return self.groups[name]
 
     def apply(self, callable: Callable):
+        # fixme, we have callable over the entire group and callable on each group member
         # apply callable to each group and return dict {group_name, return of callable for group}
         return {k: callable(v) for k, v in self.groups}
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -127,11 +127,11 @@ class AgentSet(MutableSet, Sequence):
         return agent in self._agents
 
     def select(
-        self,
-        filter_func: Callable[[Agent], bool] | None = None,
-        n: int = 0,
-        inplace: bool = False,
-        agent_type: type[Agent] | None = None,
+            self,
+            filter_func: Callable[[Agent], bool] | None = None,
+            n: int = 0,
+            inplace: bool = False,
+            agent_type: type[Agent] | None = None,
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
@@ -154,7 +154,7 @@ class AgentSet(MutableSet, Sequence):
             count = 0
             for agent in self:
                 if (not filter_func or filter_func(agent)) and (
-                    not agent_type or isinstance(agent, agent_type)
+                        not agent_type or isinstance(agent, agent_type)
                 ):
                     yield agent
                     count += 1
@@ -191,10 +191,10 @@ class AgentSet(MutableSet, Sequence):
             )
 
     def sort(
-        self,
-        key: Callable[[Agent], Any] | str,
-        ascending: bool = False,
-        inplace: bool = False,
+            self,
+            key: Callable[[Agent], Any] | str,
+            ascending: bool = False,
+            inplace: bool = False,
     ) -> AgentSet:
         """
         Sort the agents in the AgentSet based on a specified attribute or custom function.
@@ -368,8 +368,8 @@ class AgentSet(MutableSet, Sequence):
         return self.model.random
 
     def group_by(
-        self, by: Callable | str, return_agentset=False
-    ) -> dict[str, list] | dict[str, AgentSet]:
+            self, by: Callable | str,
+    ) -> AgentSetGroupBy:
         """
         Group agents by the specified attribute
 
@@ -381,18 +381,8 @@ class AgentSet(MutableSet, Sequence):
                                 * if ``by`` is a str, it should refer to an attribute on the agent and the value
                                   of this attribute will be used for grouping
 
-            return_agentset (bool, optional): Controls the datatype of the values in the return dictionary. Given
-                                              the performance overhead of creating an AgentSet, it defaults to
-                                              returning a list. Only set to true if you need the advanced
-                                              functionality of AgentSet.
-
-                                                * If False, values will be a list
-                                                * If True, values will be an AgentSet
-
-
         Returns:
-            dictionary with the group identifier (i.e., callable return or attribute value) as key and an AgentSet as
-            value
+            AgentSetGroupBy
 
         """
         groups = defaultdict(list)
@@ -408,6 +398,25 @@ class AgentSet(MutableSet, Sequence):
             return {k: AgentSet(v) for k, v in groups.items()}
         return groups
 
+
+class AgentSetGroupBy:
+    # Helper class to enable pandas style split, apply, combine syntax
+
+    def __init__(self, groups: dict[Any, list]):
+        self.groups: dict[Any, list] = groups
+
+    def get_group(self, name: Any, agentset=True):
+        # return group for specified name
+        if agentset:
+            return AgentSet(self.groups[name])
+        else:
+            return self.groups[name]
+
+    def apply(self, callable: Callable):
+        # apply callable to each group and return dict {group_name, return of callable for group}
+        return {k: callable(v) for k, v in self.groups}
+
+    # add iteration
 
 # consider adding for performance reasons
 # for Sequence: __reversed__, index, and count

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Iterable, Iterator, MutableSet, Sequence
 from random import Random
 
 # mypy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, List
 
 if TYPE_CHECKING:
     # We ensure that these are not imported during runtime to prevent cyclic
@@ -127,11 +127,11 @@ class AgentSet(MutableSet, Sequence):
         return agent in self._agents
 
     def select(
-        self,
-        filter_func: Callable[[Agent], bool] | None = None,
-        n: int = 0,
-        inplace: bool = False,
-        agent_type: type[Agent] | None = None,
+            self,
+            filter_func: Callable[[Agent], bool] | None = None,
+            n: int = 0,
+            inplace: bool = False,
+            agent_type: type[Agent] | None = None,
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
@@ -154,7 +154,7 @@ class AgentSet(MutableSet, Sequence):
             count = 0
             for agent in self:
                 if (not filter_func or filter_func(agent)) and (
-                    not agent_type or isinstance(agent, agent_type)
+                        not agent_type or isinstance(agent, agent_type)
                 ):
                     yield agent
                     count += 1
@@ -191,10 +191,10 @@ class AgentSet(MutableSet, Sequence):
             )
 
     def sort(
-        self,
-        key: Callable[[Agent], Any] | str,
-        ascending: bool = False,
-        inplace: bool = False,
+            self,
+            key: Callable[[Agent], Any] | str,
+            ascending: bool = False,
+            inplace: bool = False,
     ) -> AgentSet:
         """
         Sort the agents in the AgentSet based on a specified attribute or custom function.
@@ -227,7 +227,7 @@ class AgentSet(MutableSet, Sequence):
         return self
 
     def do(
-        self, method_name: str, *args, return_results: bool = False, **kwargs
+            self, method_name: str, *args, return_results: bool = False, **kwargs
     ) -> AgentSet | list[Any]:
         """
         Invoke a method on each agent in the AgentSet.
@@ -355,6 +355,37 @@ class AgentSet(MutableSet, Sequence):
             Random: The random number generator associated with the model.
         """
         return self.model.random
+
+    def apply(self, func: Callable, axis: str = "agent", args=(), result_type=None, **kwargs) -> List[Any] | Any:
+        """
+        Apply a function to all agents in the AgentSet either to each agent individually or to the entire agentset.
+
+        Args:
+            func (Callable): The function to apply to each individual agent or the entire agentset
+            axis (str): {'agent', 'agetset'} The axis along which to apply the function.
+
+                         * 'agent' means apply the function to each agent.
+                         * 'agentset' means apply the function to the entire agentset.
+
+            args (list or tuple):Positional arguments to pass to the function.
+            kwargs (dict): Additional keyword arguments to pass as keywords arguments to the function.
+
+        Returns:
+            the result of applying the function along the specified axis. In case of axis=agent, it will be a list with
+            the return of func for each agent. In case of axis=agentset, it is the return of func.
+
+        Notes:
+            To maintain method chaining in case of axis=agentset, func should return an agentset
+
+        """
+        if axis == "agent":
+            # TODO:: add a results_type to make it trivial to return a dataframe with agent.id and func results?
+            # TODO:: this is a good idea, but tricky because you don't know all column names
+            return [func(agent, *args, **kwargs) for agent in self]
+        elif axis == "agentset":
+            return func(self, *args, **kwargs)
+        else:
+            raise ValueError(f"axis should be `agent` or `agentset` not {axis}")
 
 
 # consider adding for performance reasons

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -389,7 +389,9 @@ class AgentSet(MutableSet, Sequence):
         else:
             raise ValueError(f"axis should be `agent` or `agentset` not {axis}")
 
-    def group_by(self, by: Callable | str, return_agentset=False) -> dict[str, list] | dict[str, AgentSet]:
+    def group_by(
+        self, by: Callable | str, return_agentset=False
+    ) -> dict[str, list] | dict[str, AgentSet]:
         """
         Group agents by the specified attribute
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -127,11 +127,11 @@ class AgentSet(MutableSet, Sequence):
         return agent in self._agents
 
     def select(
-            self,
-            filter_func: Callable[[Agent], bool] | None = None,
-            n: int = 0,
-            inplace: bool = False,
-            agent_type: type[Agent] | None = None,
+        self,
+        filter_func: Callable[[Agent], bool] | None = None,
+        n: int = 0,
+        inplace: bool = False,
+        agent_type: type[Agent] | None = None,
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
@@ -154,7 +154,7 @@ class AgentSet(MutableSet, Sequence):
             count = 0
             for agent in self:
                 if (not filter_func or filter_func(agent)) and (
-                        not agent_type or isinstance(agent, agent_type)
+                    not agent_type or isinstance(agent, agent_type)
                 ):
                     yield agent
                     count += 1
@@ -191,10 +191,10 @@ class AgentSet(MutableSet, Sequence):
             )
 
     def sort(
-            self,
-            key: Callable[[Agent], Any] | str,
-            ascending: bool = False,
-            inplace: bool = False,
+        self,
+        key: Callable[[Agent], Any] | str,
+        ascending: bool = False,
+        inplace: bool = False,
     ) -> AgentSet:
         """
         Sort the agents in the AgentSet based on a specified attribute or custom function.
@@ -368,7 +368,8 @@ class AgentSet(MutableSet, Sequence):
         return self.model.random
 
     def group_by(
-            self, by: Callable | str,
+        self,
+        by: Callable | str,
     ) -> AgentSetGroupBy:
         """
         Group agents by the specified attribute
@@ -416,6 +417,7 @@ class AgentSetGroupBy:
         return {k: callable(v) for k, v in self.groups}
 
     # add iteration
+
 
 # consider adding for performance reasons
 # for Sequence: __reversed__, index, and count

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Iterable, Iterator, MutableSet, Sequence
 from random import Random
 
 # mypy
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     # We ensure that these are not imported during runtime to prevent cyclic
@@ -127,11 +127,11 @@ class AgentSet(MutableSet, Sequence):
         return agent in self._agents
 
     def select(
-            self,
-            filter_func: Callable[[Agent], bool] | None = None,
-            n: int = 0,
-            inplace: bool = False,
-            agent_type: type[Agent] | None = None,
+        self,
+        filter_func: Callable[[Agent], bool] | None = None,
+        n: int = 0,
+        inplace: bool = False,
+        agent_type: type[Agent] | None = None,
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
@@ -154,7 +154,7 @@ class AgentSet(MutableSet, Sequence):
             count = 0
             for agent in self:
                 if (not filter_func or filter_func(agent)) and (
-                        not agent_type or isinstance(agent, agent_type)
+                    not agent_type or isinstance(agent, agent_type)
                 ):
                     yield agent
                     count += 1
@@ -191,10 +191,10 @@ class AgentSet(MutableSet, Sequence):
             )
 
     def sort(
-            self,
-            key: Callable[[Agent], Any] | str,
-            ascending: bool = False,
-            inplace: bool = False,
+        self,
+        key: Callable[[Agent], Any] | str,
+        ascending: bool = False,
+        inplace: bool = False,
     ) -> AgentSet:
         """
         Sort the agents in the AgentSet based on a specified attribute or custom function.
@@ -227,7 +227,7 @@ class AgentSet(MutableSet, Sequence):
         return self
 
     def do(
-            self, method_name: str, *args, return_results: bool = False, **kwargs
+        self, method_name: str, *args, return_results: bool = False, **kwargs
     ) -> AgentSet | list[Any]:
         """
         Invoke a method on each agent in the AgentSet.
@@ -356,7 +356,9 @@ class AgentSet(MutableSet, Sequence):
         """
         return self.model.random
 
-    def apply(self, func: Callable, axis: str = "agent", args=(), result_type=None, **kwargs) -> List[Any] | Any:
+    def apply(
+        self, func: Callable, axis: str = "agent", args=(), result_type=None, **kwargs
+    ) -> list[Any] | Any:
         """
         Apply a function to all agents in the AgentSet either to each agent individually or to the entire agentset.
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -373,11 +373,11 @@ class AgentSet(MutableSet, Sequence):
             kwargs (dict): Additional keyword arguments to pass as keywords arguments to the function.
 
         Returns:
-            the result of applying the function along the specified axis. In case of axis=agent, it will be a list with
-            the return of func for each agent. In case of axis=agentset, it is the return of func.
+            the result of applying the function along the specified axis. In case of ``axis='agent'``, it will be a list
+            with the return of `func` for each agent. In case of ``axis='agentset'``, it is the return of ``func``.
 
         Notes:
-            To maintain method chaining in case of axis=agentset, func should return an agentset
+            To maintain method chaining in case of axis=agentset, func should return an AgentSet
 
         """
         if axis == "agent":


### PR DESCRIPTION
This PR enhances AgentSet.do to take a callable or str. Currently, `AgentSet.do` takes a str which maps to a method on the agents in the set. This PR makes it possible to use a callable instead. This callable will be called with the agent as the first argument.