### PR TITLE
docs: Update overview for Mesa 3.0

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -196,27 +196,27 @@ This will create an interactive visualization of your model, including:
 
 You can also create custom visualization components using Matplotlib. For more advanced usage and customization options, please refer to the [visualization tutorial](tutorials/visualization_tutorial).
 
-## Further resources
+### Further resources
 To further explore Mesa and its features, we have the following resources available:
 
-### Tutorials
+#### Tutorials
 - [Introductory Tutorial](tutorials/intro_tutorial): Learn how to create your first Mesa model.
 - [Visualization Tutorial](tutorials/visualization_tutorial.html): Learn how to create interactive visualizations for your models.
 
-### API documentation
+#### API documentation
 - [Mesa API reference](apis): Detailed documentation of Mesa's classes and functions.
 
-### Example models
+#### Example models
 - [Mesa Examples repository](https://github.com/projectmesa/mesa-examples): A collection of example models demonstrating various Mesa features and modeling techniques.
 
-### Migration guide
+#### Migration guide
 - [Mesa 3.0 Migration guide](migration_guide): If you're upgrading from an earlier version of Mesa, this guide will help you navigate the changes in Mesa 3.0.
 
-### Source Ccode and development
+#### Source Ccode and development
 - [Mesa GitHub repository](https://github.com/projectmesa/mesa): Access the full source code of Mesa, contribute to its development, or report issues.
 - [Mesa release notes](https://github.com/projectmesa/mesa/releases): View the detailed changelog of Mesa, including all past releases and their features.
 
-### Community and support
+#### Community and support
 - [Mesa GitHub Discussions](https://github.com/projectmesa/mesa/discussions): Join discussions, ask questions, and connect with other Mesa users.
 - [Matrix Chat](https://matrix.to/#/#project-mesa:matrix.org): Real-time chat for quick questions and community interaction.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -58,6 +58,50 @@ You should see agents 1-5, activated in random order. See the [tutorial](tutoria
 
 To bootstrap a new model install mesa and run `mesa startproject`
 
+### AgentSet and model.agents
+Mesa 3.0 introduces the AgentSet class and the `model.agents` attribute, providing powerful tools for managing agents.
+
+#### model.agents
+`model.agents` is an AgentSet containing all agents in the model. It's automatically updated when agents are added or removed:
+
+```python
+# Get total number of agents
+num_agents = len(model.agents)
+
+# Iterate over all agents
+for agent in model.agents:
+    print(agent.unique_id)
+```
+
+#### AgentSet Functionality
+AgentSet offers several methods for efficient agent management:
+
+1. **Selecting**: Filter agents based on criteria.
+   ```python
+   high_energy_agents = model.agents.select(lambda a: a.energy > 50)
+   ```
+2. **Shuffling and Sorting**: Randomize or order agents.
+   ```python
+   shuffled_agents = model.agents.shuffle()
+   sorted_agents = model.agents.sort(key="energy", ascending=False)
+   ```
+3. **Applying methods**: Execute methods on all agents.
+   ```python
+   model.agents.do("step")
+   model.agents.shuffle_do("move")  # Shuffle then apply method
+   ```
+4. **Aggregating**: Compute aggregate values across agents.
+   ```python
+   avg_energy = model.agents.agg("energy", func=np.mean)
+   ```
+5. **Grouping**: Group agents by attributes.
+   ```python
+   grouped_agents = model.agents.groupby("species")
+   ```
+`model.agents` can also be accessed within the model using `self.agents`.
+
+These are just some examples of using the AgentSet, there are many more possibilities, see the [AgentSet API docs](apis/agent).
+
 ### Analysis modules
 
 If you're using modeling for research, you'll want a way to collect the data each model run generates. You'll probably also want to run the model multiple times, to see how some output changes with different parameters. Data collection and batch running are implemented in the appropriately-named analysis modules:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Mesa is a modular framework for building, analyzing and visualizing agent-based 
 
 Mesa is modular, meaning that its modeling, analysis and visualization components are kept separate but intended to work together. The modules are grouped into three categories:
 
-1. **Modeling:** Modules used to build the models themselves: a model and agent classes, space for them to move around on, and built-in functionality for managing agents.
+1. **Modeling:** Classes used to build the models themselves: a model and agent classes, space for them to move around in, and built-in functionality for managing agents.
 2. **Analysis:** Tools to collect data generated from your model, or to run it multiple times with different parameter values.
 3. **Visualization:** Classes to create and launch an interactive model visualization, using a browser-based interface.
 
@@ -38,8 +38,8 @@ class MyModel(mesa.Model):
         super().__init__()
         self.grid = mesa.space.MultiGrid(10, 10, torus=True)
         for _ in range(n_agents):
-            new_age = self.random.randint(0, 80)
-            a = MyAgent(self, new_age)
+            initial_age = self.random.randint(0, 80)
+            a = MyAgent(self, initial_age)
             coords = (self.random.randrange(0, 10), self.random.randrange(0, 10))
             self.grid.place_agent(a, coords)
 
@@ -59,7 +59,7 @@ You should see agents 1-5, activated in random order. See the [tutorial](tutoria
 To bootstrap a new model install mesa and run `mesa startproject`
 
 ### AgentSet and model.agents
-Mesa 3.0 introduces the AgentSet class and the `model.agents` attribute, providing powerful tools for managing agents.
+Mesa 3.0 makes `model.agents` and the AgentSet class central in managing and activating agents.
 
 #### model.agents
 `model.agents` is an AgentSet containing all agents in the model. It's automatically updated when agents are added or removed:
@@ -97,8 +97,13 @@ AgentSet offers several methods for efficient agent management:
 5. **Grouping**: Group agents by attributes.
    ```python
    grouped_agents = model.agents.groupby("species")
+
+   for _, agent_group in grouped_agents:
+      agent_group.shuffle_do()
+   species_counts = grouped_agents.count()
+   mean_age_by_group = grouped_agents.agg("age", np.mean)
    ```
-`model.agents` can also be accessed within the model using `self.agents`.
+`model.agents` can also be accessed within a model instance using `self.agents`.
 
 These are just some examples of using the AgentSet, there are many more possibilities, see the [AgentSet API docs](apis/agent).
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -151,3 +151,29 @@ This will create an interactive visualization of your model, including:
 - A slider to adjust the number of agents
 
 You can also create custom visualization components using Matplotlib. For more advanced usage and customization options, please refer to the [visualization tutorial](tutorials/visualization_tutorial).
+
+## Further resources
+To further explore Mesa and its features, we have the following resources available:
+
+### Tutorials
+- [Introductory Tutorial](tutorials/intro_tutorial): Learn how to create your first Mesa model.
+- [Visualization Tutorial](tutorials/visualization_tutorial.html): Learn how to create interactive visualizations for your models.
+
+### API documentation
+- [Mesa API reference](apis): Detailed documentation of Mesa's classes and functions.
+
+### Example models
+- [Mesa Examples repository](https://github.com/projectmesa/mesa-examples): A collection of example models demonstrating various Mesa features and modeling techniques.
+
+### Migration guide
+- [Mesa 3.0 Migration guide](migration_guide): If you're upgrading from an earlier version of Mesa, this guide will help you navigate the changes in Mesa 3.0.
+
+### Source Ccode and development
+- [Mesa GitHub repository](https://github.com/projectmesa/mesa): Access the full source code of Mesa, contribute to its development, or report issues.
+- [Mesa release notes](https://github.com/projectmesa/mesa/releases): View the detailed changelog of Mesa, including all past releases and their features.
+
+### Community and support
+- [Mesa GitHub Discussions](https://github.com/projectmesa/mesa/discussions): Join discussions, ask questions, and connect with other Mesa users.
+- [Matrix Chat](https://matrix.to/#/#project-mesa:matrix.org): Real-time chat for quick questions and community interaction.
+
+Enjoy modelling with Mesa, and feel free to reach out!


### PR DESCRIPTION
Update the overview.md page for Mesa 3.0. Please review:
- The updated explanations
- If it's follows Mesa 3.0s best practices
- The new AgentSet section (3130ccd)
- The new visualisation API
- The new further resources section (70d748a)

Rendered docs are [available here](https://mesa--2317.org.readthedocs.build/en/2317/overview.html).

Closes #2259.