### PR TITLE
Visualize PropertyLayers

### DIFF
--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -8,6 +8,8 @@ import numpy as np
 import solara
 from matplotlib.colors import LinearSegmentedColormap, to_rgba
 from matplotlib.figure import Figure
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
 
 import mesa
 from mesa.experimental.cell_space import VoronoiGrid
@@ -101,11 +103,18 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
             normalized_data = (data - vmin) / (vmax - vmin)
             rgba_data = np.full((*data.shape, 4), rgba_color)
             rgba_data[..., 3] *= normalized_data * alpha
+            cmap = LinearSegmentedColormap.from_list(layer_name, [(0, 0, 0, 0), rgba_color])
             im = ax.imshow(
                 rgba_data.transpose(1, 0, 2),
                 extent=(0, width, 0, height),
                 origin="lower",
             )
+            if colorbar:
+                norm = Normalize(vmin=vmin, vmax=vmax)
+                sm = ScalarMappable(norm=norm, cmap=cmap)
+                sm.set_array([])
+                ax.figure.colorbar(sm, ax=ax, orientation="vertical")
+
         elif "colormap" in portrayal:
             cmap = portrayal.get("colormap", "viridis")
             if isinstance(cmap, list):

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -100,6 +100,7 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
             normalized_data = (data - vmin) / (vmax - vmin)
             rgba_data = np.full((*data.shape, 4), rgba_color)
             rgba_data[..., 3] *= normalized_data * alpha
+            rgba_data = np.clip(rgba_data, 0, 1)
             cmap = LinearSegmentedColormap.from_list(
                 layer_name, [(0, 0, 0, 0), (*rgba_color[:3], alpha)]
             )

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -1,22 +1,18 @@
 """Matplotlib based solara components for visualization MESA spaces and plots."""
 
-from collections import defaultdict
-
 import networkx as nx
+import solara
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.figure import Figure
-import solara
-from mesa.visualization.utils import update_counter
-from mesa.space import PropertyLayer
 
 import mesa
 from mesa.experimental.cell_space import VoronoiGrid
+from mesa.space import PropertyLayer
 from mesa.visualization.utils import update_counter
 
 
 def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
-    """
-    Create a Matplotlib-based space visualization component.
+    """Create a Matplotlib-based space visualization component.
 
     Args:
         agent_portrayal (function): Function to portray agents
@@ -26,6 +22,7 @@ def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
         function: A function that creates a SpaceMatplotlib component
     """
     if agent_portrayal is None:
+
         def agent_portrayal(a):
             return {"id": a.unique_id}
 
@@ -36,7 +33,12 @@ def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
 
 
 @solara.component
-def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencies: list[any] | None = None):
+def SpaceMatplotlib(
+    model,
+    agent_portrayal,
+    propertylayer_portrayal,
+    dependencies: list[any] | None = None,
+):
     update_counter.get()
     space_fig = Figure()
     space_ax = space_fig.subplots()
@@ -47,7 +49,9 @@ def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencie
     if isinstance(space, mesa.space._Grid):
         _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
     elif isinstance(space, mesa.space.ContinuousSpace):
-        _draw_continuous_space(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+        _draw_continuous_space(
+            space, space_ax, agent_portrayal, propertylayer_portrayal, model
+        )
     elif isinstance(space, mesa.space.NetworkGrid):
         _draw_network_grid(space, space_ax, agent_portrayal)
     elif isinstance(space, VoronoiGrid):
@@ -57,8 +61,7 @@ def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencie
 
 
 def draw_property_layers(ax, space, propertylayer_portrayal, model):
-    """
-    Draw PropertyLayers on the given axes.
+    """Draw PropertyLayers on the given axes.
 
     Args:
         ax (matplotlib.axes.Axes): The axes to draw on.
@@ -71,30 +74,33 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
         if layer is None or not isinstance(layer, PropertyLayer):
             continue
 
-        cmap = portrayal.get('colormap', 'viridis')
-        alpha = portrayal.get('alpha', 0.5)
-        vmin = portrayal.get('vmin', np.min(layer.data))
-        vmax = portrayal.get('vmax', np.max(layer.data))
+        cmap = portrayal.get("colormap", "viridis")
+        alpha = portrayal.get("alpha", 0.5)
+        vmin = portrayal.get("vmin", np.min(layer.data))
+        vmax = portrayal.get("vmax", np.max(layer.data))
 
         if isinstance(cmap, list):
             cmap = LinearSegmentedColormap.from_list(layer_name, cmap)
 
-        im = ax.imshow(layer.data.T, cmap=cmap, alpha=alpha, vmin=vmin, vmax=vmax,
-                       extent=(0, space.width, 0, space.height), origin='lower')
+        im = ax.imshow(
+            layer.data.T,
+            cmap=cmap,
+            alpha=alpha,
+            vmin=vmin,
+            vmax=vmax,
+            extent=(0, space.width, 0, space.height),
+            origin="lower",
+        )
         plt.colorbar(im, ax=ax, label=layer_name)
 
 
-import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap
-from matplotlib.figure import Figure
+import numpy as np
 import solara
-from mesa.visualization.utils import update_counter
 
 
 def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
-    """
-    Create a Matplotlib-based space visualization component.
+    """Create a Matplotlib-based space visualization component.
 
     Args:
         agent_portrayal (function): Function to portray agents
@@ -104,6 +110,7 @@ def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
         function: A function that creates a SpaceMatplotlib component
     """
     if agent_portrayal is None:
