### PR TITLE
AgentSet: Allow selecting a fraction of agents in the AgentSet

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -122,38 +122,41 @@ class AgentSet(MutableSet, Sequence):
         self,
         filter_func: Callable[[Agent], bool] | None = None,
         n: int = 0,
-        p: float = 1.0,
+        fraction: float = 1.0,
         inplace: bool = False,
         agent_type: type[Agent] | None = None,
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
-
+    
         Args:
             filter_func (Callable[[Agent], bool], optional): A function that takes an Agent and returns True if the
                 agent should be included in the result. Defaults to None, meaning no filtering is applied.
             n (int, optional): The number of agents to select. If 0, all matching agents are selected. Defaults to 0.
-            p (float, optional): The fraction of agents to select. If 0.2, it selects 20% of Agents in the AgentSet. Defaults to 1.0.
+            fraction (float, optional): The fraction of agents to select. If 0.2, it selects 20% of Agents in the AgentSet. Defaults to 1.0.
             inplace (bool, optional): If True, modifies the current AgentSet; otherwise, returns a new AgentSet. Defaults to False.
             agent_type (type[Agent], optional): The class type of the agents to select. Defaults to None, meaning no type filtering is applied.
-
+    
         Returns:
             AgentSet: A new AgentSet containing the selected agents, unless inplace is True, in which case the current AgentSet is updated.
+    
+        Raises:
+            ValueError: If both n and fraction are set.
 
         Note:
-            n and p can't both be set at the same time, set one at most.
+            n and fraction just return the first n or fraction of agents. To take a random sample, shuffle() beforehand.
         """
 
         if filter_func is None and agent_type is None and n == 0 and p == 1.0:
             return self if inplace else copy.copy(self)
 
-        if p != 1.0 and n != 0:
+        if n != 0 and fraction != 1.0:
             raise ValueError(
-                "Cannot set both n and p. Please set only one of these parameters."
+                "Cannot set both n and fraction. Please set only one of these parameters."
             )
 
-        if p < 1.0:
-            n = round(len(self) * p)
+        if fraction < 1.0:
+            n = round(len(self) * fraction)
 
         def agent_generator(filter_func=None, agent_type=None, n=0):
             count = 0

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -139,10 +139,16 @@ class AgentSet(MutableSet, Sequence):
 
         Returns:
             AgentSet: A new AgentSet containing the selected agents, unless inplace is True, in which case the current AgentSet is updated.
+
+        Note:
+            n and p can't both be set at the same time, set one at most.
         """
 
         if filter_func is None and agent_type is None and n == 0 and p == 1.0:
             return self if inplace else copy.copy(self)
+
+        if p != 1.0 and n != 0:
+            raise ValueError("Cannot set both n and p. Please set only one of these parameters.")
 
         if p < 1.0:
             n = round(len(self) * p)

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -147,7 +147,7 @@ class AgentSet(MutableSet, Sequence):
             n and fraction just return the first n or fraction of agents. To take a random sample, shuffle() beforehand.
         """
 
-        if filter_func is None and agent_type is None and n == 0 and p == 1.0:
+        if filter_func is None and agent_type is None and n == 0 and fraction == 1.0:
             return self if inplace else copy.copy(self)
 
         if n != 0 and fraction != 1.0:

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -148,7 +148,9 @@ class AgentSet(MutableSet, Sequence):
             return self if inplace else copy.copy(self)
 
         if p != 1.0 and n != 0:
-            raise ValueError("Cannot set both n and p. Please set only one of these parameters.")
+            raise ValueError(
+                "Cannot set both n and p. Please set only one of these parameters."
+            )
 
         if p < 1.0:
             n = round(len(self) * p)

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -133,9 +133,8 @@ class AgentSet(MutableSet, Sequence):
             filter_func (Callable[[Agent], bool], optional): A function that takes an Agent and returns True if the
                 agent should be included in the result. Defaults to None, meaning no filtering is applied.
             at_most (int | float, optional): The maximum amount of agents to select. Defaults to infinity.
-              - If an integer of 1 or larger, the first n matching agents are selected.
+              - If an integer, at most the first number of matching agents are selected.
               - If a float between 0 and 1, at most that fraction of original the agents are selected.
-            fraction (float, optional): The fraction of agents to select. If 0.2, it selects 20% of Agents in the AgentSet. Defaults to 1.0.
             inplace (bool, optional): If True, modifies the current AgentSet; otherwise, returns a new AgentSet. Defaults to False.
             agent_type (type[Agent], optional): The class type of the agents to select. Defaults to None, meaning no type filtering is applied.
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -143,8 +143,10 @@ class AgentSet(MutableSet, Sequence):
         Raises:
             ValueError: If both n and fraction are set.
 
-        Note:
-            n and fraction just return the first n or fraction of agents. To take a random sample, shuffle() beforehand.
+        Notes:
+            - n and fraction just return the first n or fraction of agents. To take a random sample, shuffle() beforehand.
+            - n and fraction are upper limits. When specificing other criterea it can be smaller.
+            - A fraction is taken of the original AgentSet length, not the finally selected one.
         """
 
         if filter_func is None and agent_type is None and n == 0 and fraction == 1.0:

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -122,6 +122,7 @@ class AgentSet(MutableSet, Sequence):
         self,
         filter_func: Callable[[Agent], bool] | None = None,
         n: int = 0,
