### PR TITLE
Resolve multiprocessing warning, state Python 3.13 support

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -1,4 +1,5 @@
 import itertools
+import multiprocessing
 from collections.abc import Iterable, Mapping
 from functools import partial
 from multiprocessing import Pool
@@ -7,6 +8,8 @@ from typing import Any
 from tqdm.auto import tqdm
 
 from mesa.model import Model
+
+multiprocessing.set_start_method("spawn", force=True)
 
 
 def batch_run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR addresses a DeprecationWarning related to using `fork()` in multi-threaded processes, which can lead to deadlocks in the child processes when using Python's `multiprocessing` module.  The 'spawn' method avoids the issues that arise from forking in a multi-threaded environment by starting a new Python interpreter process for each worker, which is safer and more compatible with modern systems.

It also adds the Python 3.13 qualifier to the pyproject.toml.