### PR TITLE
Make cell connections public and named

### DIFF
--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -69,16 +69,17 @@ class Cell:
         self.properties: dict[Coordinate, object] = {}
         self.random = random
 
-    def connect(self, other: Cell, name: Coordinate | None = None) -> None:
+    def connect(self, other: Cell, key: Coordinate | None = None) -> None:
         """Connects this cell to another cell.
 
         Args:
             other (Cell): other cell to connect to
+            key (Tuple[int, ...]): key for the connection. Should resemble a relative coordinate
 
         """
-        if name is None:
-            name = other.coordinate
-        self.connections[name] = other
+        if key is None:
+            key = other.coordinate
+        self.connections[key] = other
 
     def disconnect(self, other: Cell) -> None:
         """Disconnects this cell from another cell.

--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -76,7 +76,7 @@ class Cell:
         """
         if name is None:
             name = str(other.coordinate)
-        self.connections.update({name: other})
+        self.connections[name] = other
 
     def disconnect(self, other: Cell) -> None:
         """Disconnects this cell from another cell.
@@ -85,7 +85,9 @@ class Cell:
             other (Cell): other cell to remove from connections
 
         """
-        self.connections = {k: v for k, v in self.connections.items() if v != other}
+        keys_to_remove = [k for k, v in self.connections.items() if v == other]
+        for key in keys_to_remove:
+            del self.connections[key]
 
     def add_agent(self, agent: CellAgent) -> None:
         """Adds an agent to the cell.

--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from mesa.agent import Agent
     from mesa.experimental.cell_space.cell_agent import CellAgent
 
+Coordinate = tuple[int, ...]
+
 
 class Cell:
     """The cell represents a position in a discrete space.
@@ -45,7 +47,7 @@ class Cell:
 
     def __init__(
         self,
-        coordinate: tuple[int, ...],
+        coordinate: Coordinate,
         capacity: float | None = None,
         random: Random | None = None,
     ) -> None:
@@ -59,15 +61,15 @@ class Cell:
         """
         super().__init__()
         self.coordinate = coordinate
-        self.connections: dict[str, Cell] = {}
+        self.connections: dict[Coordinate, Cell] = {}
         self.agents: list[
             Agent
         ] = []  # TODO:: change to AgentSet or weakrefs? (neither is very performant, )
         self.capacity = capacity
-        self.properties: dict[str, object] = {}
+        self.properties: dict[Coordinate, object] = {}
         self.random = random
 
-    def connect(self, other: Cell, name: str | None = None) -> None:
+    def connect(self, other: Cell, name: Coordinate | None = None) -> None:
         """Connects this cell to another cell.
 
         Args:
@@ -75,7 +77,7 @@ class Cell:
 
         """
         if name is None:
-            name = str(other.coordinate)
+            name = other.coordinate
         self.connections[name] = other
 
     def disconnect(self, other: Cell) -> None:

--- a/mesa/experimental/cell_space/discrete_space.py
+++ b/mesa/experimental/cell_space/discrete_space.py
@@ -52,7 +52,8 @@ class DiscreteSpace(Generic[T]):
     def cutoff_empties(self):  # noqa
         return 7.953 * len(self._cells) ** 0.384
 
-    def _connect_single_cell(self, cell: T): ...
+    def _connect_single_cell(self, cell: T):
+        ...
 
     @cached_property
     def all_cells(self):
@@ -62,11 +63,11 @@ class DiscreteSpace(Generic[T]):
     def __iter__(self):  # noqa
         return iter(self._cells.values())
 
-    def __getitem__(self, key):  # noqa
+    def __getitem__(self, key: tuple[int, ...]) -> T:  # noqa: D105
         return self._cells[key]
 
     @property
-    def empties(self) -> CellCollection:
+    def empties(self) -> CellCollection[T]:
         """Return all empty in spaces."""
         return self.all_cells.select(lambda cell: cell.is_empty)
 

--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -102,7 +102,7 @@ class Grid(DiscreteSpace[T], Generic[T]):
             if self.torus:
                 n_coord = tuple(nc % d for nc, d in zip(n_coord, self.dimensions))
             if all(0 <= nc < d for nc, d in zip(n_coord, self.dimensions)):
-                cell.connect(self._cells[n_coord], f"{d_coord}")
+                cell.connect(self._cells[n_coord], d_coord)
 
     def _connect_single_cell_2d(self, cell: T, offsets: list[tuple[int, int]]) -> None:
         i, j = cell.coordinate
@@ -113,7 +113,7 @@ class Grid(DiscreteSpace[T], Generic[T]):
             if self.torus:
                 ni, nj = ni % height, nj % width
             if 0 <= ni < height and 0 <= nj < width:
-                cell.connect(self._cells[ni, nj], f"{(di, dj)}")
+                cell.connect(self._cells[ni, nj], (di, dj))
 
 
 class OrthogonalMooreGrid(Grid[T]):

--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -12,7 +12,7 @@ from mesa.experimental.cell_space import Cell, DiscreteSpace
 T = TypeVar("T", bound=Cell)
 
 
-class Grid(DiscreteSpace, Generic[T]):
+class Grid(DiscreteSpace[T], Generic[T]):
     """Base class for all grid classes.
 
     Attributes:
