### PR TITLE
model: Automatically increase `step` counter

### DIFF
--- a/benchmarks/BoltzmannWealth/boltzmann_wealth.py
+++ b/benchmarks/BoltzmannWealth/boltzmann_wealth.py
@@ -38,7 +38,6 @@ class BoltzmannWealth(mesa.Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self._advance_time()
         self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -132,14 +132,14 @@ def _model_run_func(
     """
     run_id, iteration, kwargs = run
     model = model_cls(**kwargs)
-    while model.running and model._steps <= max_steps:
+    while model.running and model.steps <= max_steps:
         model.step()
 
     data = []
 
-    steps = list(range(0, model._steps, data_collection_period))
-    if not steps or steps[-1] != model._steps - 1:
-        steps.append(model._steps - 1)
+    steps = list(range(0, model.steps, data_collection_period))
+    if not steps or steps[-1] != model.steps - 1:
+        steps.append(model.steps - 1)
 
     for step in steps:
         model_data, all_agents_data = _collect_data(model, step)

--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -180,7 +180,7 @@ class DataCollector:
         rep_funcs = self.agent_reporters.values()
 
         def get_reports(agent):
-            _prefix = (agent.model._steps, agent.unique_id)
+            _prefix = (agent.model.steps, agent.unique_id)
             reports = tuple(rep(agent) for rep in rep_funcs)
             return _prefix + reports
 
@@ -216,7 +216,7 @@ class DataCollector:
 
         if self.agent_reporters:
             agent_records = self._record_agents(model)
-            self._agent_records[model._steps] = list(agent_records)
+            self._agent_records[model.steps] = list(agent_records)
 
     def add_table_row(self, table_name, row, ignore_missing=False):
         """Add a row dictionary to a specific table.

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -83,6 +83,20 @@ class Model:
         self._steps: int = 0
         self._time: TimeT = 0  # the model's clock
 
+        # Wrap the user-defined step method
+        if hasattr(self, "step"):
+            self._user_step = self.step
+            self.step = self._wrapped_step
+
+    def _wrapped_step(self, *args: Any, **kwargs: Any) -> None:
+        """Automatically increments time and steps after calling the user's step method."""
+        # Automatically increment time and step counters
+        self._time += kwargs.get("time", 1)
+        self._steps += kwargs.get("step", 1)
+        # Call the original user-defined step method
+        if self._user_step:
+            self._user_step(*args, **kwargs)
+
     @property
     def agents(self) -> AgentSet:
         """Provides an AgentSet of all agents in the model, combining agents from all types."""
@@ -179,11 +193,6 @@ class Model:
 
     def step(self) -> None:
         """A single step. Fill in here."""
-
-    def _advance_time(self, deltat: TimeT = 1):
-        """Increment the model's steps counter and clock."""
-        self._steps += 1
-        self._time += deltat
 
     def next_id(self) -> int:
         """Return the next unique ID for agents, increment current_id"""

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -69,8 +69,6 @@ class BaseScheduler:
         self.model = model
         self.steps = 0
         self.time: TimeT = 0
-        self._original_step = self.step
-        self.step = self._wrapped_step
 
         if agents is None:
             agents = []
@@ -112,11 +110,6 @@ class BaseScheduler:
         self.do_each("step")
         self.steps += 1
         self.time += 1
-
-    def _wrapped_step(self):
-        """Wrapper for the step method to include time and step updating."""
-        self._original_step()
-        self.model._advance_time()
 
     def get_agent_count(self) -> int:
         """Returns the current number of agents in the queue."""

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -244,7 +244,7 @@ def ModelController(model, play_interval, current_step, reset_counter):
         """Advance the model by one step."""
         model.step()
         previous_step.value = current_step.value
-        current_step.value = model._steps
+        current_step.value = model.steps
 
     def do_play():
         """Run the model continuously."""

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -83,8 +83,8 @@ class MockModel(Model):
         return 42
 
     def step(self):
-        self.datacollector.collect(self)
         self.schedule.step()
+        self.datacollector.collect(self)
 
 
 def test_batch_run():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -66,3 +66,4 @@ class TestExamples(unittest.TestCase):
                 model = model_class()
                 for _ in range(10):
                     model.step()
+                self.assertEqual(model.steps, 10)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,7 +9,9 @@ def test_model_set_up():
     assert model.current_id == 0
     assert model.current_id + 1 == model.next_id()
     assert model.current_id == 1
+    assert model.steps == 0
     model.step()
+    assert model.steps == 1
 
 
 def test_running():
@@ -18,12 +20,12 @@ def test_running():
 
         def step(self):
             """Increase steps until 10."""
-            self.steps += 1
             if self.steps == 10:
                 self.running = False
 
     model = TestModel()
     model.run_model()
+    assert model.steps == 10
 
 
 def test_seed(seed=23):


### PR DESCRIPTION
This pull request adds automatically increasing of `steps` counter in the Mesa model, even if the users overwrites the `Model.step()` method. It also removes the `_time` variable.

#### Background
Previously, Mesa required users to manually increment the step counters using the `_advance_time()` method, or by modifying the `model._time` and `model._step` values directly. This use of an private method was non-ideal.

- Closes #2222
- Initial discussion: https://github.com/projectmesa/mesa/pull/1942#issuecomment-1903386624

#### Changes
`steps` is now incremented automatically within the `Model` class itself. Each call to the `step()` method will increment the `steps` counter by 1.

The `_time` counter is removed (for motivation, read the discussion below).

#### Implementation details
The core change involves wrapping the user-defined `step` method with `_wrapped_step` which handles the incrementing process **before** executing the user's step logic. This ensures that all increment operations are centrally managed and transparent to the user.

I choose to increment the time before the user step, in the spirit of "a new step" (or a new day) has begun. Then the model does things during the step, and.
```Python
def step():
    # Time is increased automatically at the beginning of the step
    self.agents.shuffle().do("step")  # Do things during the step
    self.datacollector.collect()      # Collect data at the end of the step
```

Here's the updated version of your examples with the initial whitespaces removed from the code blocks:

#### Example Usage
You don't need to do anything to use this features. You can access steps at any moment.
```python
class MyModel(Model):
    def step(self):
        # User logic here

my_model = MyModel()
my_model.step()
```

#### Todo:
- [x] Tests pass
- [x] Check and if needed, update examples
  - [x] https://github.com/projectmesa/mesa-examples/pull/162
- [x] Add tests
- ~Check how this interacts with the experimental DEVS simulator~

#### Resolve:
- https://github.com/projectmesa/mesa/discussions/2227
  - [x] Resolution: `steps` is automatically increased by exactly `1`.
- https://github.com/projectmesa/mesa/discussions/2228
  - [x] Resolution: `_time` is removed.
- https://github.com/projectmesa/mesa/discussions/2229
  - [x] Resolution: 1) increase counter, 2) perform step, 3) collect data
- https://github.com/projectmesa/mesa/discussions/2230
  - [x] Resolution: We claim `steps`. Further discussion can continue.
- https://github.com/projectmesa/mesa/discussions/2231
  - [x] Resolution: Needle is moving towards removing them. Other PR.