### PR TITLE
experimental: Integrate PropertyLayers into cell space

### DIFF
--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -36,6 +36,7 @@ class Cell:
         "capacity",
         "properties",
         "random",
+        "_mesa_property_layers",
         "__dict__",
     ]
 
@@ -71,7 +72,7 @@ class Cell:
         self.capacity: int = capacity
         self.properties: dict[Coordinate, object] = {}
         self.random = random
-        self.property_layers: dict[str, PropertyLayer] = {}
+        self._mesa_property_layers: dict[str, PropertyLayer] = {}
 
     def connect(self, other: Cell, key: Coordinate | None = None) -> None:
         """Connects this cell to another cell.
@@ -198,16 +199,16 @@ class Cell:
     # PropertyLayer methods
     def get_property(self, property_name: str) -> Any:
         """Get the value of a property."""
-        return self.property_layers[property_name].data[self.coordinate]
+        return self._mesa_property_layers[property_name].data[self.coordinate]
 
     def set_property(self, property_name: str, value: Any):
         """Set the value of a property."""
-        self.property_layers[property_name].set_cell(self.coordinate, value)
+        self._mesa_property_layers[property_name].set_cell(self.coordinate, value)
 
     def modify_property(
         self, property_name: str, operation: Callable, value: Any = None
     ):
         """Modify the value of a property."""
-        self.property_layers[property_name].modify_cell(
+        self._mesa_property_layers[property_name].modify_cell(
             self.coordinate, operation, value
         )

--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import cache, cached_property
 from random import Random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mesa.experimental.cell_space.cell_collection import CellCollection
+from mesa.space import PropertyLayer
 
 if TYPE_CHECKING:
     from mesa.agent import Agent
@@ -69,6 +71,7 @@ class Cell:
         self.capacity: int = capacity
         self.properties: dict[Coordinate, object] = {}
         self.random = random
+        self.property_layers: dict[str, PropertyLayer] = {}
 
     def connect(self, other: Cell, key: Coordinate | None = None) -> None:
         """Connects this cell to another cell.
@@ -191,3 +194,30 @@ class Cell:
             if not include_center:
                 neighborhood.pop(self, None)
             return neighborhood
+
+    # PropertyLayer methods
+    def add_property_layer(self, property_layer: PropertyLayer):
+        """Add a PropertyLayer to the cell."""
+        if property_layer.name in self.property_layers:
+            raise ValueError(f"Property layer {property_layer.name} already exists.")
+        self.property_layers[property_layer.name] = property_layer
+
+    def remove_property_layer(self, property_name: str):
+        """Remove a PropertyLayer from the cell."""
+        del self.property_layers[property_name]
+
+    def get_property(self, property_name: str) -> Any:
+        """Get the value of a property."""
+        return self.property_layers[property_name].data[self.coordinate]
+
+    def set_property(self, property_name: str, value: Any):
+        """Set the value of a property."""
+        self.property_layers[property_name].set_cell(self.coordinate, value)
+
+    def modify_property(
+        self, property_name: str, operation: Callable, value: Any = None
+    ):
+        """Modify the value of a property."""
+        self.property_layers[property_name].modify_cell(
+            self.coordinate, operation, value
+        )

--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -196,16 +196,6 @@ class Cell:
             return neighborhood
 
     # PropertyLayer methods
-    def add_property_layer(self, property_layer: PropertyLayer):
-        """Add a PropertyLayer to the cell."""
-        if property_layer.name in self.property_layers:
-            raise ValueError(f"Property layer {property_layer.name} already exists.")
-        self.property_layers[property_layer.name] = property_layer
-
-    def remove_property_layer(self, property_name: str):
-        """Remove a PropertyLayer from the cell."""
-        del self.property_layers[property_name]
-
     def get_property(self, property_name: str) -> Any:
         """Get the value of a property."""
         return self.property_layers[property_name].data[self.coordinate]

--- a/mesa/experimental/cell_space/discrete_space.py
+++ b/mesa/experimental/cell_space/discrete_space.py
@@ -92,7 +92,7 @@ class DiscreteSpace(Generic[T]):
         self.property_layers[property_layer.name] = property_layer
         if add_to_cells:
             for cell in self._cells.values():
