### PR TITLE
Move cell movement into a descriptor

### DIFF
--- a/benchmarks/Schelling/schelling.py
+++ b/benchmarks/Schelling/schelling.py
@@ -52,7 +52,7 @@ class Schelling(Model):
 
     def __init__(
         self,
-        simulator,
+        simulator=None,
         height=40,
         width=40,
         homophily=3,

--- a/benchmarks/Schelling/schelling.py
+++ b/benchmarks/Schelling/schelling.py
@@ -31,7 +31,7 @@ class SchellingAgent(CellAgent):
 
         # If unhappy, move:
         if similar < self.homophily:
-            self.move_to(self.model.grid.select_random_empty_cell())
+            self.cell = self.model.grid.select_random_empty_cell()
         else:
             self.model.happy += 1
 
@@ -81,7 +81,7 @@ class Schelling(Model):
             if self.random.random() < density:
                 agent_type = 1 if self.random.random() < self.minority_pc else 0
                 agent = SchellingAgent(self, agent_type, radius, homophily)
-                agent.move_to(cell)
+                agent.cell = cell
 
     def step(self):
         """Run one step of the model."""

--- a/benchmarks/Schelling/schelling.py
+++ b/benchmarks/Schelling/schelling.py
@@ -1,13 +1,14 @@
 """Schelling separation for performance benchmarking."""
+from __future__ import annotations
 
 from mesa import Model
-from mesa.experimental.cell_space import CellAgent, OrthogonalMooreGrid
+from mesa.experimental.cell_space import CellAgent, OrthogonalMooreGrid, Cell
 
 
 class SchellingAgent(CellAgent):
     """Schelling segregation agent."""
 
-    def __init__(self, model, agent_type, radius, homophily):
+    def __init__(self, model: Schelling, agent_type: int, radius: int, homophily: float, cell: Cell):
         """Create a new Schelling agent.
 
         Args:
@@ -15,11 +16,13 @@ class SchellingAgent(CellAgent):
             agent_type: type of agent (minority=1, majority=0)
             radius: size of neighborhood of agent
             homophily: fraction of neighbors of the same type that triggers movement
+            cell: the cell in which the agent is located
         """
         super().__init__(model)
         self.type = agent_type
         self.radius = radius
         self.homophily = homophily
+        self.cell = cell
 
     def step(self):
         """Run one step of the agent."""
@@ -41,6 +44,7 @@ class Schelling(Model):
 
     def __init__(
         self,
+        simulator,
         height=40,
         width=40,
         homophily=3,
@@ -48,11 +52,11 @@ class Schelling(Model):
         density=0.8,
         minority_pc=0.5,
         seed=None,
-        simulator=None,
     ):
         """Create a new Schelling model.
 
         Args:
+            simulator: simulator instance
             height: height of the grid
             width: width of the grid
             homophily: Minimum number of agents of same class needed to be happy
@@ -63,8 +67,9 @@ class Schelling(Model):
             simulator: a simulator instance
         """
         super().__init__(seed=seed)
-        self.minority_pc = minority_pc
         self.simulator = simulator
+        self.minority_pc = minority_pc
+        self.happy = 0
 
         self.grid = OrthogonalMooreGrid(
             [height, width],
@@ -80,8 +85,7 @@ class Schelling(Model):
         for cell in self.grid:
             if self.random.random() < density:
                 agent_type = 1 if self.random.random() < self.minority_pc else 0
-                agent = SchellingAgent(self, agent_type, radius, homophily)
-                agent.cell = cell
+                SchellingAgent(self, agent_type, radius, homophily, cell)
 
     def step(self):
         """Run one step of the model."""

--- a/benchmarks/Schelling/schelling.py
+++ b/benchmarks/Schelling/schelling.py
@@ -1,14 +1,22 @@
 """Schelling separation for performance benchmarking."""
+
 from __future__ import annotations
 
 from mesa import Model
-from mesa.experimental.cell_space import CellAgent, OrthogonalMooreGrid, Cell
+from mesa.experimental.cell_space import Cell, CellAgent, OrthogonalMooreGrid
 
 
 class SchellingAgent(CellAgent):
     """Schelling segregation agent."""
 
-    def __init__(self, model: Schelling, agent_type: int, radius: int, homophily: float, cell: Cell):
+    def __init__(
+        self,
+        model: Schelling,
+        agent_type: int,
+        radius: int,
+        homophily: float,
+        cell: Cell,
+    ):
         """Create a new Schelling agent.
 
         Args:

--- a/benchmarks/WolfSheep/wolf_sheep.py
+++ b/benchmarks/WolfSheep/wolf_sheep.py
@@ -33,10 +33,6 @@ class Animal(CellAgent):
         self.energy_from_food = energy_from_food
         self.cell = cell
 
-    def random_move(self):
-        """Move to a random neighboring cell."""
-        self.cell = self.cell.neighborhood.select_random_cell()
-
     def spawn_offspring(self):
         """Create offspring."""
         self.energy /= 2
@@ -52,7 +48,7 @@ class Animal(CellAgent):
 
     def step(self):
         """One step of the agent."""
-        self.random_move()
+        self.cell = self.cell.neighborhood.select_random_cell()
         self.energy -= 1
 
         self.feed()

--- a/benchmarks/WolfSheep/wolf_sheep.py
+++ b/benchmarks/WolfSheep/wolf_sheep.py
@@ -36,7 +36,7 @@ class Animal(CellAgent):
     def spawn_offspring(self):
         """Create offspring."""
         self.energy /= 2
-        offspring = self.__class__(
+        self.__class__(
             self.model,
             self.energy,
             self.p_reproduce,
@@ -112,9 +112,10 @@ class GrassPatch(CellAgent):
             model: a model instance
             countdown: Time for the patch of grass to be fully grown again
             grass_regrowth_time : time to fully regrow grass
+            cell: the cell to which the patch of grass belongs
         """
         super().__init__(model)
-        self._fully_grown = True if countdown == 0 else False
+        self._fully_grown = True if countdown == 0 else False  # Noqa: SIM210
         self.grass_regrowth_time = grass_regrowth_time
         self.cell = cell
 
@@ -198,10 +199,7 @@ class WolfSheep(Model):
         possibly_fully_grown = [True, False]
         for cell in self.grid:
             fully_grown = self.random.choice(possibly_fully_grown)
-            if fully_grown:
-                countdown = 0
-            else:
-                countdown = self.random.randrange(grass_regrowth_time)
+            countdown = 0 if fully_grown else self.random.randrange(grass_regrowth_time)
             GrassPatch(self, countdown, grass_regrowth_time, cell)
 
     def step(self):

--- a/benchmarks/WolfSheep/wolf_sheep.py
+++ b/benchmarks/WolfSheep/wolf_sheep.py
@@ -17,7 +17,7 @@ from mesa.experimental.devs import ABMSimulator
 class Animal(CellAgent):
     """The base animal class."""
 
-    def __init__(self, model, energy, p_reproduce, energy_from_food):
+    def __init__(self, model, energy, p_reproduce, energy_from_food, cell):
         """Initializes an animal.
 
         Args:
@@ -25,11 +25,13 @@ class Animal(CellAgent):
             energy: starting amount of energy
             p_reproduce: probability of sexless reproduction
             energy_from_food: energy obtained from 1 unit of food
+            cell: the cell in which the animal starts
         """
         super().__init__(model)
         self.energy = energy
         self.p_reproduce = p_reproduce
         self.energy_from_food = energy_from_food
+        self.cell = cell
 
     def random_move(self):
         """Move to a random neighboring cell."""
@@ -43,15 +45,10 @@ class Animal(CellAgent):
             self.energy,
             self.p_reproduce,
             self.energy_from_food,
+            self.cell,
         )
-        offspring.cell = self.cell
 
     def feed(self): ...  # noqa: D102
-
-    def die(self):
-        """Die."""
-        self.cell.remove_agent(self)
-        self.remove()
 
     def step(self):
         """One step of the agent."""
@@ -61,7 +58,7 @@ class Animal(CellAgent):
         self.feed()
 
         if self.energy < 0:
-            self.die()
+            self.remove()
         elif self.random.random() < self.p_reproduce:
             self.spawn_offspring()
 
@@ -91,7 +88,7 @@ class Wolf(Animal):
             self.energy += self.energy_from_food
 
             # Kill the sheep
-            sheep_to_eat.die()
+            sheep_to_eat.remove()
 
 
 class GrassPatch(CellAgent):
@@ -112,19 +109,18 @@ class GrassPatch(CellAgent):
                 function_args=[self, "fully_grown", True],
             )
 