+        p: float = 1.0,
         inplace: bool = False,
         agent_type: type[Agent] | None = None,
     ) -> AgentSet:
@@ -132,6 +133,7 @@ class AgentSet(MutableSet, Sequence):
             filter_func (Callable[[Agent], bool], optional): A function that takes an Agent and returns True if the
                 agent should be included in the result. Defaults to None, meaning no filtering is applied.
             n (int, optional): The number of agents to select. If 0, all matching agents are selected. Defaults to 0.
+            p (float, optional): The fraction of agents to select. If 0.2, it selects 20% of Agents in the AgentSet. Defaults to 1.0.
             inplace (bool, optional): If True, modifies the current AgentSet; otherwise, returns a new AgentSet. Defaults to False.
             agent_type (type[Agent], optional): The class type of the agents to select. Defaults to None, meaning no type filtering is applied.
 
@@ -139,8 +141,11 @@ class AgentSet(MutableSet, Sequence):
             AgentSet: A new AgentSet containing the selected agents, unless inplace is True, in which case the current AgentSet is updated.
         """
 
-        if filter_func is None and agent_type is None and n == 0:
+        if filter_func is None and agent_type is None and n == 0 and p == 1.0:
             return self if inplace else copy.copy(self)
+
+        if p < 1.0:
+            n = round(len(self) * p)
 
         def agent_generator(filter_func=None, agent_type=None, n=0):
             count = 0

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -128,7 +128,7 @@ class AgentSet(MutableSet, Sequence):
     ) -> AgentSet:
         """
         Select a subset of agents from the AgentSet based on a filter function and/or quantity limit.
-    
+
         Args:
             filter_func (Callable[[Agent], bool], optional): A function that takes an Agent and returns True if the
                 agent should be included in the result. Defaults to None, meaning no filtering is applied.
@@ -136,10 +136,10 @@ class AgentSet(MutableSet, Sequence):
             fraction (float, optional): The fraction of agents to select. If 0.2, it selects 20% of Agents in the AgentSet. Defaults to 1.0.
             inplace (bool, optional): If True, modifies the current AgentSet; otherwise, returns a new AgentSet. Defaults to False.
             agent_type (type[Agent], optional): The class type of the agents to select. Defaults to None, meaning no type filtering is applied.
-    
+
         Returns:
             AgentSet: A new AgentSet containing the selected agents, unless inplace is True, in which case the current AgentSet is updated.
-    
+
         Raises:
             ValueError: If both n and fraction are set.
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -145,7 +145,7 @@ class AgentSet(MutableSet, Sequence):
 
         Notes:
             - n and fraction just return the first n or fraction of agents. To take a random sample, shuffle() beforehand.
