### PR TITLE
GroupBy: Add `count` and `agg` methods

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -15,7 +15,7 @@ import operator
 import warnings
 import weakref
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator, MutableSet, Sequence
+from collections.abc import Callable, Hashable, Iterable, Iterator, MutableSet, Sequence
 from random import Random
 
 # mypy
@@ -620,7 +620,7 @@ class GroupBy:
         """
         return {k: len(v) for k, v in self.groups.items()}
 
-    def agg(self, attr_name: str, func: Callable) -> dict[Any, Any]:
+    def agg(self, attr_name: str, func: Callable) -> dict[Hashable, Any]:
         """
         Aggregate the values of a specific attribute across each group using the provided function.
 
@@ -629,7 +629,7 @@ class GroupBy:
             func (Callable): The function to apply (e.g., sum, min, max, mean).
 
         Returns:
-            dict: A dictionary mapping group names to the result of applying the aggregation function.
+            dict[Hashable, Any]: A dictionary mapping group names to the result of applying the aggregation function.
         """
         return {
             group_name: func([getattr(agent, attr_name) for agent in group])

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -612,8 +612,7 @@ class GroupBy:
         return self
 
     def count(self) -> dict[Any, int]:
-        """
-        Return the count of agents in each group.
+        """Return the count of agents in each group.
 
         Returns:
             dict: A dictionary mapping group names to the number of agents in each group.
@@ -621,8 +620,7 @@ class GroupBy:
         return {k: len(v) for k, v in self.groups.items()}
 
     def agg(self, attr_name: str, func: Callable) -> dict[Hashable, Any]:
-        """
-        Aggregate the values of a specific attribute across each group using the provided function.
+        """Aggregate the values of a specific attribute across each group using the provided function.
 
         Args:
             attr_name (str): The name of the attribute to aggregate.

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -611,6 +611,31 @@ class GroupBy:
 
         return self
 
+    def count(self) -> dict[Any, int]:
+        """
+        Return the count of agents in each group.
+
+        Returns:
+            dict: A dictionary mapping group names to the number of agents in each group.
+        """
+        return {k: len(v) for k, v in self.groups.items()}
+
+    def agg(self, attr_name: str, func: Callable) -> dict[Any, Any]:
+        """
+        Aggregate the values of a specific attribute across each group using the provided function.
+
+        Args:
+            attr_name (str): The name of the attribute to aggregate.
+            func (Callable): The function to apply (e.g., sum, min, max, mean).
+
+        Returns:
+            dict: A dictionary mapping group names to the result of applying the aggregation function.
+        """
+        return {
+            group_name: func([getattr(agent, attr_name) for agent in group])
+            for group_name, group in self.groups.items()
+        }
+
     def __iter__(self):  # noqa: D105
         return iter(self.groups.items())
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -524,6 +524,7 @@ def test_agentset_groupby():
         def __init__(self, model):
             super().__init__(model)
             self.even = self.unique_id % 2 == 0
+            self.value = self.unique_id * 10
 
         def get_unique_identifier(self):
             return self.unique_id
@@ -559,6 +560,37 @@ def test_agentset_groupby():
     groups = agentset.groupby("even", result_type="agentset")
     another_ref_to_groups = groups.do(lambda x: x.do("step"))
     assert groups == another_ref_to_groups
+
+    # New tests for count() method
+    groups = agentset.groupby("even")
+    count_result = groups.count()
+    assert count_result == {True: 5, False: 5}
+
+    # New tests for agg() method
+    groups = agentset.groupby("even")
+    sum_result = groups.agg("value", sum)
+    assert sum_result[True] == sum(agent.value for agent in agents if agent.even)
+    assert sum_result[False] == sum(agent.value for agent in agents if not agent.even)
+
+    max_result = groups.agg("value", max)
+    assert max_result[True] == max(agent.value for agent in agents if agent.even)
+    assert max_result[False] == max(agent.value for agent in agents if not agent.even)
+
+    min_result = groups.agg("value", min)
+    assert min_result[True] == min(agent.value for agent in agents if agent.even)
+    assert min_result[False] == min(agent.value for agent in agents if not agent.even)
+
+    # Test with a custom aggregation function
+    def custom_agg(values):
+        return sum(values) / len(values) if values else 0
+
+    custom_result = groups.agg("value", custom_agg)
+    assert custom_result[True] == custom_agg(
+        [agent.value for agent in agents if agent.even]
+    )
+    assert custom_result[False] == custom_agg(
+        [agent.value for agent in agents if not agent.even]
+    )
 
 
 def test_oldstyle_agent_instantiation():


### PR DESCRIPTION
Added two new methods to the `GroupBy` class:

- `count`: Returns the count of agents in each group.
- `agg`: Performs aggregation on a specific attribute across groups, applying a function like `sum`, `min`, `max`, or `mean`.

### Usage examples
1. **`count()`**: 
   - Returns the count of agents in each group.
   - **Usage Example:**
     ```python
     grouped_agents.count()
     ```
     **Output:**
     ```python
     {
         "group_1": 10,  # 10 agents in group_1
         "group_2": 8,   # 8 agents in group_2
     }
     ```

2. **`agg(attr_name, func)`**:
   - Aggregates the values of a specific attribute across each group using a provided function (e.g., `sum`, `min`, `max`, `mean`).
   - **Usage Example:**
     ```python
     # Sum the wealth of all agents in each group
     grouped_agents.agg("wealth", sum)
     ```
     **Output:**
     ```python
     {
         "group_1": 15000,  # Total wealth of agents in group_1
         "group_2": 12000,  # Total wealth of agents in group_2
     }
     ```

<hr>

I'm a bit worried about our AgentSet and now GroupBy exploding our code base.
1. Is there any built-in functionality or libraries for this? It seems we're implementing very obvious behavior ourselves here.
2. Do we need to split into multiple files?
3. How do we keep this properly documented? Do we need guides for this?

(obviously tests are still needed)