### PR TITLE
Update issue template to point directly at discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/asking-help.md
+++ b/.github/ISSUE_TEMPLATE/asking-help.md
@@ -1,9 +1,0 @@
----
-name: Asking for help
-about: If you need help using Mesa, you should post in https://github.com/projectmesa/mesa/discussions
----
-
-<!--
-    ATTENTION: Don't raise an issue here!
-    If you need help, ask in https://github.com/projectmesa/mesa/discussions
--->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,8 @@ about: Let us know if something is broken on Mesa
 <!-- A clear and concise description of what you expected to happen -->
 
 **To Reproduce**
-<!-- Steps to reproduce the bug, or a link to a project where the bug is visible -->
+<!-- Steps to reproduce the bug, or a link to a project where the bug is visible
+Include a Minimal reproducible example: https://stackoverflow.com/help/minimal-reproducible-example -->
 
 **Additional context**
 <!--

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions, ideas, showcases and more
+    url: https://github.com/projectmesa/mesa/discussions
+    about: Discuss Mesa, ask questions, share ideas, and showcase your projects


### PR DESCRIPTION
Update issue template to point directly at discussions, instead of doing that in the "ask-help" template.

- Add a `config.yml` file with `contact_links` section that points directly to our discussion forum
- Remove the `ask-help.md` template
- Update the Bug report template to ask for a Include a minimal reproducible example.

Based on the GitHub [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).