### PR TITLE
Solara viz: use_task for non-threaded continous play

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -23,8 +23,8 @@ See the Visualization Tutorial and example models for more details.
 
 from __future__ import annotations
 
+import asyncio
 import copy
-import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
@@ -235,12 +235,12 @@ def ModelController(model: solara.Reactive[Model], play_interval=100):
 
     solara.use_effect(save_initial_model, [model.value])
 
-    def step():
+    async def step():
         while playing.value:
-            time.sleep(play_interval / 1000)
+            await asyncio.sleep(play_interval / 1000)
             do_step()
 
-    solara.use_thread(step, [playing.value])
+    solara.lab.use_task(step, dependencies=[playing.value], prefer_threaded=False)
 
     def do_step():
         """Advance the model by one step."""


### PR DESCRIPTION
This is an alternative to https://github.com/projectmesa/mesa/pull/2303 

While investigating #2303 I realized that `use_thread` is deprecated and recommended to replace with `use_task`, which also allows not using a thread at all, but a coroutine. This allows this version to also work in environments where threading can be problematic (colab) or isn't available at all (Pyodide, WASM, etc.). It also avoids possible issues with threads running in the background forever. 

It also runs blazingly fast!

[screen-capture (1).webm](https://github.com/user-attachments/assets/857e4ea7-519a-491c-bf5e-52fc87a7c40c)
