### PR TITLE
Split AgentSet into map and do to seperate return types

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import operator
+import warnings
 import weakref
 from collections.abc import Callable, Iterable, Iterator, MutableSet, Sequence
 from random import Random
@@ -217,23 +218,65 @@ class AgentSet(MutableSet, Sequence):
         return self
 
     def do(
-        self, method: str | Callable, *args, return_results: bool = False, **kwargs
-    ) -> AgentSet | list[Any]:
+        self, method: str | Callable, *args, **kwargs
+    ) -> AgentSet:
         """
         Invoke a method or function on each agent in the AgentSet.
 
         Args:
-            method (str, callable): the callable to do on each agents
+            method (str, callable): the callable to do on each agent
 
                                         * in case of str, the name of the method to call on each agent.
                                         * in case of callable, the function to be called with each agent as first argument
 
-            return_results (bool, optional): If True, returns the results of the method calls; otherwise, returns the AgentSet itself. Defaults to False, so you can chain method calls.
             *args: Variable length argument list passed to the callable being called.
             **kwargs: Arbitrary keyword arguments passed to the callable being called.
 
         Returns:
             AgentSet | list[Any]: The results of the callable calls if return_results is True, otherwise the AgentSet itself.
+        """
+        try:
+            return_results = kwargs.pop("return_results")
+        except KeyError:
+            return_results = False
+        else:
+            warnings.warn("Using return_results is deprecated. Use AgenSet.do in case of return_results=False, and "
+                          "AgentSet.apply in case of return_results=True", stacklevel=2)
+
+        if return_results:
+            return self.apply(method, *args, **kwargs)
+
+
+        # we iterate over the actual weakref keys and check if weakref is alive before calling the method
+        if isinstance(method, str):
+            for agentref in self._agents.keyrefs():
+                if (agent := agentref()) is not None:
+                    getattr(agent, method)(*args, **kwargs)
+        else:
+            for agentref in self._agents.keyrefs():
+                if (agent := agentref()) is not None:
+                    method(agent, *args, **kwargs)
+
+        return self
+
+
+    def apply(
+        self, method: str | Callable, *args, **kwargs
+    ) -> list[Any]:
+        """
+        Invoke a method or function on each agent in the AgentSet.
+
+        Args:
+            method (str, callable): the callable to apply on each agent
+
+                                        * in case of str, the name of the method to call on each agent.
+                                        * in case of callable, the function to be called with each agent as first argument
+
+            *args: Variable length argument list passed to the callable being called.
+            **kwargs: Arbitrary keyword arguments passed to the callable being called.
+
+        Returns:
+           list[Any]: The results of the callable calls
         """
         # we iterate over the actual weakref keys and check if weakref is alive before calling the method
         if isinstance(method, str):
@@ -249,7 +292,8 @@ class AgentSet(MutableSet, Sequence):
                 if (agent := agentref()) is not None
             ]
 
-        return res if return_results else self
+        return res
+
 
     def get(self, attr_names: str | list[str]) -> list[Any]:
         """

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -240,12 +240,12 @@ class AgentSet(MutableSet, Sequence):
         else:
             warnings.warn(
                 "Using return_results is deprecated. Use AgenSet.do in case of return_results=False, and "
-                "AgentSet.apply in case of return_results=True",
+                "AgentSet.map in case of return_results=True",
                 stacklevel=2,
             )
 
         if return_results:
-            return self.apply(method, *args, **kwargs)
+            return self.map(method, *args, **kwargs)
 
         # we iterate over the actual weakref keys and check if weakref is alive before calling the method
         if isinstance(method, str):

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -217,9 +217,7 @@ class AgentSet(MutableSet, Sequence):
         self._agents = weakref.WeakKeyDictionary({agent: None for agent in agents})
         return self
 
-    def do(
-        self, method: str | Callable, *args, **kwargs
-    ) -> AgentSet:
+    def do(self, method: str | Callable, *args, **kwargs) -> AgentSet:
         """
         Invoke a method or function on each agent in the AgentSet.
 
@@ -240,12 +238,14 @@ class AgentSet(MutableSet, Sequence):
         except KeyError:
             return_results = False
         else:
-            warnings.warn("Using return_results is deprecated. Use AgenSet.do in case of return_results=False, and "
-                          "AgentSet.apply in case of return_results=True", stacklevel=2)
+            warnings.warn(
+                "Using return_results is deprecated. Use AgenSet.do in case of return_results=False, and "
+                "AgentSet.apply in case of return_results=True",
+                stacklevel=2,
+            )
 
         if return_results:
             return self.apply(method, *args, **kwargs)
-
 
         # we iterate over the actual weakref keys and check if weakref is alive before calling the method
         if isinstance(method, str):
@@ -259,10 +259,7 @@ class AgentSet(MutableSet, Sequence):
 
         return self
 
-
-    def apply(
-        self, method: str | Callable, *args, **kwargs
-    ) -> list[Any]:
+    def apply(self, method: str | Callable, *args, **kwargs) -> list[Any]:
         """
         Invoke a method or function on each agent in the AgentSet.
 
@@ -293,7 +290,6 @@ class AgentSet(MutableSet, Sequence):
             ]
 
         return res
-
 
     def get(self, attr_names: str | list[str]) -> list[Any]:
         """

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -259,9 +259,9 @@ class AgentSet(MutableSet, Sequence):
 
         return self
 