@@ -62,9 +62,11 @@ class Grid(DiscreteSpace, Generic[T]):
         else:
             self._connect_cells_nd()
 
-    def _connect_cells_2d(self) -> None: ...
+    def _connect_cells_2d(self) -> None:
+        ...
 
-    def _connect_cells_nd(self) -> None: ...
+    def _connect_cells_nd(self) -> None:
+        ...
 
     def _validate_parameters(self):
         if not all(isinstance(dim, int) and dim > 0 for dim in self.dimensions):
@@ -100,7 +102,7 @@ class Grid(DiscreteSpace, Generic[T]):
             if self.torus:
                 n_coord = tuple(nc % d for nc, d in zip(n_coord, self.dimensions))
             if all(0 <= nc < d for nc, d in zip(n_coord, self.dimensions)):
-                cell.connect(self._cells[n_coord])
+                cell.connect(self._cells[n_coord], f"{d_coord}")
 
     def _connect_single_cell_2d(self, cell: T, offsets: list[tuple[int, int]]) -> None:
         i, j = cell.coordinate
@@ -111,7 +113,7 @@ class Grid(DiscreteSpace, Generic[T]):
             if self.torus:
                 ni, nj = ni % height, nj % width
             if 0 <= ni < height and 0 <= nj < width:
-                cell.connect(self._cells[ni, nj])
+                cell.connect(self._cells[ni, nj], f"{(di, dj)}")
 
 
 class OrthogonalMooreGrid(Grid[T]):
@@ -133,7 +135,6 @@ class OrthogonalMooreGrid(Grid[T]):
             ( 1, -1), ( 1, 0), ( 1, 1),
         ]
         # fmt: on
-        height, width = self.dimensions
 
         for cell in self.all_cells:
             self._connect_single_cell_2d(cell, offsets)
@@ -165,13 +166,12 @@ class OrthogonalVonNeumannGrid(Grid[T]):
                     ( 1, 0),
         ]
         # fmt: on
-        height, width = self.dimensions
 
         for cell in self.all_cells:
             self._connect_single_cell_2d(cell, offsets)
 
     def _connect_cells_nd(self) -> None:
-        offsets = []
+        offsets: list[tuple[int, ...]] = []
         dimensions = len(self.dimensions)
         for dim in range(dimensions):
             for delta in [

--- a/mesa/experimental/cell_space/network.py
+++ b/mesa/experimental/cell_space/network.py
@@ -7,7 +7,7 @@ from mesa.experimental.cell_space.cell import Cell
 from mesa.experimental.cell_space.discrete_space import DiscreteSpace
 
 
-class Network(DiscreteSpace):
+class Network(DiscreteSpace[Cell]):
     """A networked discrete space."""
 
     def __init__(
@@ -37,6 +37,6 @@ class Network(DiscreteSpace):
         for cell in self.all_cells:
             self._connect_single_cell(cell)
 
-    def _connect_single_cell(self, cell):
+    def _connect_single_cell(self, cell: Cell):
         for node_id in self.G.neighbors(cell.coordinate):
-            cell.connect(self._cells[node_id])
+            cell.connect(self._cells[node_id], node_id)

--- a/mesa/experimental/cell_space/voronoi.py
+++ b/mesa/experimental/cell_space/voronoi.py
@@ -216,8 +216,8 @@ class VoronoiGrid(DiscreteSpace):
 
         for point in self.triangulation.export_triangles():
             for i, j in combinations(point, 2):
-                self._cells[i].connect(self._cells[j])
-                self._cells[j].connect(self._cells[i])
+                self._cells[i].connect(self._cells[j], (i, j))
+                self._cells[j].connect(self._cells[i], (j, i))
 
     def _validate_parameters(self) -> None:
         if self.capacity is not None and not isinstance(self.capacity, float | int):
@@ -233,9 +233,10 @@ class VoronoiGrid(DiscreteSpace):
 
     def _get_voronoi_regions(self) -> tuple:
         if self.voronoi_coordinates is None or self.regions is None:
-            self.voronoi_coordinates, self.regions = (
-                self.triangulation.export_voronoi_regions()
-            )
+            (
+                self.voronoi_coordinates,
+                self.regions,
+            ) = self.triangulation.export_voronoi_regions()
         return self.voronoi_coordinates, self.regions
 
     @staticmethod

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -26,46 +26,46 @@ def test_orthogonal_grid_neumann():
     assert len(grid._cells) == width * height
 
     # von neumann neighborhood, torus false, top left corner
-    assert len(grid._cells[(0, 0)]._connections) == 2
-    for connection in grid._cells[(0, 0)]._connections:
+    assert len(grid._cells[(0, 0)].connections.values()) == 2
+    for connection in grid._cells[(0, 0)].connections.values():
         assert connection.coordinate in {(0, 1), (1, 0)}
 
     # von neumann neighborhood, torus false, top right corner
-    for connection in grid._cells[(0, width - 1)]._connections:
+    for connection in grid._cells[(0, width - 1)].connections.values():
         assert connection.coordinate in {(0, width - 2), (1, width - 1)}
 
     # von neumann neighborhood, torus false, bottom left corner
-    for connection in grid._cells[(height - 1, 0)]._connections:
+    for connection in grid._cells[(height - 1, 0)].connections.values():
         assert connection.coordinate in {(height - 1, 1), (height - 2, 0)}
 
     # von neumann neighborhood, torus false, bottom right corner
-    for connection in grid._cells[(height - 1, width - 1)]._connections:
+    for connection in grid._cells[(height - 1, width - 1)].connections.values():
         assert connection.coordinate in {
             (height - 1, width - 2),
             (height - 2, width - 1),
         }
 
     # von neumann neighborhood middle of grid
-    assert len(grid._cells[(5, 5)]._connections) == 4
-    for connection in grid._cells[(5, 5)]._connections:
+    assert len(grid._cells[(5, 5)].connections.values()) == 4
+    for connection in grid._cells[(5, 5)].connections.values():
         assert connection.coordinate in {(4, 5), (5, 4), (5, 6), (6, 5)}
 
     # von neumann neighborhood, torus True, top corner
     grid = OrthogonalVonNeumannGrid((width, height), torus=True, capacity=None)
-    assert len(grid._cells[(0, 0)]._connections) == 4
-    for connection in grid._cells[(0, 0)]._connections:
+    assert len(grid._cells[(0, 0)].connections.values()) == 4
+    for connection in grid._cells[(0, 0)].connections.values():
         assert connection.coordinate in {(0, 1), (1, 0), (0, 9), (9, 0)}
 
     # von neumann neighborhood, torus True, top right corner
-    for connection in grid._cells[(0, width - 1)]._connections:
+    for connection in grid._cells[(0, width - 1)].connections.values():
         assert connection.coordinate in {(0, 8), (0, 0), (1, 9), (9, 9)}
 
     # von neumann neighborhood, torus True, bottom left corner
-    for connection in grid._cells[(9, 0)]._connections:
+    for connection in grid._cells[(9, 0)].connections.values():
         assert connection.coordinate in {(9, 1), (9, 9), (0, 0), (8, 0)}
 
     # von neumann neighborhood, torus True, bottom right corner
-    for connection in grid._cells[(9, 9)]._connections:
+    for connection in grid._cells[(9, 9)].connections.values():
         assert connection.coordinate in {(9, 0), (9, 8), (8, 9), (0, 9)}
 
 
@@ -79,12 +79,12 @@ def test_orthogonal_grid_neumann_3d():
     assert len(grid._cells) == width * height * depth
 
     # von neumann neighborhood, torus false, top left corner
-    assert len(grid._cells[(0, 0, 0)]._connections) == 3
-    for connection in grid._cells[(0, 0, 0)]._connections:
+    assert len(grid._cells[(0, 0, 0)].connections.values()) == 3
+    for connection in grid._cells[(0, 0, 0)].connections.values():
         assert connection.coordinate in {(0, 0, 1), (0, 1, 0), (1, 0, 0)}
 
     # von neumann neighborhood, torus false, top right corner
-    for connection in grid._cells[(0, width - 1, 0)]._connections:
+    for connection in grid._cells[(0, width - 1, 0)].connections.values():
         assert connection.coordinate in {
             (0, width - 1, 1),
             (0, width - 2, 0),
@@ -92,7 +92,7 @@ def test_orthogonal_grid_neumann_3d():
         }
 
     # von neumann neighborhood, torus false, bottom left corner
-    for connection in grid._cells[(height - 1, 0, 0)]._connections:
+    for connection in grid._cells[(height - 1, 0, 0)].connections.values():
         assert connection.coordinate in {
             (height - 1, 0, 1),
             (height - 1, 1, 0),
@@ -100,7 +100,7 @@ def test_orthogonal_grid_neumann_3d():
         }
 
     # von neumann neighborhood, torus false, bottom right corner
-    for connection in grid._cells[(height - 1, width - 1, 0)]._connections:
+    for connection in grid._cells[(height - 1, width - 1, 0)].connections.values():
         assert connection.coordinate in {
             (height - 1, width - 1, 1),
             (height - 1, width - 2, 0),
@@ -108,8 +108,8 @@ def test_orthogonal_grid_neumann_3d():
         }
 
     # von neumann neighborhood middle of grid
-    assert len(grid._cells[(5, 5, 5)]._connections) == 6
-    for connection in grid._cells[(5, 5, 5)]._connections:
+    assert len(grid._cells[(5, 5, 5)].connections.values()) == 6
+    for connection in grid._cells[(5, 5, 5)].connections.values():
         assert connection.coordinate in {
             (4, 5, 5),
             (5, 4, 5),
@@ -121,8 +121,8 @@ def test_orthogonal_grid_neumann_3d():
 
     # von neumann neighborhood, torus True, top corner
     grid = OrthogonalVonNeumannGrid((width, height, depth), torus=True, capacity=None)
-    assert len(grid._cells[(0, 0, 0)]._connections) == 6
-    for connection in grid._cells[(0, 0, 0)]._connections:
+    assert len(grid._cells[(0, 0, 0)].connections.values()) == 6
+    for connection in grid._cells[(0, 0, 0)].connections.values():
         assert connection.coordinate in {
             (0, 0, 1),
             (0, 1, 0),
@@ -140,13 +140,13 @@ def test_orthogonal_grid_moore():
 
     # Moore neighborhood, torus false, top corner
     grid = OrthogonalMooreGrid((width, height), torus=False, capacity=None)
-    assert len(grid._cells[(0, 0)]._connections) == 3
-    for connection in grid._cells[(0, 0)]._connections:
+    assert len(grid._cells[(0, 0)].connections.values()) == 3
+    for connection in grid._cells[(0, 0)].connections.values():
         assert connection.coordinate in {(0, 1), (1, 0), (1, 1)}
 
     # Moore neighborhood middle of grid
-    assert len(grid._cells[(5, 5)]._connections) == 8
-    for connection in grid._cells[(5, 5)]._connections:
+    assert len(grid._cells[(5, 5)].connections.values()) == 8
+    for connection in grid._cells[(5, 5)].connections.values():
         # fmt: off
         assert connection.coordinate in {(4, 4), (4, 5), (4, 6),
                                          (5, 4),         (5, 6),
@@ -155,8 +155,8 @@ def test_orthogonal_grid_moore():
 
     # Moore neighborhood, torus True, top corner
     grid = OrthogonalMooreGrid([10, 10], torus=True, capacity=None)
-    assert len(grid._cells[(0, 0)]._connections) == 8
-    for connection in grid._cells[(0, 0)]._connections:
+    assert len(grid._cells[(0, 0)].connections.values()) == 8
+    for connection in grid._cells[(0, 0)].connections.values():
         # fmt: off
         assert connection.coordinate in {(9, 9), (9, 0), (9, 1),
                                          (0, 9),         (0, 1),
@@ -172,8 +172,8 @@ def test_orthogonal_grid_moore_3d():
 
     # Moore neighborhood, torus false, top corner
     grid = OrthogonalMooreGrid((width, height, depth), torus=False, capacity=None)
-    assert len(grid._cells[(0, 0, 0)]._connections) == 7
-    for connection in grid._cells[(0, 0, 0)]._connections:
+    assert len(grid._cells[(0, 0, 0)].connections.values()) == 7
+    for connection in grid._cells[(0, 0, 0)].connections.values():
         assert connection.coordinate in {
             (0, 0, 1),
             (0, 1, 0),
@@ -185,8 +185,8 @@ def test_orthogonal_grid_moore_3d():
         }
 
     # Moore neighborhood middle of grid
-    assert len(grid._cells[(5, 5, 5)]._connections) == 26
-    for connection in grid._cells[(5, 5, 5)]._connections:
+    assert len(grid._cells[(5, 5, 5)].connections.values()) == 26
+    for connection in grid._cells[(5, 5, 5)].connections.values():
         # fmt: off
         assert connection.coordinate in {(4, 4, 4), (4, 4, 5), (4, 4, 6), (4, 5, 4), (4, 5, 5), (4, 5, 6), (4, 6, 4), (4, 6, 5), (4, 6, 6),
                                          (5, 4, 4), (5, 4, 5), (5, 4, 6), (5, 5, 4),             (5, 5, 6), (5, 6, 4), (5, 6, 5), (5, 6, 6),
@@ -195,8 +195,8 @@ def test_orthogonal_grid_moore_3d():
 
     # Moore neighborhood, torus True, top corner
     grid = OrthogonalMooreGrid((width, height, depth), torus=True, capacity=None)
-    assert len(grid._cells[(0, 0, 0)]._connections) == 26
-    for connection in grid._cells[(0, 0, 0)]._connections:
+    assert len(grid._cells[(0, 0, 0)].connections.values()) == 26
+    for connection in grid._cells[(0, 0, 0)].connections.values():
         # fmt: off
         assert connection.coordinate in {(9, 9, 9), (9, 9, 0), (9, 9, 1), (9, 0, 9), (9, 0, 0), (9, 0, 1), (9, 1, 9), (9, 1, 0), (9, 1, 1),
                                          (0, 9, 9), (0, 9, 0), (0, 9, 1), (0, 0, 9),             (0, 0, 1), (0, 1, 9), (0, 1, 0), (0, 1, 1),
@@ -213,8 +213,8 @@ def test_orthogonal_grid_moore_4d():
 
     # Moore neighborhood, torus false, top corner
     grid = OrthogonalMooreGrid((width, height, depth, time), torus=False, capacity=None)
-    assert len(grid._cells[(0, 0, 0, 0)]._connections) == 15
-    for connection in grid._cells[(0, 0, 0, 0)]._connections:
+    assert len(grid._cells[(0, 0, 0, 0)].connections.values()) == 15
+    for connection in grid._cells[(0, 0, 0, 0)].connections.values():
         assert connection.coordinate in {
             (0, 0, 0, 1),
             (0, 0, 1, 0),
@@ -234,8 +234,8 @@ def test_orthogonal_grid_moore_4d():
         }
 
     # Moore neighborhood middle of grid
-    assert len(grid._cells[(5, 5, 5, 5)]._connections) == 80
-    for connection in grid._cells[(5, 5, 5, 5)]._connections:
+    assert len(grid._cells[(5, 5, 5, 5)].connections.values()) == 80
+    for connection in grid._cells[(5, 5, 5, 5)].connections.values():
         # fmt: off
         assert connection.coordinate in {(4, 4, 4, 4), (4, 4, 4, 5), (4, 4, 4, 6), (4, 4, 5, 4), (4, 4, 5, 5), (4, 4, 5, 6), (4, 4, 6, 4), (4, 4, 6, 5), (4, 4, 6, 6),
                                          (4, 5, 4, 4), (4, 5, 4, 5), (4, 5, 4, 6), (4, 5, 5, 4), (4, 5, 5, 5), (4, 5, 5, 6), (4, 5, 6, 4), (4, 5, 6, 5), (4, 5, 6, 6),
@@ -255,19 +255,19 @@ def test_orthogonal_grid_moore_1d():
 
     # Moore neighborhood, torus false, left edge
     grid = OrthogonalMooreGrid((width,), torus=False, capacity=None)
-    assert len(grid._cells[(0,)]._connections) == 1
-    for connection in grid._cells[(0,)]._connections:
+    assert len(grid._cells[(0,)].connections.values()) == 1
+    for connection in grid._cells[(0,)].connections.values():
         assert connection.coordinate in {(1,)}
 
     # Moore neighborhood middle of grid
-    assert len(grid._cells[(5,)]._connections) == 2
-    for connection in grid._cells[(5,)]._connections:
+    assert len(grid._cells[(5,)].connections.values()) == 2
+    for connection in grid._cells[(5,)].connections.values():
         assert connection.coordinate in {(4,), (6,)}
 
     # Moore neighborhood, torus True, left edge
     grid = OrthogonalMooreGrid((width,), torus=True, capacity=None)
-    assert len(grid._cells[(0,)]._connections) == 2
-    for connection in grid._cells[(0,)]._connections:
+    assert len(grid._cells[(0,)].connections.values()) == 2
+    for connection in grid._cells[(0,)].connections.values():
         assert connection.coordinate in {(1,), (9,)}
 
 
@@ -321,21 +321,21 @@ def test_hexgrid():
     assert len(grid._cells) == width * height
 
     # first row
-    assert len(grid._cells[(0, 0)]._connections) == 2
-    for connection in grid._cells[(0, 0)]._connections:
+    assert len(grid._cells[(0, 0)].connections.values()) == 2
+    for connection in grid._cells[(0, 0)].connections.values():
         assert connection.coordinate in {(0, 1), (1, 0)}
 
     # second row
-    assert len(grid._cells[(1, 0)]._connections) == 5
-    for connection in grid._cells[(1, 0)]._connections:
+    assert len(grid._cells[(1, 0)].connections.values()) == 5
+    for connection in grid._cells[(1, 0)].connections.values():
         # fmt: off
         assert connection.coordinate in {(0, 0), (0, 1),
                                                     (1, 1),
                                          (2, 0), (2, 1)}
 
     # middle odd row
-    assert len(grid._cells[(5, 5)]._connections) == 6
-    for connection in grid._cells[(5, 5)]._connections:
+    assert len(grid._cells[(5, 5)].connections.values()) == 6
+    for connection in grid._cells[(5, 5)].connections.values():
         # fmt: off
         assert connection.coordinate in {(4, 5), (4, 6),
                                       (5, 4),       (5, 6),
@@ -344,8 +344,8 @@ def test_hexgrid():
         # fmt: on
 
     # middle even row
-    assert len(grid._cells[(4, 4)]._connections) == 6
-    for connection in grid._cells[(4, 4)]._connections:
+    assert len(grid._cells[(4, 4)].connections.values()) == 6
+    for connection in grid._cells[(4, 4)].connections.values():
         # fmt: off
         assert connection.coordinate in {(3, 3), (3, 4),
                                       (4, 3),       (4, 5),
@@ -357,8 +357,8 @@ def test_hexgrid():
     assert len(grid._cells) == width * height
 
     # first row
-    assert len(grid._cells[(0, 0)]._connections) == 6
-    for connection in grid._cells[(0, 0)]._connections:
+    assert len(grid._cells[(0, 0)].connections.values()) == 6
+    for connection in grid._cells[(0, 0)].connections.values():
         # fmt: off
         assert connection.coordinate in {(9, 9), (9, 0),
                                       (0, 9),       (0, 1),
@@ -380,7 +380,7 @@ def test_networkgrid():
     assert len(grid._cells) == n
 
     for i, cell in grid._cells.items():
-        for connection in cell._connections:
+        for connection in cell.connections.values():
             assert connection.coordinate in G.neighbors(i)
 
 
@@ -393,8 +393,8 @@ def test_voronoigrid():
     assert len(grid._cells) == len(points)
 
     # Check cell neighborhood
-    assert len(grid._cells[0]._connections) == 2
-    for connection in grid._cells[0]._connections:
+    assert len(grid._cells[0].connections.values()) == 2
+    for connection in grid._cells[0].connections.values():
         assert connection.coordinate in [[1, 1], [1, 3]]
 
     with pytest.raises(ValueError):
@@ -434,15 +434,14 @@ def test_cell():
 
     # connect
     cell1.connect(cell2)
-    assert cell2 in cell1._connections
+    assert cell2 in cell1.connections.values()
 
     # disconnect
     cell1.disconnect(cell2)
-    assert cell2 not in cell1._connections
+    assert cell2 not in cell1.connections.values()
 
     # remove cell not in connections
-    with pytest.raises(ValueError):
-        cell1.disconnect(cell2)
+    cell1.disconnect(cell2)
 
     # add_agent
     model = Model()


### PR DESCRIPTION
This PR changes the formerly private attribute `_connections` from the `Cell` class to be public and to be no longer a list, but a dictionary that includes a name for each connections. For Grids this defaults to the relative direction ( `(0, 1)`, `(-1, -1)`, etc.). For Network this is the node name of the "other" cell. 

This allows more powerful and direct agent movements, because you no longer need to query the connection to see where it leads or be dependent on the order in which directions were created. +

This PR also includes some type improvements