-    def __init__(self, model, fully_grown, countdown, grass_regrowth_time):
+    def __init__(self, model, countdown, grass_regrowth_time, cell):
         """Creates a new patch of grass.
 
         Args:
             model: a model instance
-            fully_grown: (boolean) Whether the patch of grass is fully grown or not
             countdown: Time for the patch of grass to be fully grown again
             grass_regrowth_time : time to fully regrow grass
         """
-        # TODO:: fully grown can just be an int --> so one less param (i.e. countdown)
         super().__init__(model)
-        self._fully_grown = fully_grown
+        self._fully_grown = True if countdown == 0 else False
         self.grass_regrowth_time = grass_regrowth_time
+        self.cell = cell
 
         if not self.fully_grown:
             self.model.simulator.schedule_event_relative(
@@ -191,13 +187,13 @@ class WolfSheep(Model):
                 self.random.randrange(self.height),
             )
             energy = self.random.randrange(2 * sheep_gain_from_food)
-            sheep = Sheep(
+            Sheep(
                 self,
                 energy,
                 sheep_reproduce,
                 sheep_gain_from_food,
+                self.grid[pos]
             )
-            sheep.cell = self.grid[pos]
 
         # Create wolves
         for _ in range(self.initial_wolves):
@@ -206,24 +202,23 @@ class WolfSheep(Model):
                 self.random.randrange(self.height),
             )
             energy = self.random.randrange(2 * wolf_gain_from_food)
