### PR TITLE
Add pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- Provide a brief summary of the bug and its impact. -->
+
+## Bug / Issue
+<!-- Link to the related issue(s) and describe the bug. Include details like the context, what was expected, and what actually happened. -->
+
+## Implementation
+<!-- Describe the changes made to resolve the issue. Highlight any important parts of the code that were modified. -->
+
+## Testing
+<!-- Detail the testing performed to verify the fix. Include information on test cases, steps taken, and any relevant results.
+
+If you're fixing the visualisation, add before/after screenshots. -->
+
+## Additional Notes
+<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work.

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- Provide a concise summary of the feature and its purpose. -->
+
+## Motive
+<!-- Explain the reasoning behind this feature. Include details on the problem it addresses or the enhancement it provides. -->
+
+## Implementation
+<!-- Describe how the feature was implemented. Include details on the approach taken, important decisions made, and code changes. -->
+
+## Usage Examples
+<!-- Provide code snippets or examples demonstrating how to use the new feature. Highlight key scenarios where this feature will be beneficial.
+
+If you're modifying the visualisation, add before/after screenshots. -->
+
+## Additional Notes
+<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work. -->


### PR DESCRIPTION
Added GitHub pull request templates for bug fixes and feature additions to help new contributors format their PRs and help maintainers to review these.

The PR templates where modelled on the large PRs that were merged into Mesa recently.

In general, I don't like pushing things too hard into a mold, since each PR is different and might benefit from a different structure, but I feel these two are a good starting point, especially for new contributors.

See the docs [Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) for more information.