### PR TITLE
Migration guide: Add note about removing Agents from the model

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -221,10 +221,10 @@ self.agents_by_type[AgentType].shuffle_do("step")
 2. If you were using `self.schedule.agents`, replace it with `self.agents`.
 3. If you were using `self.schedule.get_agent_count()`, replace it with `len(self.agents)`.
 4. If you were using `self.schedule.agents_by_type`, replace it with `self.agents_by_type`.
-5. Instead of `self.schedule.add()` and `self.schedule.remove()`, agents are now automatically added to and removed from the model's AgentSet (`model.agents`) when they are created or removed.
-   - You still need to remove the Agent itself. Use `Agent.remove()` for that. Often you would:
-     - Replace `self.schedule.remove(agent)` with `agent.remove()` (in the Model)
-     - Replace `self.model.schedule.remove(self)` with `self.remove()` (in the Agent)
+5. Agents are now automatically added to or removed from the model's `AgentSet` (`model.agents`) when they are created or deleted, eliminating the need to manually call `self.schedule.add()` or `self.schedule.remove()`. 
+   - However, you still need to explicitly remove the Agent itself by using `Agent.remove()`. Typically, this means:
+     - Replace `self.schedule.remove(agent)` with `agent.remove()` in the Model.
+     - Replace `self.model.schedule.remove(self)` with `self.remove()` within the Agent.
 
 From now on you're now not bound by 5 distinct schedulers, but can mix and match any combination of AgentSet methods (`do`, `shuffle`, `select`, etc.) to get the desired Agent activation.
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -221,7 +221,7 @@ self.agents_by_type[AgentType].shuffle_do("step")
 2. If you were using `self.schedule.agents`, replace it with `self.agents`.
 3. If you were using `self.schedule.get_agent_count()`, replace it with `len(self.agents)`.
 4. If you were using `self.schedule.agents_by_type`, replace it with `self.agents_by_type`.
-5. Agents are now automatically added to or removed from the model's `AgentSet` (`model.agents`) when they are created or deleted, eliminating the need to manually call `self.schedule.add()` or `self.schedule.remove()`. 
+5. Agents are now automatically added to or removed from the model's `AgentSet` (`model.agents`) when they are created or deleted, eliminating the need to manually call `self.schedule.add()` or `self.schedule.remove()`.
    - However, you still need to explicitly remove the Agent itself by using `Agent.remove()`. Typically, this means:
      - Replace `self.schedule.remove(agent)` with `agent.remove()` in the Model.
      - Replace `self.model.schedule.remove(self)` with `self.remove()` within the Agent.

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -222,6 +222,7 @@ self.agents_by_type[AgentType].shuffle_do("step")
 3. If you were using `self.schedule.get_agent_count()`, replace it with `len(self.agents)`.
 4. If you were using `self.schedule.agents_by_type`, replace it with `self.agents_by_type`.
 5. Instead of `self.schedule.add()` and `self.schedule.remove()`, agents are now automatically added to and removed from the model's AgentSet when they are created or removed.
+   - You might still want to remove the Agent from the model completely. Use `self.remove()` in that case (often replacing `self.schedule.remove()`).
 
 From now on you're now not bound by 5 distinct schedulers, but can mix and match any combination of AgentSet methods (`do`, `shuffle`, `select`, etc.) to get the desired Agent activation.
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -222,7 +222,9 @@ self.agents_by_type[AgentType].shuffle_do("step")
 3. If you were using `self.schedule.get_agent_count()`, replace it with `len(self.agents)`.
 4. If you were using `self.schedule.agents_by_type`, replace it with `self.agents_by_type`.
 5. Instead of `self.schedule.add()` and `self.schedule.remove()`, agents are now automatically added to and removed from the model's AgentSet when they are created or removed.
-   - You might still want to remove the Agent from the model completely. Use `self.remove()` in that case (often replacing `self.schedule.remove()`).
+   - You still need to remove the Agent itself. Use `Agent.remove()` for that. Often you would:
+     - Replace `self.schedule.remove(agent)` with `agent.remove()` (in the Model)
+     - Replace `self.model.schedule.remove(self)` with `self.remove()` (in the Agent)
 
 From now on you're now not bound by 5 distinct schedulers, but can mix and match any combination of AgentSet methods (`do`, `shuffle`, `select`, etc.) to get the desired Agent activation.
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -221,7 +221,7 @@ self.agents_by_type[AgentType].shuffle_do("step")
 2. If you were using `self.schedule.agents`, replace it with `self.agents`.
 3. If you were using `self.schedule.get_agent_count()`, replace it with `len(self.agents)`.
 4. If you were using `self.schedule.agents_by_type`, replace it with `self.agents_by_type`.
-5. Instead of `self.schedule.add()` and `self.schedule.remove()`, agents are now automatically added to and removed from the model's AgentSet when they are created or removed.
+5. Instead of `self.schedule.add()` and `self.schedule.remove()`, agents are now automatically added to and removed from the model's AgentSet (`model.agents`) when they are created or removed.
    - You still need to remove the Agent itself. Use `Agent.remove()` for that. Often you would:
      - Replace `self.schedule.remove(agent)` with `agent.remove()` (in the Model)
      - Replace `self.model.schedule.remove(self)` with `self.remove()` (in the Agent)


### PR DESCRIPTION
Add note about removing Agents from the model to the Migration guide.

It now reads:

> 5. Instead of `self.schedule.add()` and `self.schedule.remove()`, agents are now automatically added to and removed from the model's AgentSet (`model.agents`) when they are created or removed.
>    - You still need to remove the Agent itself. Use `Agent.remove()` for that. Often you would:
>      - Replace `self.schedule.remove(agent)` with `agent.remove()` (in the Model)
>      - Replace `self.model.schedule.remove(self)` with `self.remove()` (in the Agent)