-            wolf = Wolf(
+            Wolf(
                 self,
                 energy,
                 wolf_reproduce,
                 wolf_gain_from_food,
+                self.grid[pos]
             )
-            wolf.cell = self.grid[pos]
 
         # Create grass patches
         possibly_fully_grown = [True, False]
         for cell in self.grid:
             fully_grown = self.random.choice(possibly_fully_grown)
             if fully_grown:
-                countdown = grass_regrowth_time
+                countdown = 0
             else:
                 countdown = self.random.randrange(grass_regrowth_time)
-            patch = GrassPatch(self, fully_grown, countdown, grass_regrowth_time)
-            patch.cell = cell
+            GrassPatch(self, countdown, grass_regrowth_time, cell)
 
     def step(self):
         """Run one step of the model."""

--- a/benchmarks/WolfSheep/wolf_sheep.py
+++ b/benchmarks/WolfSheep/wolf_sheep.py
@@ -17,6 +17,7 @@ from mesa.experimental.devs import ABMSimulator
 class Animal(CellAgent):
     """The base animal class."""
 
+
     def __init__(self, model, energy, p_reproduce, energy_from_food):
         """Initializes an animal.
 
@@ -33,7 +34,7 @@ class Animal(CellAgent):
 
     def random_move(self):
         """Move to a random neighboring cell."""
-        self.move_to(self.cell.neighborhood.select_random_cell())
+        self.cell = self.cell.neighborhood.select_random_cell()
 
     def spawn_offspring(self):
         """Create offspring."""
@@ -44,7 +45,7 @@ class Animal(CellAgent):
             self.p_reproduce,
             self.energy_from_food,
         )
-        offspring.move_to(self.cell)
+        offspring.cell = self.cell
 
     def feed(self): ...  # noqa: D102
 
@@ -197,7 +198,7 @@ class WolfSheep(Model):
                 sheep_reproduce,
                 sheep_gain_from_food,
             )
-            sheep.move_to(self.grid[pos])
+            sheep.cell = self.grid[pos]
 
         # Create wolves
         for _ in range(self.initial_wolves):
@@ -212,7 +213,7 @@ class WolfSheep(Model):
                 wolf_reproduce,
                 wolf_gain_from_food,
             )
-            wolf.move_to(self.grid[pos])
+            wolf.cell = self.grid[pos]
 
         # Create grass patches
         possibly_fully_grown = [True, False]
@@ -223,7 +224,7 @@ class WolfSheep(Model):
             else:
                 countdown = self.random.randrange(grass_regrowth_time)
             patch = GrassPatch(self, fully_grown, countdown, grass_regrowth_time)
-            patch.move_to(cell)
+            patch.cell = cell
 
     def step(self):
         """Run one step of the model."""

--- a/benchmarks/WolfSheep/wolf_sheep.py
+++ b/benchmarks/WolfSheep/wolf_sheep.py
@@ -17,7 +17,6 @@ from mesa.experimental.devs import ABMSimulator
 class Animal(CellAgent):
     """The base animal class."""
 
-
     def __init__(self, model, energy, p_reproduce, energy_from_food):
         """Initializes an animal.
 

--- a/benchmarks/WolfSheep/wolf_sheep.py
+++ b/benchmarks/WolfSheep/wolf_sheep.py
@@ -187,13 +187,7 @@ class WolfSheep(Model):
                 self.random.randrange(self.height),
             )
             energy = self.random.randrange(2 * sheep_gain_from_food)
