### PR TITLE
docs: Fix Visualization Tutorial (2.x branch)

### DIFF
--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -43,7 +43,7 @@
     "import mesa\n",
     "\n",
     "# You can either define the BoltzmannWealthModel (aka MoneyModel) or install mesa-models:\n",
-    "%pip install --quiet -U git+https://github.com/projectmesa/mesa-examples#egg=mesa-models\n",
+    "%pip install --quiet -U git+https://github.com/projectmesa/mesa-examples@mesa-2.x#egg=mesa-models\n",
     "\n",
     "from mesa_models.boltzmann_wealth_model.model import BoltzmannWealthModel"
    ]


### PR DESCRIPTION
The scheduler was removed (in projectmesa/mesa-examples#183) from the example model used by the [Visualization Tutorial](https://mesa.readthedocs.io/en/latest/tutorials/visualization_tutorial.html#), so the docs started failing.

This PR fixes it in the `2.3.x-maintenance` branch by checking out the mesa-examples [`mesa-2.x`](https://github.com/projectmesa/mesa-examples/tree/mesa-2.x) branch instead of the main branch.
```diff
- https://github.com/projectmesa/mesa-examples#egg=mesa-models
+ https://github.com/projectmesa/mesa-examples@mesa-2.x#egg=mesa-models
```

![image](https://github.com/user-attachments/assets/550a7a10-6a6a-4792-9752-1dd120f9acde)