-                cell.property_layers[property_layer.name] = property_layer
+                cell._mesa_property_layers[property_layer.name] = property_layer
 
     def remove_property_layer(self, property_name: str, remove_from_cells: bool = True):
         """Remove a property layer from the grid.
@@ -104,7 +104,7 @@ class DiscreteSpace(Generic[T]):
         del self.property_layers[property_name]
         if remove_from_cells:
             for cell in self._cells.values():
-                del cell.property_layers[property_name]
+                del cell._mesa_property_layers[property_name]
 
     def set_property(
         self, property_name: str, value, condition: Callable[[T], bool] | None = None

--- a/mesa/experimental/cell_space/discrete_space.py
+++ b/mesa/experimental/cell_space/discrete_space.py
@@ -23,7 +23,7 @@ class DiscreteSpace(Generic[T]):
         random (Random): The random number generator
         cell_klass (Type) : the type of cell class
         empties (CellCollection) : collecction of all cells that are empty
-        property_layers (dict[str, PropertyLayer]): the property layers of the grid
+        property_layers (dict[str, PropertyLayer]): the property layers of the discrete space
     """
 
     def __init__(
@@ -31,7 +31,6 @@ class DiscreteSpace(Generic[T]):
         capacity: int | None = None,
         cell_klass: type[T] = Cell,
         random: Random | None = None,
-        property_layers: None | PropertyLayer | list[PropertyLayer] = None,
     ):
         """Instantiate a DiscreteSpace.
 
@@ -39,7 +38,6 @@ class DiscreteSpace(Generic[T]):
             capacity: capacity of cells
             cell_klass: base class for all cells
             random: random number generator
-            property_layers: property layers to add to the grid
         """
         super().__init__()
         self.capacity = capacity
@@ -52,11 +50,6 @@ class DiscreteSpace(Generic[T]):
         self._empties: dict[tuple[int, ...], None] = {}
         self._empties_initialized = False
         self.property_layers: dict[str, PropertyLayer] = {}
-        if property_layers:
-            if isinstance(property_layers, PropertyLayer):
-                property_layers = [property_layers]
-            for layer in property_layers:
-                self.add_property_layer(layer)
 
     @property
     def cutoff_empties(self):  # noqa

--- a/mesa/experimental/cell_space/discrete_space.py
+++ b/mesa/experimental/cell_space/discrete_space.py
@@ -88,7 +88,12 @@ class DiscreteSpace(Generic[T]):
     def add_property_layer(
         self, property_layer: PropertyLayer, add_to_cells: bool = True
     ):
-        """Add a property layer to the grid."""
+        """Add a property layer to the grid.
+
+        Args:
+            property_layer: the property layer to add
+            add_to_cells: whether to add the property layer to all cells (default: True)
+        """
         if property_layer.name in self.property_layers:
             raise ValueError(f"Property layer {property_layer.name} already exists.")
         self.property_layers[property_layer.name] = property_layer
@@ -97,7 +102,12 @@ class DiscreteSpace(Generic[T]):
                 cell.property_layers[property_layer.name] = property_layer
 
     def remove_property_layer(self, property_name: str, remove_from_cells: bool = True):
-        """Remove a property layer from the grid."""
+        """Remove a property layer from the grid.
+
+        Args:
+            property_name: the name of the property layer to remove
+            remove_from_cells: whether to remove the property layer from all cells (default: True)
+        """
         del self.property_layers[property_name]
         if remove_from_cells:
             for cell in self._cells.values():
@@ -106,7 +116,13 @@ class DiscreteSpace(Generic[T]):
     def set_property(
         self, property_name: str, value, condition: Callable[[T], bool] | None = None
     ):
-        """Set the value of a property for all cells in the grid."""
+        """Set the value of a property for all cells in the grid.
+
+        Args:
+            property_name: the name of the property to set
+            value: the value to set
+            condition: a function that takes a cell and returns a boolean
+        """
         self.property_layers[property_name].set_cells(value, condition)
 
     def modify_properties(
@@ -116,5 +132,12 @@ class DiscreteSpace(Generic[T]):
         value: Any = None,
         condition: Callable[[T], bool] | None = None,
     ):
-        """Modify the values of a specific property for all cells in the grid."""
+        """Modify the values of a specific property for all cells in the grid.
+
+        Args:
+            property_name: the name of the property to modify
+            operation: the operation to perform
+            value: the value to use in the operation
+            condition: a function that takes a cell and returns a boolean (used to filter cells)
+        """
         self.property_layers[property_name].modify_cells(operation, value, condition)

--- a/mesa/experimental/cell_space/discrete_space.py
+++ b/mesa/experimental/cell_space/discrete_space.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import cached_property
 from random import Random
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from mesa.experimental.cell_space.cell import Cell
 from mesa.experimental.cell_space.cell_collection import CellCollection
+from mesa.space import PropertyLayer
 
 T = TypeVar("T", bound=Cell)
 
@@ -21,7 +23,7 @@ class DiscreteSpace(Generic[T]):
         random (Random): The random number generator
         cell_klass (Type) : the type of cell class
         empties (CellCollection) : collecction of all cells that are empty
