### PR TITLE
Visualisation: Allow specifying Agent shapes in agent_portrayal

### DIFF
--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -142,7 +142,8 @@
    "source": [
     "#### Changing the agents\n",
     "\n",
-    "In the visualization above, all we could see is the agents moving around -- but not how much money they had, or anything else of interest. Let's change it so that agents who are broke (wealth 0) are drawn in red, smaller. (TODO: currently, we can't predict the drawing order of the circles, so a broke agent may be overshadowed by a wealthy agent. We should fix this by doing a hollow circle instead)\n",
+    "In the visualization above, all we could see is the agents moving around -- but not how much money they had, or anything else of interest. Let's change it so that agents who are broke (wealth 0) are drawn in red, smaller. (TODO: Currently, we can't predict the drawing order of the circles, so a broke agent may be overshadowed by a wealthy agent. We should fix this by doing a hollow circle instead)\n",
+    "In addition to size and color, an agent's shape can also be customized when using the default drawer. The allowed values for shapes can be found [here](https://matplotlib.org/stable/api/markers_api.html).\n",
     "\n",
     "To do this, we go back to our `agent_portrayal` code and add some code to change the portrayal based on the agent properties and launch the server again."
    ]

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -36,7 +36,12 @@ def _split_and_scatter(portray_data, space_ax):
     c = portray_data["c"]
     m = portray_data["m"]
 
-    assert len(x) == len(y) == len(s) == len(c) == len(m)
+    if not (len(x) == len(y) == len(s) == len(c) == len(m)):
+        raise ValueError(
+            "Length mismatch in portrayal data lists: "
+            f"x: {len(x)}, y: {len(y)}, s: {len(s)}, "
+            f"c: {len(c)}, m: {len(m)}"
+        )
 
     # Group the data by marker
     for i in range(len(x)):

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -39,8 +39,8 @@ def _split_and_scatter(portray_data, space_ax):
     if not (len(x) == len(y) == len(s) == len(c) == len(m)):
         raise ValueError(
             "Length mismatch in portrayal data lists: "
-            f"x: {len(x)}, y: {len(y)}, s: {len(s)}, "
-            f"c: {len(c)}, m: {len(m)}"
+            f"x: {len(x)}, y: {len(y)}, size: {len(s)}, "
+            f"color: {len(c)}, marker: {len(m)}"
         )
 
     # Group the data by marker
@@ -53,7 +53,8 @@ def _split_and_scatter(portray_data, space_ax):
 
     # Plot each group with the same marker
     for marker, data in grouped_data.items():
-        space_ax.scatter(data["x"], data["y"], s=data["s"], c=data["c"], marker=marker)
+        space_ax.scatter(data["x"], data["y"], s=data["s"],
+                         c=data["c"], marker=marker)
 
 
 def _draw_grid(space, space_ax, agent_portrayal):
@@ -82,9 +83,9 @@ def _draw_grid(space, space_ax, agent_portrayal):
                     # establishing a default prevents misalignment if some agents are not given size, color, etc.
                     size = data.get("size", default_size)
                     s.append(size)
-                    color = data.get("color", "b")
+                    color = data.get("color", "tab:blue")
                     c.append(color)
-                    mark = data.get("shape", ".")
+                    mark = data.get("shape", "o")
                     m.append(mark)
         out = {"x": x, "y": y, "s": s, "c": c, "m": m}
         return out
@@ -123,9 +124,9 @@ def _draw_continuous_space(space, space_ax, agent_portrayal):
             # establishing a default prevents misalignment if some agents are not given size, color, etc.
             size = data.get("size", default_size)
             s.append(size)
-            color = data.get("color", "b")
+            color = data.get("color", "tab:blue")
             c.append(color)
