### PR TITLE
CI: Add optional dependency for examples

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install uv
       run: pip install uv
     - name: Install Mesa
-      run: uv pip install --system .[dev]
+      run: uv pip install --system .[examples]
     - name: Checkout mesa-examples
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -86,4 +86,4 @@ jobs:
     - name: Test examples
       run: |
         cd mesa-examples
-        pytest -rA -Werror test_examples.py
+        pytest -rA -Werror -Wdefault::FutureWarning test_examples.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ dev = [
   "sphinx",
   "pytest-mock",
 ]
+examples = [
+  "pytest >= 4.6",
+  "scipy"
+]
 docs = [
   "sphinx",
   "ipython",


### PR DESCRIPTION
The Game of Life fast example (https://github.com/projectmesa/mesa-examples/pull/182) needs SciPy. Instead of adding it to our dev dependencies, I created a new, lighter examples optional dependency category (with SciPy).