### PR TITLE
AgentSet: Add `set` method

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -323,7 +323,7 @@ class AgentSet(MutableSet, Sequence):
         Args:
             attr_name (str): The name of the attribute to set.
             value (Any): The value to set the attribute to.
-    
+
         Returns:
             AgentSet: The AgentSet instance itself, after setting the attribute.
         """

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -316,16 +316,20 @@ class AgentSet(MutableSet, Sequence):
                 for agent in self._agents
             ]
 
-    def set(self, attr_name: str, value: Any) -> None:
+    def set(self, attr_name: str, value: Any) -> AgentSet:
         """
         Set a specified attribute to a given value for all agents in the AgentSet.
 
         Args:
             attr_name (str): The name of the attribute to set.
             value (Any): The value to set the attribute to.
+    
+        Returns:
+            AgentSet: The AgentSet instance itself, after setting the attribute.
         """
         for agent in self:
             setattr(agent, attr_name, value)
+        return self
 
     def __getitem__(self, item: int | slice) -> Agent:
         """

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -316,6 +316,17 @@ class AgentSet(MutableSet, Sequence):
                 for agent in self._agents
             ]
 
+    def set(self, attr_name: str, value: Any) -> None:
+        """
+        Set a specified attribute to a given value for all agents in the AgentSet.
+
+        Args:
+            attr_name (str): The name of the attribute to set.
+            value (Any): The value to set the attribute to.
+        """
+        for agent in self:
+            setattr(agent, attr_name, value)
+
     def __getitem__(self, item: int | slice) -> Agent:
         """
         Retrieve an agent or a slice of agents from the AgentSet.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -270,6 +270,30 @@ def test_agentset_do_callable():
     assert len(agentset) == 0
 
 
+def test_agentset_set_method():
+    # Initialize the model and agents with and without existing attributes
+    class TestAgentWithAttribute(Agent):
+        def __init__(self, unique_id, model, age=None):
+            super().__init__(unique_id, model)
+            self.age = age
+
+    model = Model()
+    agents = [TestAgentWithAttribute(model.next_id(), model, age=i) for i in range(5)]
+    agentset = AgentSet(agents, model)
+
+    # Set a new attribute "health" and an existing attribute "age" for all agents
+    agentset.set("health", 100).set("age", 50).set("status", "active")
+
+    # Check if all agents have the "health", "age", and "status" attributes correctly set
+    for agent in agentset:
+        assert hasattr(agent, "health")
+        assert agent.health == 100
+        assert hasattr(agent, "age")
+        assert agent.age == 50
+        assert hasattr(agent, "status")
+        assert agent.status == "active"
+
+
 def test_agentset_map_str():
     model = Model()
     agents = [TestAgent(model.next_id(), model) for _ in range(10)]


### PR DESCRIPTION
This PR adds a `set` method to the `AgentSet` class that allows setting a specified attribute of all agents within the set to a given value. This method provides a streamlined way to update agent attributes in bulk, without having to resort to `lambda` or other callable functions.

### Motive
The motivation behind this feature is to simplify and expedite the process of modifying attributes across all agents in an `AgentSet`. Previously, this required iterating manually over the agents or using a `lambda` or other callable function. This new method makes the operation more elegant.

### Implementation
The `set` method was added to the `AgentSet` class. It iterates through all agents in the set and applies the `setattr` function to assign the specified value to the desired attribute. The method operates in place, modifying the existing agents directly.

The (now updated) AgentSet itself is returned, which allows for chaining.

You can both set existing Agent variables or set new ones.

### Usage Examples
```python
# Set the 'has_license' attribute to True for all agents in the AgentSet
agents.set('has_license', True)
```
Note that it doesn't matter if `has_license` already exists in the Agent, both work.

Together with #2253, you can now set a value for a fraction of your AgentSet:
```Python
# Select 40% of the agents from the AgentSet
model.agents.select(p=0.4).set('has_license', True)
```
It's also possible to set multiple things by chaining the `set()` commands:
```python
agents.set('has_license', True).set('age', 45).set('continent', 'Europe')
```
### Additional Notes
It feels logical that if you have a `get` method, you also should have a `set` method.

**Edit:**
- Modified to return an AgentSet, so you can keep the output or keep chaining.
- It modified the Agents itself, like with `do()`, so inplace isn't needed.
- We don't allow dicts, those can be added later if needed.
