### PR TITLE
Docs: Fix broken relative links by removing `.html` suffix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ Mesa Packages <packages>
 [github issue tracker]: https://github.com/projectmesa/mesa/issues
 [matrix chat room]: https://matrix.to/#/#project-mesa:matrix.org
 [mesa]: https://github.com/projectmesa/mesa/
-[mesa introductory tutorial]: tutorials/intro_tutorial.html
-[mesa visualization tutorial]: tutorials/visualization_tutorial.html
+[mesa introductory tutorial]: tutorials/intro_tutorial
+[mesa visualization tutorial]: tutorials/visualization_tutorial
 [pypi]: https://pypi.python.org/pypi/Mesa/
 [ticket]: https://github.com/projectmesa/mesa/issues

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -56,7 +56,7 @@ model = MyModel(5)
 model.step()
 ```
 
-You should see agents 0-4, activated in random order. See the [tutorial](tutorials/intro_tutorial.html) or API documentation for more detail on how to add model functionality.
+You should see agents 0-4, activated in random order. See the [tutorial](tutorials/intro_tutorial) or API documentation for more detail on how to add model functionality.
 
 To bootstrap a new model install mesa and run `mesa startproject`
 
@@ -64,8 +64,8 @@ To bootstrap a new model install mesa and run `mesa startproject`
 
 If you're using modeling for research, you'll want a way to collect the data each model run generates. You'll probably also want to run the model multiple times, to see how some output changes with different parameters. Data collection and batch running are implemented in the appropriately-named analysis modules:
 
-- [mesa.datacollection](apis/datacollection.html)
-- [mesa.batchrunner](apis/batchrunner.html)
+- [mesa.datacollection](apis/datacollection)
+- [mesa.batchrunner](apis/batchrunner)
 
 You'd add a data collector to the model like this:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,8 +17,8 @@ Mesa is modular, meaning that its modeling, analysis and visualization component
 Most models consist of one class to represent the model itself; one class (or more) for agents; a scheduler to handle time (what order the agents act in), and possibly a space for the agents to inhabit and move through. These are implemented in Mesa's modeling modules:
 
 - `mesa.Model`, `mesa.Agent`
-- [mesa.time](apis/time.html)
-- [mesa.space](apis/space.html)
+- [mesa.time](apis/time)
+- [mesa.space](apis/space)
 
 The skeleton of a model might look like this:
 


### PR DESCRIPTION
A few links in the documentation of Mesa are broken, they redirect to incorrect links.
Particularily, on the website of Introduction to Mesa Documentation, the links appear to redirect at the wrong web-page.

This PR fixes that by removing the `.html` suffixes from the relative links. This should fix the 6 relative links below:

index: [current](https://mesa.readthedocs.io/en/latest/index.html) | [This PR](https://mesa--2274.org.readthedocs.build/en/2274/index.html)
- Mesa Introductory Tutorial
- Mesa Visualization Tutorial

overview: [current](https://mesa.readthedocs.io/en/latest/overview.html) | [This PR](https://mesa--2274.org.readthedocs.build/en/2274/overview.html)
- mesa.time
- mesa.space
- mesa.datacollection
- mesa.batchrunner

Resolves https://github.com/projectmesa/mesa/issues/2098 and resolves https://github.com/projectmesa/mesa/issues/2244.