### PR TITLE
Readthedocs: Don't let notebook failures pass silently

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,8 @@ pygments_style = "gruvbox-dark"
 
 nb_execution_timeout = 60
 nb_execution_mode = "cache"
+nb_execution_allow_errors = False
+nb_execution_raise_on_error = True
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
Adds both to `docs/conf.py`:

```Python
nb_execution_allow_errors = False
nb_execution_raise_on_error = True
```

To make sure that when one of the (tutorial) notebooks fails, the Readthedocs also fails and doesn't continue silently.

See the [myst-nb](https://myst-nb.readthedocs.io/en/latest/computation/execute.html#error-reporting-warning-vs-failure) docs.

Closes #2270.