### PR TITLE
AgentSet: Refactor shuffle (overhaul)

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -128,7 +128,7 @@ class AgentSet(MutableSet, Sequence):
 
         self.model = model
         self._agents_list: list[weakref.ref] = [weakref.ref(agent) for agent in agents]
-        self._agents_set: set[int] = set(id(agent) for agent in agents)
+        self._agents_set: set[int] = {id(agent) for agent in agents}
 
     def __len__(self) -> int:
         """Return the number of agents in the AgentSet."""
@@ -219,7 +219,9 @@ class AgentSet(MutableSet, Sequence):
             return self
         else:
             new_agentset = AgentSet([], self.model)
-            new_agentset._agents_list = self.random.sample(self._agents_list, len(self._agents_list))
+            new_agentset._agents_list = self.random.sample(
+                self._agents_list, len(self._agents_list)
+            )
             new_agentset._agents_set = self._agents_set.copy()
             return new_agentset
 


### PR DESCRIPTION
More radical approach then #2283 to approaching shuffle performance.

<details>
<summary>Small benchmark:</summary>

```Python
from mesa import Agent, Model

class MyAgent(Agent):
    def __init__(self, model):
        super().__init__(model)

    def step(self):
        pass

class MyModel1(Model):
    def __init__(self):
        super().__init__()
        # Create 10000
        for _ in range(1000000):
            MyAgent(self)

    def step(self):
        self.agents.shuffle().do("step")


class MyModel2(Model):
    def __init__(self):
        super().__init__()
        # Create 10000
        for _ in range(1000000):
            MyAgent(self)

    def step(self):
        self.agents.shuffle(inplace=True).do("step")

# Benchmark the two models
from time import time

models = [MyModel1(), MyModel2()]
times = []
print("Running models...")
for model in models:
    print(f"Running {model}")
    start = time()
    for _ in range(100):
        model.step()
    times.append(time() - start)

print(f"Results: {times}")
```
</details>

| Configuration                  | shuffle().do() | shuffle(inplace=True).do() | shuffle_do() | new shuffle().do() | new shuffle(inplace=True).do() |
|--------------------------------|----------------|----------------------------|--------------|--------------------|--------------------------------|
| **10,000 agents, 1,000 steps** | 8.27 s         | 3.65 s                     | 3.06 s       | 3.26 s             | 2.90 s                         |
| **100,000 agents, 100 steps**  | 13.71 s        | 6.31 s                     | 3.71 s       | 4.89 s             | 3.94 s                         |
| **1,000,000 agents, 10 steps** | 18.36 s        | 9.44 s                     | 5.75 s       | 4.93 s             | 3.92 s                         |

This does include overhauling the AgentSet internal structure, but it's a lot faster, and now works with all functions chained behind `shuffle()`(so not `do()`.

Adding agents should be quite fast, but removing might be slower.