### PR TITLE
CI: Use Python 3.13

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Add project directory to PYTHONPATH
         run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
       - name: Install dependencies

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -31,10 +31,10 @@ jobs:
       fail-fast: False
       matrix:
         os: [windows, ubuntu, macos]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         include:
           - os: ubuntu
-            python-version: "3.13"
+            python-version: "3.12"
           - os: ubuntu
             python-version: "3.11"
           - os: ubuntu
@@ -68,7 +68,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
         cache: 'pip'
     - name: Install uv
       run: pip install uv

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -69,6 +69,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.13"
+        allow-prereleases: true
         cache: 'pip'
     - name: Install uv
       run: pip install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
+          allow-prereleases: true
           cache: 'pip'
       - name: Install dependencies
         run: pip install -U pip hatch


### PR DESCRIPTION
Use Python 3.13 in all CI jobs. It’s faster and gives better error messages.