### PR TITLE
Update solara_viz.py

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -449,7 +449,7 @@ def make_initial_grid_layout(layout_types):
         {
             "i": i,
             "w": 6,
-            "h": 10,
+            "h": 14,
             "moved": False,
             "x": 6 * (i % 2),
             "y": 16 * (i - i % 2),


### PR DESCRIPTION
- adjust sizes to make more visually appealing

Adjust background grid to encompass displays; interestingly I tried at a bunch of other options like using `ResponsiveColumn`, tried several different number combinations, but it seemed the simplest was the best. 

Boltzmann Wealth Current:
![Mesa current](https://github.com/user-attachments/assets/cd5b85a6-d756-4211-b60b-e37fbeac1089)
Boltzmann Wealth Adjusted
![Mesa after adjust](https://github.com/user-attachments/assets/295f9d66-3edc-4023-9c74-c4b7f026a870)

Geo-Sir Current
![Screenshot 2024-08-24 074812](https://github.com/user-attachments/assets/22d1f4ab-78d1-41ce-b98f-7a9f9274407d)
Geo-Sir Adjusted
![geo_mesa current](https://github.com/user-attachments/assets/09556b74-b8dd-425b-833e-5a031bf08fd4)

