### PR TITLE
Automatically assign `unique_id` to Agents

### DIFF
--- a/benchmarks/BoltzmannWealth/boltzmann_wealth.py
+++ b/benchmarks/BoltzmannWealth/boltzmann_wealth.py
@@ -28,7 +28,7 @@ class BoltzmannWealth(mesa.Model):
         )
         # Create agents
         for i in range(self.num_agents):
-            a = MoneyAgent(i, self)
+            a = MoneyAgent(self)
             # Add the agent to a random grid cell
             x = self.random.randrange(self.grid.width)
             y = self.random.randrange(self.grid.height)
@@ -50,8 +50,8 @@ class BoltzmannWealth(mesa.Model):
 class MoneyAgent(mesa.Agent):
     """An agent with fixed initial wealth."""
 
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model):
+        super().__init__(model)
         self.wealth = 1
 
     def move(self):

--- a/benchmarks/Flocking/flocking.py
+++ b/benchmarks/Flocking/flocking.py
@@ -27,7 +27,6 @@ class Boid(mesa.Agent):
 
     def __init__(
         self,
-        unique_id,
         model,
         speed,
         direction,
@@ -42,6 +41,7 @@ class Boid(mesa.Agent):
 
         Args:
             unique_id: Unique agent identifier.
+            model: Model instance in which the agent is located.
             speed: Distance to move per step.
             direction: numpy vector for the Boid's direction of movement.
             vision: Radius to look around for nearby Boids.
@@ -51,7 +51,7 @@ class Boid(mesa.Agent):
             match: the relative importance of matching neighbors' directions
 
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.speed = speed
         self.direction = direction
         self.vision = vision
@@ -137,7 +137,6 @@ class BoidFlockers(mesa.Model):
             pos = np.array((x, y))
             direction = np.random.random(2) * 2 - 1
             boid = Boid(
-                unique_id=i,
                 model=self,
                 speed=speed,
                 direction=direction,

--- a/benchmarks/Schelling/schelling.py
+++ b/benchmarks/Schelling/schelling.py
@@ -8,15 +8,16 @@ class SchellingAgent(CellAgent):
     Schelling segregation agent
     """
 
-    def __init__(self, unique_id, model, agent_type, radius, homophily):
+    def __init__(self, model, agent_type, radius, homophily):
         """
         Create a new Schelling agent.
         Args:
            unique_id: Unique identifier for the agent.
+           model: Model instance in which the agent is located.
            x, y: Agent initial location.
            agent_type: Indicator for the agent's type (minority=1, majority=0)
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.type = agent_type
         self.radius = radius
         self.homophily = homophily
@@ -81,9 +82,7 @@ class Schelling(Model):
         for cell in self.grid:
             if self.random.random() < density:
                 agent_type = 1 if self.random.random() < self.minority_pc else 0
-                agent = SchellingAgent(
-                    self.next_id(), self, agent_type, radius, homophily
-                )
+                agent = SchellingAgent(self, agent_type, radius, homophily)
                 agent.move_to(cell)
                 self.schedule.add(agent)
 

--- a/benchmarks/WolfSheep/wolf_sheep.py
+++ b/benchmarks/WolfSheep/wolf_sheep.py
@@ -17,8 +17,8 @@ from mesa.experimental.devs import ABMSimulator
 
 
 class Animal(CellAgent):
-    def __init__(self, unique_id, model, energy, p_reproduce, energy_from_food):
-        super().__init__(unique_id, model)
+    def __init__(self, model, energy, p_reproduce, energy_from_food):
+        super().__init__(model)
         self.energy = energy
         self.p_reproduce = p_reproduce
         self.energy_from_food = energy_from_food
@@ -29,7 +29,6 @@ class Animal(CellAgent):
     def spawn_offspring(self):
         self.energy /= 2
         offspring = self.__class__(
-            self.model.next_id(),
             self.model,
             self.energy,
             self.p_reproduce,
@@ -107,7 +106,7 @@ class GrassPatch(CellAgent):
                 function_args=[self, "fully_grown", True],
             )
 
-    def __init__(self, unique_id, model, fully_grown, countdown, grass_regrowth_time):
+    def __init__(self, model, fully_grown, countdown, grass_regrowth_time):
         """
         TODO:: fully grown can just be an int --> so one less param (i.e. countdown)
 
@@ -119,7 +118,7 @@ class GrassPatch(CellAgent):
             grass_regrowth_time : time to fully regrow grass
             countdown : Time for the patch of grass to be fully regrown if fully grown is False
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self._fully_grown = fully_grown
         self.grass_regrowth_time = grass_regrowth_time
 
@@ -189,7 +188,6 @@ class WolfSheep(Model):
             )
             energy = self.random.randrange(2 * sheep_gain_from_food)
             sheep = Sheep(
-                self.next_id(),
                 self,
                 energy,
                 sheep_reproduce,
@@ -205,7 +203,6 @@ class WolfSheep(Model):
             )
             energy = self.random.randrange(2 * wolf_gain_from_food)
             wolf = Wolf(
-                self.next_id(),
                 self,
                 energy,
                 wolf_reproduce,
@@ -221,9 +218,7 @@ class WolfSheep(Model):
                 countdown = grass_regrowth_time
             else:
                 countdown = self.random.randrange(grass_regrowth_time)
-            patch = GrassPatch(
-                self.next_id(), self, fully_grown, countdown, grass_regrowth_time
-            )
+            patch = GrassPatch(self, fully_grown, countdown, grass_regrowth_time)
             patch.move_to(cell)
 
     def step(self):

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -19,7 +19,7 @@ class CellAgent(Agent):
         cell: (Cell | None): the cell which the agent occupies
     """
 
-    def __init__(self, unique_id: int, model: Model) -> None:
+    def __init__(self, model: Model) -> None:
         """
         Create a new agent.
 
@@ -27,7 +27,7 @@ class CellAgent(Agent):
             unique_id (int): A unique identifier for this agent.
             model (Model): The model instance in which the agent exists.
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.cell: Cell | None = None
 
     def move_to(self, cell) -> None:

--- a/mesa/experimental/devs/examples/epstein_civil_violence.py
+++ b/mesa/experimental/devs/examples/epstein_civil_violence.py
@@ -7,8 +7,8 @@ from mesa.space import SingleGrid
 
 
 class EpsteinAgent(Agent):
-    def __init__(self, unique_id, model, vision, movement):
-        super().__init__(unique_id, model)
+    def __init__(self, model, vision, movement):
+        super().__init__(model)
         self.vision = vision
         self.movement = movement
 

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -123,10 +123,23 @@ class Model:
         self._steps += 1
         self._time += deltat
 
-    def next_id(self) -> int:
-        """Return the next unique ID for agents, increment current_id"""
+    @property
+    def _next_id(self) -> int:
+        """Return the next unique ID for agents. Starts at 0."""
+        return_id = self.current_id
         self.current_id += 1
-        return self.current_id
+        return return_id
+
+    def next_id(self) -> int:
+        """Old version of next_id, kept for compatibility."""
+        warnings.warn(
+            "Model.next_id() is deprecated and will be removed in a future version.\n"
+            "The Agent.unique_id parameter is now generated automatically and doesn't need to be passed in Agent() anymore.\n"
+            "Please initialize agents with the model instance only: Agent(model, ...), instead of Agent(unique_id, model, ...)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return 0  # This is a dummy return value, but some functions might expect an int. It isn't used in agent creation anyway.
 
     def reset_randomizer(self, seed: int | None = None) -> None:
         """Reset the model random number generator.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -343,7 +343,7 @@ def test_agentset_map_str():
         agentset.do("non_existing_method")
 
     results = agentset.map("get_unique_identifier")
-    assert all(i == entry for i, entry in zip(results, range(1, 11)))
+    assert all(i == entry for i, entry in zip(results, range(10)))
 
 
 def test_agentset_map_callable():
@@ -360,7 +360,7 @@ def test_agentset_map_callable():
     # related to issue #1595
 
     results = agentset.map(lambda agent: agent.unique_id)
-    assert all(i == entry for i, entry in zip(results, range(1, 11)))
+    assert all(i == entry for i, entry in zip(results, range(10)))
 
 
 def test_agentset_get_attribute():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,6 +11,46 @@ class TestAgent(Agent):
         return self.unique_id
 
 
+class PositionalAgent(Agent):
+    """Old behavior of Agent creation with unique_id and model as positional arguments.
+    Can be removed in the future."""
+
+    def __init__(self, unique_id, model):
+        super().__init__(unique_id, model)
+
+
+class NewAgent(Agent):
+    def __init__(self, model, some_other, arguments=1):
+        super().__init__(model)
+        self.some_other = some_other
+        self.arguments = arguments
+
+
+@pytest.fixture
+def model():
+    """Fixture to create a Model instance."""
+    model = Model()
+    return model
+
+
+def test_creation_with_positional_arguments(model):
+    """Old behavior of Agent creation with unique_id and model as positional arguments.
+    Can be removed/updated in the future."""
+    agent = PositionalAgent(1, model)
+    assert isinstance(agent.unique_id, int)
+    assert agent.model == model
+    assert isinstance(agent.model, Model)
+
+
+def test_creation_with_new_arguments(model):
+    """New behavior of Agent creation with model as the first argument and additional arguments."""
+    agent = NewAgent(model, "some_other", 2)
+    assert agent.model == model
+    assert isinstance(agent.model, Model)
+    assert agent.some_other == "some_other"
+    assert agent.arguments == 2
+
+
 class TestAgentDo(Agent):
     def __init__(
         self,
@@ -45,7 +85,7 @@ def test_agent_removal():
 def test_agentset():
     # create agentset
     model = Model()
-    agents = [TestAgent(model.next_id(), model) for _ in range(10)]
+    agents = [TestAgent(model) for _ in range(10)]
 
     agentset = AgentSet(agents, model)
 
@@ -57,7 +97,7 @@ def test_agentset():
         assert a1 == a2
 
     def test_function(agent):
-        return agent.unique_id > 5
+        return agent.unique_id >= 5
 
     assert len(agentset.select(test_function)) == 5
     assert len(agentset.select(test_function, n=2)) == 2

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -385,7 +385,7 @@ def test_empties_space():
 
     model = Model()
     for i in range(8):
-        grid._cells[i].add_agent(CellAgent(i, model))
+        grid._cells[i].add_agent(CellAgent(model))
 
     cell = grid.select_random_empty_cell()
     assert cell.coordinate in {8, 9}
@@ -409,7 +409,7 @@ def test_cell():
 
     # add_agent
     model = Model()
-    agent = CellAgent(1, model)
+    agent = CellAgent(model)
 
     cell1.add_agent(agent)
     assert agent in cell1.agents
@@ -422,11 +422,11 @@ def test_cell():
         cell1.remove_agent(agent)
 
     cell1 = Cell((1,), capacity=1, random=random.Random())
-    cell1.add_agent(CellAgent(1, model))
+    cell1.add_agent(CellAgent(model))
     assert cell1.is_full
 
     with pytest.raises(Exception):
-        cell1.add_agent(CellAgent(2, model))
+        cell1.add_agent(CellAgent(model))
 
 
 def test_cell_collection():
@@ -452,9 +452,9 @@ def test_cell_collection():
 
     cells = collection.cells
     model = Model()
-    cells[0].add_agent(CellAgent(1, model))
-    cells[3].add_agent(CellAgent(2, model))
-    cells[7].add_agent(CellAgent(3, model))
+    cells[0].add_agent(CellAgent(model))
+    cells[3].add_agent(CellAgent(model))
+    cells[7].add_agent(CellAgent(model))
     agents = collection.agents
     assert len(list(agents)) == 3
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,8 +7,6 @@ def test_model_set_up():
     assert model.running is True
     assert model.schedule is None
     assert model.current_id == 0
-    assert model.current_id + 1 == model.next_id()
-    assert model.current_id == 1
     model.step()
 
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -25,8 +25,9 @@ class MockAgent(Agent):
     Minimalistic agent for testing purposes.
     """
 
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model, name=""):
+        super().__init__(model)
+        self.name = name
         self.steps = 0
         self.advances = 0
 
@@ -38,10 +39,10 @@ class MockAgent(Agent):
     def stage_one(self):
         if self.model.enable_kill_other_agent:
             self.kill_other_agent()
-        self.model.log.append(self.unique_id + "_1")
+        self.model.log.append(f"{self.name}_1")
 
     def stage_two(self):
-        self.model.log.append(self.unique_id + "_2")
+        self.model.log.append(f"{self.name}_2")
 
     def advance(self):
         self.advances += 1
@@ -50,7 +51,7 @@ class MockAgent(Agent):
         if self.model.enable_kill_other_agent:
             self.kill_other_agent()
         self.steps += 1
-        self.model.log.append(self.unique_id)
+        self.model.log.append(f"{self.name}")
 
 
 class MockModel(Model):
@@ -90,7 +91,7 @@ class MockModel(Model):
 
         # Make agents
         for name in ["A", "B"]:
-            agent = MockAgent(name, self)
+            agent = MockAgent(self, name)
             self.schedule.add(agent)
 
     def step(self):
@@ -168,7 +169,7 @@ class TestRandomActivation(TestCase):
 
     def test_init(self):
         model = Model()
-        agents = [MockAgent(model.next_id(), model) for _ in range(10)]
+        agents = [MockAgent(model) for _ in range(10)]
 
         scheduler = RandomActivation(model, agents)
         assert all(agent in scheduler.agents for agent in agents)
@@ -227,7 +228,7 @@ class TestRandomActivation(TestCase):
         model = MockModel(activation=RANDOM)
         # Create 10 agents
         for _ in range(10):
-            model.schedule.add(MockAgent(model.next_id(), model))
+            model.schedule.add(MockAgent(model))
         # Run 3 steps
         for _ in range(3):
             model.step()
@@ -273,7 +274,7 @@ class TestRandomActivationByType(TestCase):
 
     def test_init(self):
         model = Model()
-        agents = [MockAgent(model.next_id(), model) for _ in range(10)]
+        agents = [MockAgent(model) for _ in range(10)]
         agents += [Agent(model.next_id(), model) for _ in range(10)]
 
         scheduler = RandomActivationByType(model, agents)


### PR DESCRIPTION
Automatically assign `unique_id` to Agents. This has two goals:

- Automatically assign agents an `unique_id` value on creation.
- Guarantee that all `unique_id` values are actually unique.

A few design considerations:
- The `current_id` counter starts now at `0`, instead of `1`.
  - This is consistent with `for i in range(n)` loops, which also assign unique_ids from 1.
- Warnings are thrown for the most common cases of agent initialization. Other cases get an informative error.
- The counter is kept inside the model. Testing of unique ids becomes almost impossible without that. It can be moved in another PR if desired.
- `next_id()` was commonly use, so that also gets a deprecation warning.
- The `current_id` counter is kept public. It can be useful to see how many agents are created in total, and is used here and there. Again, can be modified in another PR.

### Usage
Instead of:
```Python
Agent(unique_id, model, ...)
```
You can (and should) now initialize your Agent with:
```Python
Agent(model, ...)
```

Resolves #2213 