-
+        property_layers (dict[str, PropertyLayer]): the property layers of the grid
     """
 
     def __init__(
@@ -29,6 +31,7 @@ class DiscreteSpace(Generic[T]):
         capacity: int | None = None,
         cell_klass: type[T] = Cell,
         random: Random | None = None,
+        property_layers: None | PropertyLayer | list[PropertyLayer] = None,
     ):
         """Instantiate a DiscreteSpace.
 
@@ -36,6 +39,7 @@ class DiscreteSpace(Generic[T]):
             capacity: capacity of cells
             cell_klass: base class for all cells
             random: random number generator
+            property_layers: property layers to add to the grid
         """
         super().__init__()
         self.capacity = capacity
@@ -47,6 +51,12 @@ class DiscreteSpace(Generic[T]):
 
         self._empties: dict[tuple[int, ...], None] = {}
         self._empties_initialized = False
+        self.property_layers: dict[str, PropertyLayer] = {}
+        if property_layers:
+            if isinstance(property_layers, PropertyLayer):
+                property_layers = [property_layers]
+            for layer in property_layers:
+                self.add_property_layer(layer)
 
     @property
     def cutoff_empties(self):  # noqa
@@ -73,3 +83,38 @@ class DiscreteSpace(Generic[T]):
     def select_random_empty_cell(self) -> T:
         """Select random empty cell."""
         return self.random.choice(list(self.empties))
+
+    # PropertyLayer methods
+    def add_property_layer(
+        self, property_layer: PropertyLayer, add_to_cells: bool = True
+    ):
+        """Add a property layer to the grid."""
+        if property_layer.name in self.property_layers:
+            raise ValueError(f"Property layer {property_layer.name} already exists.")
+        self.property_layers[property_layer.name] = property_layer
+        if add_to_cells:
+            for cell in self._cells.values():
+                cell.add_property_layer(property_layer)
+
+    def remove_property_layer(self, property_name: str, remove_from_cells: bool = True):
+        """Remove a property layer from the grid."""
+        del self.property_layers[property_name]
+        if remove_from_cells:
+            for cell in self._cells.values():
+                cell.remove_property_layer(property_name)
+
+    def set_property(
+        self, property_name: str, value, condition: Callable[[T], bool] | None = None
+    ):
+        """Set the value of a property for all cells in the grid."""
+        self.property_layers[property_name].set_cells(value, condition)
+
+    def modify_properties(
+        self,
+        property_name: str,
+        operation: Callable,
+        value: Any = None,
+        condition: Callable[[T], bool] | None = None,
+    ):
+        """Modify the values of a specific property for all cells in the grid."""
+        self.property_layers[property_name].modify_cells(operation, value, condition)

--- a/mesa/experimental/cell_space/discrete_space.py
+++ b/mesa/experimental/cell_space/discrete_space.py
@@ -94,14 +94,14 @@ class DiscreteSpace(Generic[T]):
         self.property_layers[property_layer.name] = property_layer
         if add_to_cells:
             for cell in self._cells.values():
-                cell.add_property_layer(property_layer)
+                cell.property_layers[property_layer.name] = property_layer
 
     def remove_property_layer(self, property_name: str, remove_from_cells: bool = True):
         """Remove a property layer from the grid."""
         del self.property_layers[property_name]
         if remove_from_cells:
             for cell in self._cells.values():
-                cell.remove_property_layer(property_name)
+                del cell.property_layers[property_name]
 
     def set_property(
         self, property_name: str, value, condition: Callable[[T], bool] | None = None

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -542,7 +542,7 @@ def test_property_layer_integration():
 
     # Test accessing PropertyLayer from a cell
     cell = grid._cells[(0, 0)]
-    assert "elevation" in cell.property_layers
+    assert "elevation" in cell._mesa_property_layers
     assert cell.get_property("elevation") == 0
 
     # Test setting property value for a cell
@@ -567,7 +567,7 @@ def test_property_layer_integration():
     # Test removing a PropertyLayer
     grid.remove_property_layer("elevation")
     assert "elevation" not in grid.property_layers
-    assert "elevation" not in cell.property_layers
+    assert "elevation" not in cell._mesa_property_layers
 
 
 def test_multiple_property_layers():

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -641,4 +641,3 @@ def test_cell_agent():  # noqa: D103
     assert agent not in model._all_agents
     assert agent not in cell1.agents
     assert agent not in cell2.agents
-


### PR DESCRIPTION
Integrate the PropertyLayers into the cell space. Initially only in the DiscreteSpace, and thereby the Grids.

Since we're in the experimental space, this PR is ready for review as-is.

In future PRs:
- Add a more comprehensive select function
https://github.com/projectmesa/mesa/blob/4c829896975f57ceffaf6b403e89fac25490b04d/mesa/space.py#L872
- Integrate PropertyLayer into CellCollection
  - Thinking about how to do this fast. For larger collections, keeping a mask is probably most performant, but for smaller collections, maybe just iterate though the cells.