### PR TITLE
benchmarks: Add BoltzmannWealth model

### DIFF
--- a/benchmarks/BoltzmannWealth/boltzmann_wealth.py
+++ b/benchmarks/BoltzmannWealth/boltzmann_wealth.py
@@ -1,0 +1,78 @@
+# https://github.com/projectmesa/mesa-examples/blob/main/examples/boltzmann_wealth_model_experimental/model.py
+import mesa
+
+
+def compute_gini(model):
+    agent_wealths = [agent.wealth for agent in model.agents]
+    x = sorted(agent_wealths)
+    N = model.num_agents
+    B = sum(xi * (N - i) for i, xi in enumerate(x)) / (N * sum(x))
+    return 1 + (1 / N) - 2 * B
+
+
+class BoltzmannWealth(mesa.Model):
+    """A simple model of an economy where agents exchange currency at random.
+
+    All the agents begin with one unit of currency, and each time step can give
+    a unit of currency to another agent. Note how, over time, this produces a
+    highly skewed distribution of wealth.
+    """
+
+    def __init__(self, seed=None, N=100, width=10, height=10):
+        super().__init__()
+        self.num_agents = N
+        self.grid = mesa.space.MultiGrid(width, height, True)
+        self.schedule = mesa.time.RandomActivation(self)
+        self.datacollector = mesa.DataCollector(
+            model_reporters={"Gini": compute_gini}, agent_reporters={"Wealth": "wealth"}
+        )
+        # Create agents
+        for i in range(self.num_agents):
+            a = MoneyAgent(i, self)
+            # Add the agent to a random grid cell
+            x = self.random.randrange(self.grid.width)
+            y = self.random.randrange(self.grid.height)
+            self.grid.place_agent(a, (x, y))
+
+        self.running = True
+        self.datacollector.collect(self)
+
+    def step(self):
+        self._advance_time()
+        self.agents.shuffle().do("step")
+        # collect data
+        self.datacollector.collect(self)
+
+    def run_model(self, n):
+        for i in range(n):
+            self.step()
+
+
+class MoneyAgent(mesa.Agent):
+    """An agent with fixed initial wealth."""
+
+    def __init__(self, unique_id, model):
+        super().__init__(unique_id, model)
+        self.wealth = 1
+
+    def move(self):
+        possible_steps = self.model.grid.get_neighborhood(
+            self.pos, moore=True, include_center=False
+        )
+        new_position = self.random.choice(possible_steps)
+        self.model.grid.move_agent(self, new_position)
+
+    def give_money(self):
+        cellmates = self.model.grid.get_cell_list_contents([self.pos])
+        cellmates.pop(
+            cellmates.index(self)
+        )  # Ensure agent is not giving money to itself
+        if len(cellmates) > 0:
+            other = self.random.choice(cellmates)
+            other.wealth += 1
+            self.wealth -= 1
+
+    def step(self):
+        self.move()
+        if self.wealth > 0:
+            self.give_money()

--- a/benchmarks/BoltzmannWealth/boltzmann_wealth.py
+++ b/benchmarks/BoltzmannWealth/boltzmann_wealth.py
@@ -5,9 +5,9 @@ import mesa
 def compute_gini(model):
     agent_wealths = [agent.wealth for agent in model.agents]
     x = sorted(agent_wealths)
-    N = model.num_agents
-    B = sum(xi * (N - i) for i, xi in enumerate(x)) / (N * sum(x))
-    return 1 + (1 / N) - 2 * B
+    n = model.num_agents
+    b = sum(xi * (n - i) for i, xi in enumerate(x)) / (n * sum(x))
+    return 1 + (1 / n) - 2 * b
 
 
 class BoltzmannWealth(mesa.Model):