-            Sheep(
-                self,
-                energy,
-                sheep_reproduce,
-                sheep_gain_from_food,
-                self.grid[pos]
-            )
+            Sheep(self, energy, sheep_reproduce, sheep_gain_from_food, self.grid[pos])
 
         # Create wolves
         for _ in range(self.initial_wolves):
@@ -202,13 +196,7 @@ class WolfSheep(Model):
                 self.random.randrange(self.height),
             )
             energy = self.random.randrange(2 * wolf_gain_from_food)
-            Wolf(
-                self,
-                energy,
-                wolf_reproduce,
-                wolf_gain_from_food,
-                self.grid[pos]
-            )
+            Wolf(self, energy, wolf_reproduce, wolf_gain_from_food, self.grid[pos])
 
         # Create grass patches
         possibly_fully_grown = [True, False]

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -6,7 +6,7 @@ expressive that the default grids available in `mesa.space`.
 """
 
 from mesa.experimental.cell_space.cell import Cell
-from mesa.experimental.cell_space.cell_agent import CellAgent, CellDescriptor
+from mesa.experimental.cell_space.cell_agent import CellAgent
 from mesa.experimental.cell_space.cell_collection import CellCollection
 from mesa.experimental.cell_space.discrete_space import DiscreteSpace
 from mesa.experimental.cell_space.grid import (
@@ -21,7 +21,8 @@ from mesa.experimental.cell_space.voronoi import VoronoiGrid
 __all__ = [
     "CellCollection",
     "Cell",
-    "CellAgent" "CellDescriptor" "DiscreteSpace",
+    "CellAgent",
+    "DiscreteSpace",
     "Grid",
     "HexGrid",
     "OrthogonalMooreGrid",

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -6,7 +6,7 @@ expressive that the default grids available in `mesa.space`.
 """
 
 from mesa.experimental.cell_space.cell import Cell
