### PR TITLE
AgentSet: Add `agg` method

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -313,14 +313,9 @@ class AgentSet(MutableSet, Sequence):
             func (Callable): The function to apply to the attribute values (e.g., min, max, sum, np.mean).
 
         Returns:
-            Any: The result of applying the function to the attribute values.
+            Any: The result of applying the function to the attribute values. Often a single value.
         """
-        # Retrieve the attribute values from all agents
-        values = [
-            getattr(agent, attribute) for agent in self if hasattr(agent, attribute)
-        ]
-
-        # Apply the function to the values and return the result
+        values = self.get(attribute)
         return func(values)
 
     def get(self, attr_names: str | list[str]) -> list[Any]:

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -304,6 +304,25 @@ class AgentSet(MutableSet, Sequence):
 
         return res
 
+    def agg(self, attribute: str, func: Callable) -> Any:
+        """
+        Aggregate an attribute of all agents in the AgentSet using a specified function.
+
+        Args:
+            attribute (str): The name of the attribute to aggregate.
+            func (Callable): The function to apply to the attribute values (e.g., min, max, sum, np.mean).
+
+        Returns:
+            Any: The result of applying the function to the attribute values.
+        """
+        # Retrieve the attribute values from all agents
+        values = [
+            getattr(agent, attribute) for agent in self if hasattr(agent, attribute)
+        ]
+
+        # Apply the function to the values and return the result
+        return func(values)
+
     def get(self, attr_names: str | list[str]) -> list[Any]:
         """
         Retrieve the specified attribute(s) from each agent in the AgentSet.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,6 @@
 import pickle
 
+import numpy as np
 import pytest
 
 from mesa.agent import Agent, AgentSet
@@ -274,6 +275,41 @@ def test_agentset_do_callable():
     # Actual function for removal
     agentset.do(remove_function)
     assert len(agentset) == 0
+
+
+def test_agentset_agg():
+    model = Model()
+    agents = [TestAgent(i, model) for i in range(10)]
+
+    # Assign some values to attributes
+    for i, agent in enumerate(agents):
+        agent.energy = i + 1
+        agent.wealth = 10 * (i + 1)
+
+    agentset = AgentSet(agents, model)
+
+    # Test min aggregation
+    min_energy = agentset.agg("energy", min)
+    assert min_energy == 1
+
+    # Test max aggregation
+    max_energy = agentset.agg("energy", max)
+    assert max_energy == 10
+
+    # Test sum aggregation
+    total_energy = agentset.agg("energy", sum)
+    assert total_energy == sum(range(1, 11))
+
+    # Test mean aggregation using numpy
+    avg_wealth = agentset.agg("wealth", np.mean)
+    assert avg_wealth == 55.0
+
+    # Test aggregation with a custom function
+    def custom_func(values):
+        return sum(values) / len(values)
+
+    custom_avg_energy = agentset.agg("energy", custom_func)
+    assert custom_avg_energy == 5.5
 
 
 def test_agentset_set_method():


### PR DESCRIPTION
This PR introduces the `agg` method to the `AgentSet` class, allowing users to apply aggregation functions (e.g., `min`, `max`, `sum`, `np.mean`) to attributes of agents within the `AgentSet`. This enhancement makes it easier to compute summary statistics across agent attributes directly within the `AgentSet` interface.

This will be useful in both the model operation itself as well as for future DataCollector use.

### New Method: `agg`

```python
def agg(self, attribute: str, func: Callable) -> Any:
```

**Parameters**:
- `attribute` (str): The name of the attribute to aggregate.
- `func` (Callable): The aggregation function to apply (e.g., `min`, `max`, `sum`, `np.mean`).

**Returns**:
- The result of applying the aggregation function to the attribute values of all agents in the `AgentSet`.

### Usage Examples

```python
# Get the minimum energy value
min_energy = agentset.agg("energy", min)

# Calculate the total energy of sheep in the model
total_energy = model.get_agents_of_type[Sheep].agg("energy", sum)

# Compute the average wealth of the poorest 10% using numpy
average_wealth = agentset.select(at_most=0.1).agg("wealth", np.mean)

# Custom aggregation function
def custom_func(values):
    return sum(values) / len(values)

custom_avg_energy = agentset.agg("energy", custom_func)
```
### Future work
This function could be expended by:
- Allowing multiple attribute as input for the functions
- Allowing multiple pairs of attribute-function to be inputted
- Allowing multiple pairs of multiple attributes / functions as input

However, this PRs limit the scope to a single attribute and single function, since that's the most common use case.