### PR TITLE
Require Mesa models to be initialized with `super().__init__()`

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import operator
-import warnings
 import weakref
-from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, MutableSet, Sequence
 from random import Random
 
@@ -50,19 +48,7 @@ class Agent:
         self.pos: Position | None = None
 
         # register agent
-        try:
-            self.model.agents_[type(self)][self] = None
-        except AttributeError:
-            # model super has not been called
-            self.model.agents_ = defaultdict(dict)
-            self.model.agents_[type(self)][self] = None
-            self.model.agentset_experimental_warning_given = False
-
-            warnings.warn(
-                "The Mesa Model class was not initialized. In the future, you need to explicitly initialize the Model by calling super().__init__() on initialization.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        self.model.agents_[type(self)][self] = None
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""
@@ -99,8 +85,6 @@ class AgentSet(MutableSet, Sequence):
         interactions with the model's environment and other agents.The implementation uses a WeakKeyDictionary to store agents,
         which means that agents not referenced elsewhere in the program may be automatically removed from the AgentSet.
     """
-
-    agentset_experimental_warning_given = False
 
     def __init__(self, agents: Iterable[Agent], model: Model):
         """

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -50,11 +50,11 @@ class Agent:
         # register agent
         try:
             self.model.agents_[type(self)][self] = None
-        except AttributeError:
+        except AttributeError as err:
             # model super has not been called
             raise RuntimeError(
                 "The Mesa Model class was not initialized. You must explicitly initialize the Model by calling super().__init__() on initialization."
-            )
+            ) from err
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -48,7 +48,13 @@ class Agent:
         self.pos: Position | None = None
 
         # register agent
-        self.model.agents_[type(self)][self] = None
+        try:
+            self.model.agents_[type(self)][self] = None
+        except AttributeError:
+            # model super has not been called
+            raise RuntimeError(
+                "The Mesa Model class was not initialized. You must explicitly initialize the Model by calling super().__init__() on initialization."
+            )
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -586,7 +586,7 @@ class PropertyLayer:
         aggregate_property(operation): Performs an aggregate operation over all cells.
     """
 
-    agentset_experimental_warning_given = False
+    propertylayer_experimental_warning_given = False
 
     def __init__(
         self, name: str, width: int, height: int, default_value, dtype=np.float64
@@ -633,14 +633,14 @@ class PropertyLayer:
 
         self.data = np.full((width, height), default_value, dtype=dtype)
 
-        if not self.__class__.agentset_experimental_warning_given:
+        if not self.__class__.propertylayer_experimental_warning_given:
             warnings.warn(
                 "The new PropertyLayer and _PropertyGrid classes experimental. It may be changed or removed in any and all future releases, including patch releases.\n"
                 "We would love to hear what you think about this new feature. If you have any thoughts, share them with us here: https://github.com/projectmesa/mesa/discussions/1932",
                 FutureWarning,
                 stacklevel=2,
             )
-            self.__class__.agentset_experimental_warning_given = True
+            self.__class__.propertylayer_experimental_warning_given = True
 
     def set_cell(self, position: Coordinate, value):
         """


### PR DESCRIPTION
Remove the workaround for when the model super has not been called, and thereby require Mesa models to be initialized with `super().__init__()`.

```Python
class MyModel(mesa.Model):
    def __init__(self):
        super().__init__()  # This is now required!
```
This is needed to correctly add Agents to the model and setup other Mesa model variables.

This warning was present since Mesa 2.2.0 (https://github.com/projectmesa/mesa/pull/1928), so there has been some time to update for existing users.

This PR contains a second commit that names experimental warning in PropertyLayer correctly in space.py.