### PR TITLE
More parameter functionality in matplotlib (default) drawer visualization

### DIFF
--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -1,11 +1,12 @@
 from collections import defaultdict
 
 import matplotlib.pyplot as plt
+import networkx as nx
+import solara
 from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
-import networkx as nx
-import solara
+
 import mesa
 from mesa.space import GridContent
 
@@ -83,7 +84,6 @@ def _split_and_scatter(portray_data: dict, space_ax) -> None:
     grouped_data = defaultdict(lambda: {key: [] for key in portray_data})
 
     for i, marker in enumerate(markers):
-
         for key in portray_data:
             if key == "c":  # apply colormap if possible
                 # prepare arguments
@@ -104,7 +104,6 @@ def _split_and_scatter(portray_data: dict, space_ax) -> None:
 
 def _draw_grid(space, space_ax, agent_portrayal):
     def portray(g):
-
         default_values = {
             "size": (180 / max(g.width, g.height)) ** 2,
         }
@@ -136,7 +135,7 @@ def _draw_grid(space, space_ax, agent_portrayal):
                     for key, value in data.items():
                         if key not in out:
                             # initialize list
-                            out[key] = [default_values.get(key, None)] * num_agents
+                            out[key] = [default_values.get(key)] * num_agents
                         out[key][index] = value
                     index += 1
 
@@ -162,7 +161,6 @@ def _draw_network_grid(space, space_ax, agent_portrayal):
 
 def _draw_continuous_space(space, space_ax, agent_portrayal):
     def portray(space):
-
         # TODO: look into if more default values are needed
         #   especially relating to 'color', 'facecolor', and 'c' params &
         #   interactions w/ the current implementation of _split_and_scatter

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -22,6 +22,7 @@ def SpaceMatplotlib(model, agent_portrayal, dependencies: list[any] | None = Non
         _draw_continuous_space(space, space_ax, agent_portrayal)
     else:
         _draw_grid(space, space_ax, agent_portrayal)
+
     solara.FigureMatplotlib(space_fig, format="png", dependencies=dependencies)
 
 
@@ -94,6 +95,7 @@ def _draw_grid(space, space_ax, agent_portrayal):
     _split_and_scatter(portray(space), space_ax)
 
 
+# draws using networkx's matplotlib integration
 def _draw_network_grid(space, space_ax, agent_portrayal):
     graph = space.G
     pos = nx.spring_layout(graph, seed=0)

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -29,7 +29,8 @@ def SpaceMatplotlib(model, agent_portrayal, dependencies: list[any] | None = Non
 
 
 # used to make non(less?)-breaking change
-# this *does* however block the matplotlib 'color' param which is distinct from 'c'.
+# this *does* however block the matplotlib 'color' param which is somewhat distinct from 'c'.
+# maybe translate 'size' and 'shape' but not 'color'?
 def _translate_old_keywords(data):
     """
     Translates old keyword names in the given dictionary to the new names.

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-from matplotlib.pylab import norm
 import matplotlib.pyplot as plt
 from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
@@ -8,6 +7,7 @@ from matplotlib.ticker import MaxNLocator
 import networkx as nx
 import solara
 import mesa
+from mesa.space import GridContent
 
 
 @solara.component
@@ -110,16 +110,14 @@ def _draw_grid(space, space_ax, agent_portrayal):
         }
 
         out = {}
-        num_agents = 0  # TODO: find way to avoid iterating twice
-        for i in range(g.width):
-            for j in range(g.height):
-                content = g._grid[i][j]
-                if not content:
-                    continue
-                if not hasattr(content, "__iter__"):
-                    num_agents += 1
-                    continue
-                num_agents += len(content)
+        num_agents = 0
+        for content in g:
+            if not content:
+                continue
+            if isinstance(content, GridContent):  # one agent
+                num_agents += 1
+                continue
+            num_agents += len(content)
 
         index = 0
         for i in range(g.width):

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -104,7 +104,8 @@ def SolaraViz(
         measures: List of callables or data attributes to plot
         name: Name for display
         agent_portrayal: Options for rendering agents (dictionary);
-            Default drawer supports custom `"size"`, `"color"`, and `"shape"`.
+            Default drawer supports custom matplotlib's [scatter](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html)
+            params, with the exception of (currently) vmin, vmax, & plotnonfinite.
         space_drawer: Method to render the agent space for
             the model; default implementation is the `SpaceMatplotlib` component;
             simulations with no space to visualize should


### PR DESCRIPTION
(screenshots of changes w/ example `agent_portrayal` functions coming)

Stuff like this is now possible:
```Python
def agent_portrayal(cell):

    return {
        "c": "white" if cell.isAlive else "black",
        "s": 45,
        "marker": "*",
        "edgecolors": "purple",
        "linewidths": 0.5,
        "alpha": 0.5,
    }
```
![image](https://github.com/user-attachments/assets/02e9d2e5-4e2f-4e89-83f7-dce1688e51a5)

- updates necessary docstring
- supports all params in matplotlib's [scatter](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html) with the exception of `plotnonfinite`
- manual colormapping to get around restrictions similar to those with 'marker', where a unique colormap cannot usually be provided for each point plotted
- streamlined code for `_split_and_scatter` and `portray`