-from mesa.experimental.cell_space.cell_agent import CellDescriptor, CellAgent
+from mesa.experimental.cell_space.cell_agent import CellAgent, CellDescriptor
 from mesa.experimental.cell_space.cell_collection import CellCollection
 from mesa.experimental.cell_space.discrete_space import DiscreteSpace
 from mesa.experimental.cell_space.grid import (
@@ -21,9 +21,7 @@ from mesa.experimental.cell_space.voronoi import VoronoiGrid
 __all__ = [
     "CellCollection",
     "Cell",
-    "CellAgent"
-    "CellDescriptor"
-    "DiscreteSpace",
+    "CellAgent" "CellDescriptor" "DiscreteSpace",
     "Grid",
     "HexGrid",
     "OrthogonalMooreGrid",

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -6,7 +6,7 @@ expressive that the default grids available in `mesa.space`.
 """
 
 from mesa.experimental.cell_space.cell import Cell
-from mesa.experimental.cell_space.cell_agent import CellAgent
+from mesa.experimental.cell_space.cell_agent import CellDescriptor, CellAgent
 from mesa.experimental.cell_space.cell_collection import CellCollection
 from mesa.experimental.cell_space.discrete_space import DiscreteSpace
 from mesa.experimental.cell_space.grid import (
@@ -21,7 +21,8 @@ from mesa.experimental.cell_space.voronoi import VoronoiGrid
 __all__ = [
     "CellCollection",
     "Cell",
-    "CellAgent",
+    "CellAgent"
+    "CellDescriptor"
     "DiscreteSpace",
     "Grid",
     "HexGrid",

--- a/mesa/experimental/cell_space/cell.py
+++ b/mesa/experimental/cell_space/cell.py
@@ -117,7 +117,6 @@ class Cell:
 
         """
         self.agents.remove(agent)
-        agent.cell = None
 
     @property
     def is_empty(self) -> bool:

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -16,7 +16,7 @@ class HasCell:
     _mesa_cell: Cell = None
 
     @property
-    def cell(self) -> Cell | None:
+    def cell(self) -> Cell | None:  # noqa: D102
         return self._mesa_cell
 
     @cell.setter

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -39,4 +39,10 @@ class CellAgent(Agent):
         cell: (Cell | None): the cell which the agent occupies
     """
 
-    cell: Cell = CellDescriptor()
+    cell: Cell | None = CellDescriptor()
+
+
+    def remove(self):
+        """Remove the agent from the model."""
+        super().remove()
+        self.cell = None  # ensures that we are also removed from cell

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 class HasCell:
     """Descriptor for cell movement behavior."""
+
     _mesa_cell: Cell = None
 
     @property
@@ -19,13 +20,13 @@ class HasCell:
         return getattr(self, "_mesa_cell", None)
 
     @cell.setter
-    def cell(self, cell: Cell | None) -> None:  # noqa D105
+    def cell(self, cell: Cell | None) -> None:
         # remove from current cell
         if self.cell is not None:
             self.cell.remove_agent(self)
 
         # update private attribute
-        setattr(self, "_mesa_cell", cell)
+        self._mesa_cell = cell
 
         # add to new cell
         if cell is not None:

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -4,27 +4,27 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mesa import Agent, Model
+from mesa import Agent
 
 if TYPE_CHECKING:
     from mesa.experimental.cell_space.cell import Cell
 
 
 class CellDescriptor:
-
-    def __get__(self, instance, owner):
+    """Descriptor for cell movement behavior."""
+    def __get__(self, instance, owner):  # noqa D105
         return getattr(instance, self.private_name, None)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance, value):  # noqa D105
         if instance.cell is not None:
             instance.cell.remove_agent(self)
         setattr(instance, self.private_name, value)
 
         if value is not None:
             value.add_agent(self)
-    def __set_name__(self, owner, name):
+    def __set_name__(self, owner, name):  # noqa D105
         self.public_name = name
-        self.private_name = '_' + name
+        self.private_name = "_" + name
 
 
 class CellAgent(Agent):

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -10,6 +10,23 @@ if TYPE_CHECKING:
     from mesa.experimental.cell_space.cell import Cell
 
 
+class CellDescriptor:
+
+    def __get__(self, instance, owner):
+        return getattr(instance, self.private_name, None)
+
+    def __set__(self, instance, value):
+        if instance.cell is not None:
+            instance.cell.remove_agent(self)
+        setattr(instance, self.private_name, value)
+
+        if value is not None:
+            value.add_agent(self)
+    def __set_name__(self, owner, name):
+        self.public_name = name
+        self.private_name = '_' + name
+
+
 class CellAgent(Agent):
     """Cell Agent is an extension of the Agent class and adds behavior for moving in discrete spaces.
 
@@ -19,24 +36,4 @@ class CellAgent(Agent):
         pos: (Position | None): The position of the agent in the space
         cell: (Cell | None): the cell which the agent occupies
     """
-
-    def __init__(self, model: Model) -> None:
-        """Create a new agent.
-
-        Args:
-            model (Model): The model instance in which the agent exists.
-        """
-        super().__init__(model)
-        self.cell: Cell | None = None
-
-    def move_to(self, cell) -> None:
-        """Move agent to cell.
-
-        Args:
-            cell: cell to which agent is to move
-
-        """
-        if self.cell is not None:
-            self.cell.remove_agent(self)
-        self.cell = cell
-        cell.add_agent(self)
+    cell: Cell = CellDescriptor()

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -18,10 +18,7 @@ class CellDescriptor:
 
     def __set__(self, instance, value):  # noqa D105
         if instance.cell is not None:
-            try:
-                instance.cell.remove_agent(instance)
-            except ValueError:
-                pass
+            instance.cell.remove_agent(instance)
         setattr(instance, self.private_name, value)
 
         if value is not None:

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -17,7 +17,7 @@ class HasCell:
 
     @property
     def cell(self) -> Cell | None:
-        return getattr(self, "_mesa_cell", None)
+        return self._mesa_cell
 
     @cell.setter
     def cell(self, cell: Cell | None) -> None:

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -41,7 +41,6 @@ class CellAgent(Agent):
 
     cell: Cell | None = CellDescriptor()
 
-
     def remove(self):
         """Remove the agent from the model."""
         super().remove()

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 class CellDescriptor:
     """Descriptor for cell movement behavior."""
+
     def __get__(self, instance, owner):  # noqa D105
         return getattr(instance, self.private_name, None)
 
@@ -22,6 +23,7 @@ class CellDescriptor:
 
         if value is not None:
             value.add_agent(self)
+
     def __set_name__(self, owner, name):  # noqa D105
         self.public_name = name
         self.private_name = "_" + name
@@ -36,4 +38,5 @@ class CellAgent(Agent):
         pos: (Position | None): The position of the agent in the space
         cell: (Cell | None): the cell which the agent occupies
     """
+
     cell: Cell = CellDescriptor()

--- a/mesa/experimental/cell_space/cell_agent.py
+++ b/mesa/experimental/cell_space/cell_agent.py
@@ -18,11 +18,14 @@ class CellDescriptor:
 
     def __set__(self, instance, value):  # noqa D105
         if instance.cell is not None:
-            instance.cell.remove_agent(self)
+            try:
+                instance.cell.remove_agent(instance)
+            except ValueError:
+                pass
         setattr(instance, self.private_name, value)
 
         if value is not None:
-            value.add_agent(self)
+            value.add_agent(instance)
 
     def __set_name__(self, owner, name):  # noqa D105
         self.public_name = name

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -526,7 +526,7 @@ def test_cell_collection():
     assert len(cells) == len(collection)
 
 
-def test_cell_agent():
+def test_cell_agent():  # noqa: D103
     cell1 = Cell((1,), capacity=None, random=random.Random())
     cell2 = Cell((2,), capacity=None, random=random.Random())
 

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -553,4 +553,3 @@ def test_cell_agent():
     assert agent not in model._all_agents
     assert agent not in cell1.agents
     assert agent not in cell2.agents
-

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -524,3 +524,33 @@ def test_cell_collection():
 
     cells = collection.select()
     assert len(cells) == len(collection)
+
+
+def test_cell_agent():
+    cell1 = Cell((1,), capacity=None, random=random.Random())
+    cell2 = Cell((2,), capacity=None, random=random.Random())
+
+    # connect
+    # add_agent
+    model = Model()
+    agent = CellAgent(model)
+
+    agent.cell = cell1
+    assert agent in cell1.agents
+
+    agent.cell = None
+    assert agent not in cell1.agents
+
+    agent.cell = cell2
+    assert agent not in cell1.agents
+    assert agent in cell2.agents
+
+    agent.cell = cell1
+    assert agent in cell1.agents
+    assert agent not in cell2.agents
+
+    agent.remove()
+    assert agent not in model._all_agents
+    assert agent not in cell1.agents
+    assert agent not in cell2.agents
+


### PR DESCRIPTION
This PR encapsulates the addition to and removal from a cell of an agent in a `HasCell` mixin. It updates CellAgent to use this mixin, and adds an override of `agent.remove` to ensure agents remove themselves from the cell they are occupying when they are removed from the model. The main implication of this PR is that `CellAgent.move_to` is now redundant. I have thus removed it. In #2292, we might bring it back but with more powerful behavior.



### outdated based on discussion below
This PR is for discussion in relation to #2292. It shows how it might be possible to use composition for cell-related movement by encapsulating all the movement behavior into a descriptor. So instead of having a special `Agent.move_to` method, you can do `Agent.cell = new_cell`. You can also use whatever name you want instead of `cell`.

An additional benefit that I had not realized at first is that it cleans up the API a bit more as well. A user does not have to interact with the Cell class directly. She only needs to assign the Cell instance to whatever attribute is used for the descriptor. 