### PR TITLE
CI: Install Mesa with uv again on Python 3.13

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -53,12 +53,8 @@ jobs:
         cache: 'pip'
     - name: Install uv
       run: pip install uv
-    - name: Install Mesa with uv pip
+    - name: Install Mesa and dependencies
       run: uv pip install --system .[dev]
-      if: matrix.python-version != '3.13'
-    - name: Install Mesa with pip
-      run: pip install .[dev]
-      if: matrix.python-version == '3.13'
     - name: Test with pytest
       run: pytest --durations=10 --cov=mesa tests/ --cov-report=xml
     - if: matrix.os == 'ubuntu'


### PR DESCRIPTION
There are now Python 3.13 wheels available for Pandas with the [2.2.3](https://github.com/pandas-dev/pandas/releases/tag/v2.2.3) release, making a fast install with uv again possible.