@@ -18,9 +18,9 @@ class BoltzmannWealth(mesa.Model):
     highly skewed distribution of wealth.
     """
 
-    def __init__(self, seed=None, N=100, width=10, height=10):
+    def __init__(self, seed=None, n=100, width=10, height=10):
         super().__init__()
-        self.num_agents = N
+        self.num_agents = n
         self.grid = mesa.space.MultiGrid(width, height, True)
         self.schedule = mesa.time.RandomActivation(self)
         self.datacollector = mesa.DataCollector(
@@ -44,7 +44,7 @@ class BoltzmannWealth(mesa.Model):
         self.datacollector.collect(self)
 
     def run_model(self, n):
-        for i in range(n):
+        for _i in range(n):
             self.step()
 
 

--- a/benchmarks/configurations.py
+++ b/benchmarks/configurations.py
@@ -1,8 +1,32 @@
+from BoltzmannWealth.boltzmann_wealth import BoltzmannWealth
 from Flocking.flocking import BoidFlockers
 from Schelling.schelling import Schelling
 from WolfSheep.wolf_sheep import WolfSheep
 
 configurations = {
+    # Schelling Model Configurations
+    BoltzmannWealth: {
+        "small": {
+            "seeds": 50,
+            "replications": 5,
+            "steps": 125,
+            "parameters": {
+                "N": 100,
+                "width": 10,
+                "height": 10,
+            },
+        },
+        "large": {
+            "seeds": 10,
+            "replications": 3,
+            "steps": 10,
+            "parameters": {
+                "N": 10000,
+                "width": 100,
+                "height": 100,
+            },
+        },
+    },
     # Schelling Model Configurations
     Schelling: {
         "small": {

--- a/benchmarks/configurations.py
+++ b/benchmarks/configurations.py
@@ -11,7 +11,7 @@ configurations = {
             "replications": 5,
             "steps": 125,
             "parameters": {
-                "N": 100,
+                "n": 100,
                 "width": 10,
                 "height": 10,
             },
@@ -21,7 +21,7 @@ configurations = {
             "replications": 3,
             "steps": 10,
             "parameters": {
-                "N": 10000,
+                "n": 10000,
                 "width": 100,
                 "height": 100,
             },
@@ -59,7 +59,7 @@ configurations = {
         "small": {
             "seeds": 50,
             "replications": 5,
-            "steps": 40,
+            "steps": 80,
             "parameters": {
                 "height": 25,
                 "width": 25,

--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -16,18 +16,22 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Generic function to initialize and run a model
 def run_model(model_class, seed, parameters):
+    no_simulator = ["BoltzmannWealth"]
     start_init = timeit.default_timer()
-    simulator = ABMSimulator()
-    model = model_class(simulator=simulator, seed=seed, **parameters)
-    simulator.setup(model)
+    if model_class.__name__ in no_simulator:
+        model = model_class(seed=seed, **parameters)
+    else:
+        simulator = ABMSimulator()
+        model = model_class(simulator=simulator, seed=seed, **parameters)
+        simulator.setup(model)
 
     end_init_start_run = timeit.default_timer()
 
-    simulator.run_for(config["steps"])
+    if model_class.__name__ in no_simulator:
+        model.run_model(config["steps"])
+    else:
+        simulator.run_for(config["steps"])
 
-    # for _ in range(config["steps"]):
-    #     model.step()
-    #       time.sleep(0.0001)
     end_run = timeit.default_timer()
 
     return (end_init_start_run - start_init), (end_run - end_init_start_run)


### PR DESCRIPTION
BoltzmannWealth model to the benchmarks. It's probably the "best" test of Mesa that we have, since it does a lot of Mesa things and not a lot of other things.

A separate PR will update it to use AgentSet functionality, but I want to see the performance difference between that. This PR just adds the example model [from mesa-examples](https://github.com/projectmesa/mesa-examples/blob/1d67252a9f2abad051470a07a1607a2a3aa02b29/examples/boltzmann_wealth_model_experimental/model.py).

<hr>

@quaquel I noticed in that with the addition of discrete event scheduling in #2066 _all_ models were converted to DEVS. While I understand it was useful to test, and I think it's great to have that in the benchmark for one or two models, I think for all is a bit overkill as long as it's experimental.

So the novelty is clearly in WolfSheep, I would propose keeping that on DEVS and reverting the other two back to our regular activation.