-            mark = data.get("shape", ".")
+            mark = data.get("shape", "o")
             m.append(mark)
         out = {"x": x, "y": y, "s": s, "c": c, "m": m}
         return out

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -53,8 +53,7 @@ def _split_and_scatter(portray_data, space_ax):
 
     # Plot each group with the same marker
     for marker, data in grouped_data.items():
-        space_ax.scatter(data["x"], data["y"], s=data["s"],
-                         c=data["c"], marker=marker)
+        space_ax.scatter(data["x"], data["y"], s=data["s"], c=data["c"], marker=marker)
 
 
 def _draw_grid(space, space_ax, agent_portrayal):

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -1,8 +1,9 @@
+from collections import defaultdict
+
 import networkx as nx
 import solara
 from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
-from collections import defaultdict
 
 import mesa
 
@@ -50,8 +51,7 @@ def _split_and_scatter(portray_data, space_ax):
 
     # Plot each group with the same marker
     for marker, data in grouped_data.items():
-        space_ax.scatter(data["x"], data["y"], s=data["s"],
-                         c=data["c"], marker=marker)
+        space_ax.scatter(data["x"], data["y"], s=data["s"], c=data["c"], marker=marker)
 
 
 def _draw_grid(space, space_ax, agent_portrayal):

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -103,7 +103,8 @@ def SolaraViz(
         model_params: Parameters for initializing the model
         measures: List of callables or data attributes to plot
         name: Name for display
-        agent_portrayal: Options for rendering agents (dictionary)
+        agent_portrayal: Options for rendering agents (dictionary);
+            Default drawer supports custom `"size"`, `"color"`, and `"shape"`.
         space_drawer: Method to render the agent space for
             the model; default implementation is the `SpaceMatplotlib` component;
             simulations with no space to visualize should


### PR DESCRIPTION
This PR allows specifying an `"shape"` in the `agent_portrayal` dictionary used by matplotlib component of the Solara visualisation. In short, it allows you represent an Agent in any [matplotlib marker](https://matplotlib.org/stable/api/markers_api.html), by adding a "shape" key-value pair to the `agent_portrayal` dictionary.

This is especially useful when you're using the default shape drawer for grid or continuous space.

For example:
```Python
def agent_portrayal(cell):
    return {
        "color": "blue"
        "size": 5,
        "shape": "h"  # marker is a hexagon!
    }
```
Partial resolution of #2164.

### Examples

In Conway's Game of Life life, you can now use black squares for the agents, as how it's traditionally displayed:

```Python
def agent_portrayal(cell):
    return {
        "color": "white" if cell.alive else "black",
        "size": 45,
        "shape": "s" # marker is a square
    }
```
![image](https://github.com/user-attachments/assets/e80dac7e-a98c-4670-a8e9-b22cc674fecc)

You can also conditionally modify the shape, just like you can with the color and size:

```Python
COP_COLOR = "#000000"
AGENT_QUIET_COLOR = "#648FFF"
AGENT_REBEL_COLOR = "#FE6100"
JAIL_COLOR = "#808080"
JAIL_SHAPE = "s"


def citizen_cop_portrayal(agent):
    portrayal = {
        "Shape": "circle",
        "x": agent.pos[0],
        "y": agent.pos[1],
        "Filled": "true",
    }

    if isinstance(agent, Citizen):
        color = (
            AGENT_QUIET_COLOR if agent.condition == "Quiescent" else AGENT_REBEL_COLOR
        )
        if agent.jail_sentence:
            color = JAIL_COLOR
            shape = JAIL_SHAPE
        else:
            shape = "."
        color = JAIL_COLOR if agent.jail_sentence else color
        portrayal["color"] = color
        portrayal["shape"] = shape
        portrayal["size"] = 15.0

    else:
        assert isinstance(agent, Cop)
        portrayal["color"] = COP_COLOR
        portrayal["shape"] = "."
        portrayal["size"] = 25.0

    return portrayal
```
![image](https://github.com/user-attachments/assets/8ef8ab4e-8bbd-4c55-a571-cbfc2826e082)