-    def apply(self, method: str | Callable, *args, **kwargs) -> list[Any]:
+    def map(self, method: str | Callable, *args, **kwargs) -> list[Any]:
         """
-        Invoke a method or function on each agent in the AgentSet.
+        Invoke a method or function on each agent in the AgentSet and return the results.
 
         Args:
             method (str, callable): the callable to apply on each agent

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -270,7 +270,6 @@ def test_agentset_do_callable():
     assert len(agentset) == 0
 
 
-
 def test_agentset_apply_str():
     model = Model()
     agents = [TestAgent(model.next_id(), model) for _ in range(10)]
@@ -281,6 +280,7 @@ def test_agentset_apply_str():
 
     results = agentset.apply("get_unique_identifier")
     assert all(i == entry for i, entry in zip(results, range(1, 11)))
+
 
 def test_agentset_apply_callable():
     model = Model()
@@ -297,7 +297,6 @@ def test_agentset_apply_callable():
 
     results = agentset.apply(lambda agent: agent.unique_id)
     assert all(i == entry for i, entry in zip(results, range(1, 11)))
-
 
 
 def test_agentset_get_attribute():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -270,7 +270,7 @@ def test_agentset_do_callable():
     assert len(agentset) == 0
 
 
-def test_agentset_apply_str():
+def test_agentset_map_str():
     model = Model()
     agents = [TestAgent(model.next_id(), model) for _ in range(10)]
     agentset = AgentSet(agents, model)
@@ -278,24 +278,24 @@ def test_agentset_apply_str():
     with pytest.raises(AttributeError):
         agentset.do("non_existing_method")
 
-    results = agentset.apply("get_unique_identifier")
+    results = agentset.map("get_unique_identifier")
     assert all(i == entry for i, entry in zip(results, range(1, 11)))
 
 
-def test_agentset_apply_callable():
+def test_agentset_map_callable():
     model = Model()
     agents = [TestAgent(model.next_id(), model) for _ in range(10)]
     agentset = AgentSet(agents, model)
 
     # Test callable with non-existent function
     with pytest.raises(AttributeError):
-        agentset.apply(lambda agent: agent.non_existing_method())
+        agentset.map(lambda agent: agent.non_existing_method())
 
     # tests for addition and removal in do using callables
     # do iterates, so no error should be raised to change size while iterating
     # related to issue #1595
 
-    results = agentset.apply(lambda agent: agent.unique_id)
+    results = agentset.map(lambda agent: agent.unique_id)
     assert all(i == entry for i, entry in zip(results, range(1, 11)))
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -83,12 +83,6 @@ def test_agentset():
     assert all(
         a1 == a2.unique_id for a1, a2 in zip(agentset.get("unique_id"), agentset)
     )
-    assert all(
-        a1 == a2.unique_id
-        for a1, a2 in zip(
-            agentset.do("get_unique_identifier", return_results=True), agentset
-        )
-    )
     assert agentset == agentset.do("get_unique_identifier")
 
     agentset.discard(agents[0])
@@ -274,6 +268,36 @@ def test_agentset_do_callable():
     # Actual function for removal
     agentset.do(remove_function)
     assert len(agentset) == 0
+
+
+
+def test_agentset_apply_str():
+    model = Model()
+    agents = [TestAgent(model.next_id(), model) for _ in range(10)]
+    agentset = AgentSet(agents, model)
+
+    with pytest.raises(AttributeError):
+        agentset.do("non_existing_method")
+
+    results = agentset.apply("get_unique_identifier")
+    assert all(i == entry for i, entry in zip(results, range(1, 11)))
+
+def test_agentset_apply_callable():
+    model = Model()
+    agents = [TestAgent(model.next_id(), model) for _ in range(10)]
+    agentset = AgentSet(agents, model)
+
+    # Test callable with non-existent function
+    with pytest.raises(AttributeError):
+        agentset.apply(lambda agent: agent.non_existing_method())
+
+    # tests for addition and removal in do using callables
+    # do iterates, so no error should be raised to change size while iterating
+    # related to issue #1595
+
+    results = agentset.apply(lambda agent: agent.unique_id)
+    assert all(i == entry for i, entry in zip(results, range(1, 11)))
+
 
 
 def test_agentset_get_attribute():


### PR DESCRIPTION
# Motivation
In #2220 @corvince suggested to seperate `AgentSet.do` into 2 seperate methods based on their return type.  `AgentSet.do` executes the callable/method/function and returns the original AgentSet. `AgentSet.map`executes the callable/method/function and returns the results. At the moment both behaviors are in AgentSet.do and can be controlled with the `return_results` keyword argument. 

# Implementation details.
The code is straightforward. I wrap all kwargs to `AgentSet.do` into a dict. Check if `return_results` is in it. If it is, a DepractionWarning is issued. The rest of the code proceeds as normal. 


# Usage

```python

# some form of staged activation
# because do returns the agentset we can chain calls
some_agentset.do("step1").do("step2").do("step3")

# map returns the result of the method so here a list of unique_ids is returned
# no further method chaining of AgentSet methods is possible. 
some_agentset.map(lambda x: x.unique_id)

```