### PR TITLE
update Agent.__init__ to remove deprecation warning

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -66,7 +66,6 @@ class Agent:
         self.unique_id: int = next(self._ids[model])
         self.pos: Position | None = None
 
-
     def remove(self) -> None:
         """Remove and delete the agent from the model."""
         with contextlib.suppress(KeyError):

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -46,39 +46,26 @@ class Agent:
     # so, unique_id is unique relative to a model, and counting starts from 1
     _ids = defaultdict(functools.partial(itertools.count, 1))
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, model: Model, *args, **kwargs) -> None:
         """Create a new agent.
 
         Args:
             model (Model): The model instance in which the agent exists.
-            args: currently ignored, to be fixed in 3.1
-            kwargs: currently ignored, to be fixed in 3.1
-        """
-        # TODO: Cleanup in future Mesa version (3.1+)
-        match args:
-            # Case 1: Only the model is provided. The new correct behavior.
-            case [model]:
-                self.model = model
-                self.unique_id = next(self._ids[model])
-            # Case 2: Both unique_id and model are provided, deprecated
-            case [_, model]:
-                warnings.warn(
-                    "unique ids are assigned automatically to Agents in Mesa 3. The use of custom unique_id is "
-                    "deprecated. Only input a model when calling `super()__init__(model)`. The unique_id inputted is not used.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                self.model = model
-                self.unique_id = next(self._ids[model])
-            # Case 3: Anything else, raise an error
-            case _:
-                raise ValueError(
-                    "Invalid arguments provided to initialize the Agent. Only input a model: `super()__init__(model)`."
-                )
+            args: passed on to super
+            kwargs: passed on to super
 
+        Notes:
+            to make proper use of python's super, in each class remove the arguments and
+            keyword arguments you need and pass on the rest to super
+
+        """
+        super().__init__(*args, **kwargs)
+
+        self.model: Model = model
+        self.model.register_agent(self)
+        self.unique_id: int = next(self._ids[model])
         self.pos: Position | None = None
 
-        self.model.register_agent(self)
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -627,5 +627,3 @@ def test_agentset_groupby():
     assert custom_result[False] == custom_agg(
         [agent.value for agent in agents if not agent.even]
     )
-
-

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -301,7 +301,7 @@ def test_agentset_do_callable():
 def test_agentset_get():
     """Test AgentSet.get."""
     model = Model()
-    _ = [TestAgent(i, model) for i in range(10)]
+    _ = [TestAgent(model) for i in range(10)]
 
     agentset = model.agents
 
@@ -629,14 +629,3 @@ def test_agentset_groupby():
     )
 
 
-def test_oldstyle_agent_instantiation():
-    """Old behavior of Agent creation with unique_id and model as positional arguments.
-
-    Can be removed/updated in the future.
-    """
-    model = Model()
-    agent = Agent("some weird unique id", model)
-    assert isinstance(agent.unique_id, int)
-    assert agent.model == model
-    assert isinstance(agent.model, Model)
-    assert agent.unique_id == 1  # test that we ignore unique ID that is passed


### PR DESCRIPTION
As discussed briefly in the last developer meeting, this PR removes the deprecation warning from `Agent.__init__` regarding unique_id. The main reason for removing it here is that it is the only way to ensure proper behavior of python's super. This in turn is relevant for a range of discussions (movements, HasObservable, some geo stuff). 

It is agreed that in the last 2.X release, to come up with the first stable version of MESA 3, we will explicitly include a deprecation warning regarding unique_id.

References:
- https://github.com/projectmesa/mesa/pull/2260
- [Migration guide](https://mesa.readthedocs.io/latest/migration_guide.html#automatic-assignment-of-unique-id-to-agents)

```Python
# Old
agent = MyAgent(self.next_id(), self, ...)

# New
agent = MyAgent(self, ...)
```