### PR TITLE
CI: Add GitHub Action to append installation instructions to PRs

### DIFF
--- a/.github/workflows/pr_branch_message.yml
+++ b/.github/workflows/pr_branch_message.yml
@@ -1,8 +1,7 @@
-name: PR install note
-
+name: PR Install Note
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   add-install-note:
@@ -19,12 +18,14 @@ jobs:
           FORK_NAME=$(gh pr view $PR_NUMBER --json headRepositoryOwner -q .headRepositoryOwner.login)
           PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName -q .headRefName)
           REPO_OWNER=${FORK_NAME:-projectmesa}
-          INSTALL_NOTE="
+          INSTALL_NOTE=$(cat << EOF
 
-You can install this PR branch with:
-\`\`\`
-pip install -U -e git+https://github.com/${REPO_OWNER}/mesa@${PR_BRANCH}#egg=mesa
-\`\`\`"
+          You can install this PR branch with:
+          \`\`\`
+          pip install -U -e git+https://github.com/${REPO_OWNER}/mesa@${PR_BRANCH}#egg=mesa
+          \`\`\`
+          EOF
+          )
 
           NEW_PR_BODY="${PR_BODY}${INSTALL_NOTE}"
           gh pr edit $PR_NUMBER --body "$NEW_PR_BODY"

--- a/.github/workflows/pr_branch_message.yml
+++ b/.github/workflows/pr_branch_message.yml
@@ -1,0 +1,30 @@
+name: PR install note
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-install-note:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Add PR install note
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+          FORK_NAME=$(gh pr view $PR_NUMBER --json headRepositoryOwner -q .headRepositoryOwner.login)
+          PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName -q .headRefName)
+          REPO_OWNER=${FORK_NAME:-projectmesa}
+          INSTALL_NOTE="
+
+You can install this PR branch with:
+\`\`\`
+pip install -U -e git+https://github.com/${REPO_OWNER}/mesa@${PR_BRANCH}#egg=mesa
+\`\`\`"
+
+          NEW_PR_BODY="${PR_BODY}${INSTALL_NOTE}"
+          gh pr edit $PR_NUMBER --body "$NEW_PR_BODY"


### PR DESCRIPTION
This PR adds a simple workflow that adds the installation instructions to each PR. It helps contributors, testers and reviews quickly get an installation command to test a PR, especially if they want to install it to use with other packages such as Mesa examples.

For example, for this PR the following message would be added:

You can install this PR branch with:
```
pip install -U -e git+https://github.com/EwoutH/mesa@pr_message#egg=mesa
```