### PR TITLE
docs: Fix Visualization Tutorial (main branch)

### DIFF
--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -208,7 +208,7 @@
     "    # plt.figure(), for thread safety purpose\n",
     "    fig = Figure()\n",
     "    ax = fig.subplots()\n",
-    "    wealth_vals = [agent.wealth for agent in model.schedule.agents]\n",
+    "    wealth_vals = [agent.wealth for agent in model.agents]\n",
     "    # Note: you have to use Matplotlib's OOP API instead of plt.hist\n",
     "    # because plt.hist is not thread-safe.\n",
     "    ax.hist(wealth_vals, bins=10)\n",


### PR DESCRIPTION
The scheduler was removed (in projectmesa/mesa-examples#183) from the example model used by the [Visualization Tutorial](https://mesa.readthedocs.io/en/latest/tutorials/visualization_tutorial.html#), so the docs started failing.

This PR fixes it in the `main` branch by replacing `model.schedule.agents` with `model.agents`.

![image](https://github.com/user-attachments/assets/550a7a10-6a6a-4792-9752-1dd120f9acde)