+
         def agent_portrayal(a):
             return {"id": a.unique_id}
 
@@ -114,7 +121,12 @@ def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
 
 
 @solara.component
-def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencies: list[any] | None = None):
+def SpaceMatplotlib(
+    model,
+    agent_portrayal,
+    propertylayer_portrayal,
+    dependencies: list[any] | None = None,
+):
     update_counter.get()
     space_fig = Figure()
     space_ax = space_fig.subplots()
@@ -125,7 +137,9 @@ def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencie
     if isinstance(space, mesa.space._Grid):
         _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
     elif isinstance(space, mesa.space.ContinuousSpace):
-        _draw_continuous_space(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+        _draw_continuous_space(
+            space, space_ax, agent_portrayal, propertylayer_portrayal, model
+        )
     elif isinstance(space, mesa.space.NetworkGrid):
         _draw_network_grid(space, space_ax, agent_portrayal)
     elif isinstance(space, VoronoiGrid):
@@ -135,8 +149,7 @@ def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencie
 
 
 def draw_property_layers(ax, space, propertylayer_portrayal, model):
-    """
-    Draw PropertyLayers on the given axes.
+    """Draw PropertyLayers on the given axes.
 
     Args:
         ax (matplotlib.axes.Axes): The axes to draw on.
@@ -149,16 +162,23 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
         if layer is None or not isinstance(layer, PropertyLayer):
             continue
 
-        cmap = portrayal.get('colormap', 'viridis')
-        alpha = portrayal.get('alpha', 0.5)
-        vmin = portrayal.get('vmin', np.min(layer.data))
-        vmax = portrayal.get('vmax', np.max(layer.data))
+        cmap = portrayal.get("colormap", "viridis")
+        alpha = portrayal.get("alpha", 0.5)
+        vmin = portrayal.get("vmin", np.min(layer.data))
+        vmax = portrayal.get("vmax", np.max(layer.data))
 
         if isinstance(cmap, list):
             cmap = LinearSegmentedColormap.from_list(layer_name, cmap)
 
-        im = ax.imshow(layer.data.T, cmap=cmap, alpha=alpha, vmin=vmin, vmax=vmax,
-                       extent=(0, space.width, 0, space.height), origin='lower')
+        im = ax.imshow(
+            layer.data.T,
+            cmap=cmap,
+            alpha=alpha,
+            vmin=vmin,
+            vmax=vmax,
+            extent=(0, space.width, 0, space.height),
+            origin="lower",
+        )
         plt.colorbar(im, ax=ax, label=layer_name)
 
 
@@ -174,9 +194,9 @@ def _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
 
     # Draw grid lines
     for x in range(space.width + 1):
-        space_ax.axvline(x, color='gray', linestyle=':')
+        space_ax.axvline(x, color="gray", linestyle=":")
     for y in range(space.height + 1):
-        space_ax.axhline(y, color='gray', linestyle=':')
+        space_ax.axhline(y, color="gray", linestyle=":")
 
 
 def _get_agent_data(space, agent_portrayal):
@@ -207,7 +227,7 @@ def _split_and_scatter(portray_data, space_ax):
             [y for y, show in zip(portray_data["y"], mask) if show],
             s=[s for s, show in zip(portray_data["s"], mask) if show],
             c=[c for c, show in zip(portray_data["c"], mask) if show],
-            marker=marker
+            marker=marker,
         )
 
 

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -3,114 +3,212 @@
 from collections import defaultdict
 
 import networkx as nx
