### PR TITLE
Change warning when setting model.agents to error

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import itertools
 import random
-import warnings
 from collections import defaultdict
 
 # mypy

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -89,12 +89,10 @@ class Model:
 
     @agents.setter
     def agents(self, agents: Any) -> None:
-        warnings.warn(
-            "You are trying to set model.agents. In a next release, this attribute is used "
-            "by MESA itself so you cannot use it directly anymore."
-            "Please adjust your code to use a different attribute name for custom agent storage",
-            UserWarning,
-            stacklevel=2,
+        raise AttributeError(
+            "You are trying to set model.agents. In Mesa 3.0 and higher, this attribute will be "
+            "used by Mesa itself, so you cannot use it directly anymore."
+            "Please adjust your code to use a different attribute name for custom agent storage."
         )
 
         self._agents = agents


### PR DESCRIPTION
Replaced the warning with an `AttributeError` when attempting to set `model.agents`. This change enforces that the `agents` attribute will be reserved for internal use by Mesa in future releases. Users must update their code to use a different attribute name for custom agent storage.

This allows us to start using `model.agents` in Mesa 3.0 for ourselves, which helps with https://github.com/projectmesa/mesa/issues/2212.