-            - n and fraction are upper limits. When specificing other criterea it can be smaller.
+            - n and fraction are upper limits. When specificing other criteria it can be smaller.
             - A fraction is taken of the original AgentSet length, not the finally selected one.
         """
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -143,7 +143,7 @@ class AgentSet(MutableSet, Sequence):
 
         Notes:
             - at_most just return the first n or fraction of agents. To take a random sample, shuffle() beforehand.
-            - at_most is an upper limit. When specifying other criteria it can be smaller.
+            - at_most is an upper limit. When specifying other criteria, the number of agents returned can be smaller.
         """
         if n is not None:
             warnings.warn(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -59,10 +59,11 @@ def test_agentset():
     def test_function(agent):
         return agent.unique_id > 5
 
-    assert len(agentset.select(fraction=0.2)) == 2  # Select 20% of agents
-    assert len(agentset.select(fraction=0.549)) == 5  # Select 50% of agents
-    assert len(agentset.select(fraction=0.0)) == 0  # Select 0% of agents
-    assert len(agentset.select(fraction=1.0)) == 10  # Select 100% of agents
+    assert len(agentset.select(max=0.2)) == 2  # Select 20% of agents
+    assert len(agentset.select(max=0.549)) == 5  # Select 50% of agents
+    assert len(agentset.select(max=0.04)) == 0  # Select 0% of agents
+    assert len(agentset.select(max=1.0)) == 10  # Select 100% agents
+    assert len(agentset.select(max=1)) == 1  # Select 1 agent
 
     assert len(agentset.select(test_function)) == 5
     assert len(agentset.select(test_function, n=2)) == 2

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -59,11 +59,11 @@ def test_agentset():
     def test_function(agent):
         return agent.unique_id > 5
 
-    assert len(agentset.select(max=0.2)) == 2  # Select 20% of agents
-    assert len(agentset.select(max=0.549)) == 5  # Select 50% of agents
-    assert len(agentset.select(max=0.04)) == 0  # Select 0% of agents
-    assert len(agentset.select(max=1.0)) == 10  # Select 100% agents
-    assert len(agentset.select(max=1)) == 1  # Select 1 agent
+    assert len(agentset.select(at_most=0.2)) == 2  # Select 20% of agents
+    assert len(agentset.select(at_most=0.549)) == 5  # Select 50% of agents
+    assert len(agentset.select(at_most=0.09)) == 0  # Select 0% of agents
+    assert len(agentset.select(at_most=1.0)) == 10  # Select 100% agents
+    assert len(agentset.select(at_most=1)) == 1  # Select 1 agent
 
     assert len(agentset.select(test_function)) == 5
     assert len(agentset.select(test_function, n=2)) == 2

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -59,6 +59,11 @@ def test_agentset():
     def test_function(agent):
         return agent.unique_id > 5
 
+    assert len(agentset.select(fraction=0.2)) == 2  # Select 20% of agents
+    assert len(agentset.select(fraction=0.549)) == 5  # Select 50% of agents
+    assert len(agentset.select(fraction=0)) == 0  # Select 0% of agents
+    assert len(agentset.select(fraction=1)) == 10  # Select 100% of agents
+
     assert len(agentset.select(test_function)) == 5
     assert len(agentset.select(test_function, n=2)) == 2
     assert len(agentset.select(test_function, inplace=True)) == 5
@@ -67,11 +72,6 @@ def test_agentset():
     assert all(a1 == a2 for a1, a2 in zip(agentset.select(n=5), agentset[:5]))
 
     assert len(agentset.shuffle(inplace=False).select(n=5)) == 5
-
-    assert len(agentset.select(fraction=0.2)) == 2  # Select 20% of agents
-    assert len(agentset.select(fraction=0.549)) == 5  # Select 50% of agents
-    assert len(agentset.select(fraction=0)) == 0  # Select 0% of agents
-    assert len(agentset.select(fraction=1)) == 10  # Select 100% of agents
 
     def test_function(agent):
         return agent.unique_id

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -61,8 +61,8 @@ def test_agentset():
 
     assert len(agentset.select(fraction=0.2)) == 2  # Select 20% of agents
     assert len(agentset.select(fraction=0.549)) == 5  # Select 50% of agents
-    assert len(agentset.select(fraction=0)) == 0  # Select 0% of agents
-    assert len(agentset.select(fraction=1)) == 10  # Select 100% of agents
+    assert len(agentset.select(fraction=0.0)) == 0  # Select 0% of agents
+    assert len(agentset.select(fraction=1.0)) == 10  # Select 100% of agents
 
     assert len(agentset.select(test_function)) == 5
     assert len(agentset.select(test_function, n=2)) == 2

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -68,6 +68,11 @@ def test_agentset():
 
     assert len(agentset.shuffle(inplace=False).select(n=5)) == 5
 
+    assert len(agentset.select(fraction=0.2)) == 2  # Select 20% of agents
+    assert len(agentset.select(fraction=0.549)) == 5  # Select 50% of agents
+    assert len(agentset.select(fraction=0)) == 0     # Select 0% of agents
+    assert len(agentset.select(fraction=1)) == 10   # Select 100% of agents
+
     def test_function(agent):
         return agent.unique_id
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -70,8 +70,8 @@ def test_agentset():
 
     assert len(agentset.select(fraction=0.2)) == 2  # Select 20% of agents
     assert len(agentset.select(fraction=0.549)) == 5  # Select 50% of agents
-    assert len(agentset.select(fraction=0)) == 0     # Select 0% of agents
-    assert len(agentset.select(fraction=1)) == 10   # Select 100% of agents
+    assert len(agentset.select(fraction=0)) == 0  # Select 0% of agents
+    assert len(agentset.select(fraction=1)) == 10  # Select 100% of agents
 
     def test_function(agent):
         return agent.unique_id


### PR DESCRIPTION
This PR updates the `select` method in the `AgentSet` class by replacing the `n` parameter with a more versatile `at_most` parameter. The `at_most` parameter allows for selecting either a specific number of agents or a fraction of the total agents when provided as an integer or a float, respectively. Additionally, backward compatibility is maintained by supporting the deprecated `n` parameter, which will trigger a warning when used.

### Motive
Previously, the `select` method only allowed users to specify a fixed number of agents (`n`) to be selected. The new `at_most` parameter extends this functionality by enabling the selection of agents based on a proportion of the total set, which is particularly useful in scenarios where relative selection is desired over absolute selection.

### Implementation
- **`at_most` Parameter:** 
  - Accepts either an integer (to select a fixed number of agents) or a float between 0.0 and 1.0 (to select a fraction of the total agents).
  - `at_most=1` selects one agent, while `at_most=1.0` selects all agents.
  - If a float is provided, it determines the maximum fraction of agents to be selected from the total set. It rounds down to the nearest number of whole agents.
- **Backward Compatibility:**
  - The deprecated `n` parameter is still supported, but it now serves as a fallback for `at_most` and triggers a deprecation warning.
- **Behavior Notes:**
  - `at_most` serves as an upper limit on the number of selected agents. If additional filtering criteria are provided, the final selection may include fewer agents.
  - For random sampling, users should shuffle the `AgentSet` before applying `at_most`.

### Usage Examples
```python
# Select the first 5 agents from the AgentSet
selected_agents = agents.select(at_most=5)
selected_agents = agents.select(n=5)  # Still works but throws a deprecation warning
```
```python
# Select the first 20% of agents from the AgentSet (as currently sorted, rounded down)
selected_agents = agents.select(at_most=0.2)
```
To randomly select a fraction, add a `shuffle()`:
```python
# Select 20% of agents randomly from the AgentSet
random_agents = agents.shuffle().select(at_most=0.2)
```
Combining with sorting:
```python
# Select the 20% of agents with the lowest wealth
selected_agents = agents.sort("wealth", ascending=True).select(at_most=0.2)
```
The most powerful feature is that you can combine `at_most` with additional criteria:
```python
# Select agents with "wealth" less than 5, and at most 20% of the total
selected_agents = agents.select(lambda agent: agent.wealth < 5, at_most=0.2)

# First filter agents, then select 20% of those remaining
filtered_agents = agents.select(lambda agent: agent.wealth < 5).select(at_most=0.2)
```
You can also use it with chaining:
```Python
# Randomly select 40% of the agents from the AgentSet and set a value
model.agents.shuffle().select(at_most=0.4).set('has_license', True)
```