-import solara
+from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.figure import Figure
-from matplotlib.ticker import MaxNLocator
+import solara
+from mesa.visualization.utils import update_counter
+from mesa.space import PropertyLayer
 
 import mesa
 from mesa.experimental.cell_space import VoronoiGrid
 from mesa.visualization.utils import update_counter
 
 
-def make_space_matplotlib(agent_portrayal=None):  # noqa: D103
-    if agent_portrayal is None:
+def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
+    """
+    Create a Matplotlib-based space visualization component.
 
+    Args:
+        agent_portrayal (function): Function to portray agents
+        propertylayer_portrayal (dict): Dictionary of PropertyLayer portrayal specifications
+
+    Returns:
+        function: A function that creates a SpaceMatplotlib component
+    """
+    if agent_portrayal is None:
         def agent_portrayal(a):
             return {"id": a.unique_id}
 
     def MakeSpaceMatplotlib(model):
-        return SpaceMatplotlib(model, agent_portrayal)
+        return SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal)
 
     return MakeSpaceMatplotlib
 
 
 @solara.component
-def SpaceMatplotlib(model, agent_portrayal, dependencies: list[any] | None = None):  # noqa: D103
+def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencies: list[any] | None = None):
     update_counter.get()
     space_fig = Figure()
     space_ax = space_fig.subplots()
     space = getattr(model, "grid", None)
     if space is None:
-        # Sometimes the space is defined as model.space instead of model.grid
         space = model.space
-    if isinstance(space, mesa.space.NetworkGrid):
-        _draw_network_grid(space, space_ax, agent_portrayal)
+
+    if isinstance(space, mesa.space._Grid):
+        _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
     elif isinstance(space, mesa.space.ContinuousSpace):
