### PR TITLE
SolaraViz: Reset components when params are changed

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -158,7 +158,11 @@ def SolaraViz(
         """Update the random seed for the model."""
         reactive_seed.value = model.random.random()
 
-    dependencies = [current_step.value, reactive_seed.value]
+    dependencies = [
+        *list(model_parameters.values()),
+        current_step.value,
+        reactive_seed.value,
+    ]
 
     # if space drawer is disabled, do not include it
     layout_types = [{"Space": "default"}] if space_drawer else []


### PR DESCRIPTION
This fixes #2239 (summary can be found in the issue). cc: @DrEntropy.

> Currently, using SolaraViz,  manipulating the controls to change `model_params` doesn't change seem to cause a redraw for the `space_drawer`.  (Changing the seed, or advancing one step does redraw with the current parameters).  This is most noticeable for network space models, for example `virus_on__network`.     I also note that pressing reset redraws but not with the updated model parameters.