-        _draw_continuous_space(space, space_ax, agent_portrayal)
+        _draw_continuous_space(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+    elif isinstance(space, mesa.space.NetworkGrid):
+        _draw_network_grid(space, space_ax, agent_portrayal)
     elif isinstance(space, VoronoiGrid):
-        _draw_voronoi(space, space_ax, agent_portrayal)
-    else:
-        _draw_grid(space, space_ax, agent_portrayal)
+        _draw_voronoi(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+
     solara.FigureMatplotlib(space_fig, format="png", dependencies=dependencies)
 
 
-# matplotlib scatter does not allow for multiple shapes in one call
+def draw_property_layers(ax, space, propertylayer_portrayal, model):
+    """
+    Draw PropertyLayers on the given axes.
+
+    Args:
+        ax (matplotlib.axes.Axes): The axes to draw on.
+        space (mesa.space._Grid): The space containing the PropertyLayers.
+        propertylayer_portrayal (dict): Dictionary of PropertyLayer portrayal specifications.
+        model (mesa.Model): The model instance.
+    """
+    for layer_name, portrayal in propertylayer_portrayal.items():
+        layer = getattr(model, layer_name, None)
+        if layer is None or not isinstance(layer, PropertyLayer):
+            continue
+
+        cmap = portrayal.get('colormap', 'viridis')
+        alpha = portrayal.get('alpha', 0.5)
+        vmin = portrayal.get('vmin', np.min(layer.data))
+        vmax = portrayal.get('vmax', np.max(layer.data))
+
+        if isinstance(cmap, list):
+            cmap = LinearSegmentedColormap.from_list(layer_name, cmap)
+
+        im = ax.imshow(layer.data.T, cmap=cmap, alpha=alpha, vmin=vmin, vmax=vmax,
+                       extent=(0, space.width, 0, space.height), origin='lower')
+        plt.colorbar(im, ax=ax, label=layer_name)
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.figure import Figure
+import solara
+from mesa.visualization.utils import update_counter
+
+
+def make_space_matplotlib(agent_portrayal=None, propertylayer_portrayal=None):
+    """
+    Create a Matplotlib-based space visualization component.
+
+    Args:
+        agent_portrayal (function): Function to portray agents
+        propertylayer_portrayal (dict): Dictionary of PropertyLayer portrayal specifications
+
+    Returns:
+        function: A function that creates a SpaceMatplotlib component
+    """
+    if agent_portrayal is None:
+        def agent_portrayal(a):
+            return {"id": a.unique_id}
+
+    def MakeSpaceMatplotlib(model):
+        return SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal)
+
+    return MakeSpaceMatplotlib
+
+
+@solara.component
+def SpaceMatplotlib(model, agent_portrayal, propertylayer_portrayal, dependencies: list[any] | None = None):
+    update_counter.get()
+    space_fig = Figure()
+    space_ax = space_fig.subplots()
+    space = getattr(model, "grid", None)
+    if space is None:
+        space = model.space
+
+    if isinstance(space, mesa.space._Grid):
+        _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+    elif isinstance(space, mesa.space.ContinuousSpace):
+        _draw_continuous_space(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+    elif isinstance(space, mesa.space.NetworkGrid):
+        _draw_network_grid(space, space_ax, agent_portrayal)
+    elif isinstance(space, VoronoiGrid):
+        _draw_voronoi(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+
+    solara.FigureMatplotlib(space_fig, format="png", dependencies=dependencies)
+
+
+def draw_property_layers(ax, space, propertylayer_portrayal, model):
+    """
+    Draw PropertyLayers on the given axes.
+
+    Args:
+        ax (matplotlib.axes.Axes): The axes to draw on.
+        space (mesa.space._Grid): The space containing the PropertyLayers.
+        propertylayer_portrayal (dict): Dictionary of PropertyLayer portrayal specifications.
+        model (mesa.Model): The model instance.
+    """
+    for layer_name, portrayal in propertylayer_portrayal.items():
+        layer = getattr(model, layer_name, None)
+        if layer is None or not isinstance(layer, PropertyLayer):
+            continue
+
+        cmap = portrayal.get('colormap', 'viridis')
+        alpha = portrayal.get('alpha', 0.5)
+        vmin = portrayal.get('vmin', np.min(layer.data))
+        vmax = portrayal.get('vmax', np.max(layer.data))
+
+        if isinstance(cmap, list):
+            cmap = LinearSegmentedColormap.from_list(layer_name, cmap)
+
+        im = ax.imshow(layer.data.T, cmap=cmap, alpha=alpha, vmin=vmin, vmax=vmax,
+                       extent=(0, space.width, 0, space.height), origin='lower')
+        plt.colorbar(im, ax=ax, label=layer_name)
+
+
+def _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model):
+    if propertylayer_portrayal:
+        draw_property_layers(space_ax, space, propertylayer_portrayal, model)
+
+    agent_data = _get_agent_data(space, agent_portrayal)
+
+    space_ax.set_xlim(0, space.width)
+    space_ax.set_ylim(0, space.height)
+    _split_and_scatter(agent_data, space_ax)
+
+    # Draw grid lines
+    for x in range(space.width + 1):
+        space_ax.axvline(x, color='gray', linestyle=':')
+    for y in range(space.height + 1):
+        space_ax.axhline(y, color='gray', linestyle=':')
+
+
+def _get_agent_data(space, agent_portrayal):
+    """Helper function to get agent data for visualization."""
+    x, y, s, c, m = [], [], [], [], []
+    for agents, pos in space.coord_iter():
+        if not agents:
+            continue
+        if not isinstance(agents, list):
+            agents = [agents]
+        for agent in agents:
+            data = agent_portrayal(agent)
+            x.append(pos[0] + 0.5)  # Center the agent in the cell
+            y.append(pos[1] + 0.5)  # Center the agent in the cell
+            default_size = (180 / max(space.width, space.height)) ** 2
+            s.append(data.get("size", default_size))
+            c.append(data.get("color", "tab:blue"))
+            m.append(data.get("shape", "o"))
+    return {"x": x, "y": y, "s": s, "c": c, "m": m}
+
+
 def _split_and_scatter(portray_data, space_ax):
-    grouped_data = defaultdict(lambda: {"x": [], "y": [], "s": [], "c": []})
-
-    # Extract data from the dictionary
-    x = portray_data["x"]
-    y = portray_data["y"]
-    s = portray_data["s"]
-    c = portray_data["c"]
-    m = portray_data["m"]
-
-    if not (len(x) == len(y) == len(s) == len(c) == len(m)):
-        raise ValueError(
-            "Length mismatch in portrayal data lists: "
-            f"x: {len(x)}, y: {len(y)}, size: {len(s)}, "
-            f"color: {len(c)}, marker: {len(m)}"
+    """Helper function to split and scatter agent data."""
+    for marker in set(portray_data["m"]):
+        mask = [m == marker for m in portray_data["m"]]
+        space_ax.scatter(
+            [x for x, show in zip(portray_data["x"], mask) if show],
+            [y for y, show in zip(portray_data["y"], mask) if show],
+            s=[s for s, show in zip(portray_data["s"], mask) if show],
+            c=[c for c, show in zip(portray_data["c"], mask) if show],
+            marker=marker
         )
-
-    # Group the data by marker
-    for i in range(len(x)):
-        marker = m[i]
-        grouped_data[marker]["x"].append(x[i])
-        grouped_data[marker]["y"].append(y[i])
-        grouped_data[marker]["s"].append(s[i])
-        grouped_data[marker]["c"].append(c[i])
-
-    # Plot each group with the same marker
-    for marker, data in grouped_data.items():
-        space_ax.scatter(data["x"], data["y"], s=data["s"], c=data["c"], marker=marker)
-
-
-def _draw_grid(space, space_ax, agent_portrayal):
-    def portray(g):
-        x = []
-        y = []
-        s = []  # size
-        c = []  # color
-        m = []  # shape
-        for i in range(g.width):
-            for j in range(g.height):
-                content = g._grid[i][j]
-                if not content:
-                    continue
-                if not hasattr(content, "__iter__"):
-                    # Is a single grid
-                    content = [content]
-                for agent in content:
-                    data = agent_portrayal(agent)
-                    x.append(i)
-                    y.append(j)
-
-                    # This is the default value for the marker size, which auto-scales
-                    # according to the grid area.
-                    default_size = (180 / max(g.width, g.height)) ** 2
-                    # establishing a default prevents misalignment if some agents are not given size, color, etc.
-                    size = data.get("size", default_size)
-                    s.append(size)
-                    color = data.get("color", "tab:blue")
-                    c.append(color)
-                    mark = data.get("shape", "o")
-                    m.append(mark)
-        out = {"x": x, "y": y, "s": s, "c": c, "m": m}
-        return out
-
-    space_ax.set_xlim(-1, space.width)
-    space_ax.set_ylim(-1, space.height)
-    _split_and_scatter(portray(space), space_ax)
 
 
 def _draw_network_grid(space, space_ax, agent_portrayal):

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -44,6 +44,7 @@ def SpaceMatplotlib(
     propertylayer_portrayal,
     dependencies: list[any] | None = None,
 ):
+    """Create a Matplotlib-based space visualization component."""
     update_counter.get()
     space_fig = Figure()
     space_ax = space_fig.subplots()
@@ -86,6 +87,7 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
             warnings.warn(
                 f"Layer {layer_name} dimensions ({data.shape}) do not match space dimensions ({width}, {height}).",
                 UserWarning,
+                stacklevel=2,
             )
 
         # Get portrayal properties, or use defaults
@@ -160,7 +162,7 @@ def _get_agent_data(space, agent_portrayal):
         if not agents:
             continue
         if not isinstance(agents, list):
-            agents = [agents]
+            agents = [agents]  # noqa PLW2901
         for agent in agents:
             data = agent_portrayal(agent)
             x.append(pos[0] + 0.5)  # Center the agent in the cell

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -93,6 +93,7 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
         alpha = portrayal.get("alpha", 1)
         vmin = portrayal.get("vmin", np.min(data))
         vmax = portrayal.get("vmax", np.max(data))
+        colorbar = portrayal.get("colorbar", True)
 
         # Draw the layer
         if "color" in portrayal:
@@ -118,7 +119,8 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
                 extent=(0, width, 0, height),
                 origin="lower",
             )
-            plt.colorbar(im, ax=ax, label=layer_name)
+            if colorbar:
+                plt.colorbar(im, ax=ax, label=layer_name)
         else:
             raise ValueError(
                 f"PropertyLayer {layer_name} portrayal must include 'color' or 'colormap'."

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -54,13 +54,11 @@ def SpaceMatplotlib(
     if isinstance(space, mesa.space._Grid):
         _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
     elif isinstance(space, mesa.space.ContinuousSpace):
-        _draw_continuous_space(
-            space, space_ax, agent_portrayal, propertylayer_portrayal, model
-        )
+        _draw_continuous_space(space, space_ax, agent_portrayal, model)
     elif isinstance(space, mesa.space.NetworkGrid):
         _draw_network_grid(space, space_ax, agent_portrayal)
     elif isinstance(space, VoronoiGrid):
-        _draw_voronoi(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+        _draw_voronoi(space, space_ax, agent_portrayal, model)
     elif space is None and propertylayer_portrayal:
         draw_property_layers(space_ax, space, propertylayer_portrayal, model)
 

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -103,7 +103,7 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
             normalized_data = (data - vmin) / (vmax - vmin)
             rgba_data = np.full((*data.shape, 4), rgba_color)
             rgba_data[..., 3] *= normalized_data * alpha
-            cmap = LinearSegmentedColormap.from_list(layer_name, [(0, 0, 0, 0), rgba_color])
+            cmap = LinearSegmentedColormap.from_list(layer_name, [(0, 0, 0, 0), (*rgba_color[:3], alpha)])
             im = ax.imshow(
                 rgba_data.transpose(1, 0, 2),
                 extent=(0, width, 0, height),

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -58,7 +58,7 @@ def SpaceMatplotlib(
     elif isinstance(space, mesa.space.NetworkGrid):
         _draw_network_grid(space, space_ax, agent_portrayal)
     elif isinstance(space, VoronoiGrid):
-        _draw_voronoi(space, space_ax, agent_portrayal, model)
+        _draw_voronoi(space, space_ax, agent_portrayal)
     elif space is None and propertylayer_portrayal:
         draw_property_layers(space_ax, space, propertylayer_portrayal, model)
 
@@ -196,7 +196,7 @@ def _draw_network_grid(space, space_ax, agent_portrayal):
     )
 
 
-def _draw_continuous_space(space, space_ax, agent_portrayal):
+def _draw_continuous_space(space, space_ax, agent_portrayal, model):
     def portray(space):
         x = []
         y = []

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -6,10 +6,9 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 import solara
-from matplotlib.colors import LinearSegmentedColormap, to_rgba
-from matplotlib.figure import Figure
 from matplotlib.cm import ScalarMappable
-from matplotlib.colors import Normalize
+from matplotlib.colors import LinearSegmentedColormap, Normalize, to_rgba
+from matplotlib.figure import Figure
 
 import mesa
 from mesa.experimental.cell_space import VoronoiGrid
@@ -103,7 +102,9 @@ def draw_property_layers(ax, space, propertylayer_portrayal, model):
             normalized_data = (data - vmin) / (vmax - vmin)
             rgba_data = np.full((*data.shape, 4), rgba_color)
             rgba_data[..., 3] *= normalized_data * alpha
-            cmap = LinearSegmentedColormap.from_list(layer_name, [(0, 0, 0, 0), (*rgba_color[:3], alpha)])
+            cmap = LinearSegmentedColormap.from_list(
+                layer_name, [(0, 0, 0, 0), (*rgba_color[:3], alpha)]
+            )
             im = ax.imshow(
                 rgba_data.transpose(1, 0, 2),
                 extent=(0, width, 0, height),

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -100,11 +100,14 @@ def test_call_space_drawer(mocker):  # noqa: D103
         "Shape": "circle",
         "color": "gray",
     }
+    propertylayer_portrayal = None
     # initialize with space drawer unspecified (use default)
     # component must be rendered for code to run
     solara.render(SolaraViz(model, components=[make_space_matplotlib(agent_portrayal)]))
     # should call default method with class instance and agent portrayal
-    mock_space_matplotlib.assert_called_with(model, agent_portrayal)
+    mock_space_matplotlib.assert_called_with(
+        model, agent_portrayal, propertylayer_portrayal
+    )
 
     # specify no space should be drawn
     mock_space_matplotlib.reset_mock()


### PR DESCRIPTION
This PR adds support for visualizing PropertyLayers in the Matplotlib-based space visualization component. It allows users to overlay PropertyLayer data on top of the existing grid and agent visualizations, or on its own.

It introduces a new `propertylayer_portrayal` parameter to customize the appearance of PropertyLayers and refactors the existing space visualization code for better modularity and flexibility.

### Motive
The PropertyLayer is becoming a key feature in Mesa, so it should be visualized easily. This feature enables users to easily visualize multiple layers of data simultaneously, such as environmental factors or agent properties, alongside the agents themselves.

### Implementation
- Added a new `propertylayer_portrayal` parameter to the `make_space_matplotlib` function.
- Implemented a `draw_property_layers` function to render PropertyLayer data using Matplotlib's `imshow`.
- Modified the `_draw_grid` function to incorporate PropertyLayer visualization before drawing agents.
- Added support for both color-based and colormap-based PropertyLayer rendering.
- Implemented alpha blending for PropertyLayer visualization to allow overlaying multiple layers.
- Added colorbar support for PropertyLayer visualization.

### Usage Examples
You can visualize multiple PropertyLayers ("grass" and "temperature" in this case) along with agents in a grid space:
```python
def agent_portrayal(agent):
    return {"color": "red", "shape": "o", "size": 20}

propertylayer_portrayal = {
    "grass": {
        "colormap": "Greens",
        "alpha": 1,
    },
    "temperature": {
        "colormap": "coolwarm",
        "alpha": 0.333,
        "vmin": 0,
        "vmax": 100
    },
}

model = ExampleModel(10, 10)
page = SolaraViz(
    model,
    [make_space_matplotlib(agent_portrayal, propertylayer_portrayal)],
)
```
![image](https://github.com/user-attachments/assets/45a7eab4-3225-451b-aa98-6fd5702c1c22)

You can also use a single color for a PropertyLayer. Here we render the "cell_layer" PropertyLayer using shades of black, with the highest value having 0% opacity and the lowest value having 100% opacity. For Game of Life that means alive cells are fully black, and dead cells transparent.

```python
propertylayer_portrayal = {
    "cell_layer": {
        "color": "Black",
        "alpha": 1,
        "colorbar": False,
    },
}
```
![image](https://github.com/user-attachments/assets/b8b576be-219e-4711-8dc8-112631947093)

Any [matplotlib color](https://matplotlib.org/stable/api/colors_api.html#module-matplotlib.colors) is valid. The highest value will have that color with 0% opacity, the lowest with 100% opacity (which can again be scaled with modifying `vmin` and `vmax`).

## Additional Notes
- Currently supported spaces: Grid and standalone PropertyLayers.
  - ContinuousSpace, NetworkGrid, and VoronoiGrid can be added in future PR(s).
- Future work could include adding support for additional space types and improving the efficiency of rendering for large grids.
- The PR includes updates to handle different sizes between the PropertyLayer and the grid space, issuing warnings when there's a mismatch.
- Colorbar display can be toggled using the `colorbar` parameter in the portrayal dictionary.
- The coordinate system has been validated to ensure consistent axis directions between PropertyLayers and the grid space.
- A demo using the Game of Life model has been implemented in a separate PR (https://github.com/projectmesa/mesa-examples/pull/214) to showcase these new visualization capabilities.

### TODO
- [x] Scale colors over alpha (aside from colormap)
- [x] Add switch for colorbars and fix warning
- [x] Validate coordinate system
  - [x] Handle different sizes (just warn)
  - [x] Axis in same direction
- [x] Demo GOL (https://github.com/projectmesa/mesa-examples/pull/214)
- [ ] Add tests
- [x] Write up PR