### PR TITLE
Update version and release notes for 3.0.0b0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,10 @@ We're proud to release the first Mesa 3.0 beta! This pre-release announces that 
 
 In this beta, not so much has changed as in the alphas (we're stabilizing, that's a good sign), but there are still a few notable things:
 - Agents now have to be initialized without their `unique_id`. See [#2328](https://github.com/projectmesa/mesa/pull/2328) and the [Migration guide](https://mesa.readthedocs.io/latest/migration_guide.html#automatic-assignment-of-unique-id-to-agents).
+- PropertyLayers can now be visualized! See [#2336](https://github.com/projectmesa/mesa/pull/2336) for details and some examples, and [mesa-examples#214](https://github.com/projectmesa/mesa-examples/pull/214) as a simple example model.
 - We reduced the core dependencies of Mesa, so that's a lighter and simpler install. You can now use extras to install the dependencies, for example add `[viz]` to install all visualisation dependencies: `pip install -U --pre mesa[viz]`. See [#2265](https://github.com/projectmesa/mesa/pull/2265) for details.
 - The [Mesa Overview](https://mesa.readthedocs.io/latest/overview.html) as fully updated for 3.0. We highly recommend reading though it!
-- We made some more progress on the experimental Cell Space, adding movement and integrating the PropertyLayer. Development continues during the betas and
+- We made some more progress on the experimental Cell Space, adding movement and integrating the PropertyLayer. Among others, Agents have nu initial movement capabilities for grids. Development continues during the betas and
 
 We plan to release one or two more beta's in the coming weeks, and tag a release candidate and Mesa 3.0 late October. In the [v3.0 milestone](https://github.com/projectmesa/mesa/milestone/43) are the critical items on our todo-list.
 
@@ -23,9 +24,12 @@ We're very curious what you think, try it out and ask any questions or share any
 ## What's Changed
 ### ⚠️ Breaking changes
 * update `Agent.__init__` to remove deprecation warning by @quaquel in https://github.com/projectmesa/mesa/pull/2328
+### 🎉 New features added
+* Visualize PropertyLayers by @EwoutH in https://github.com/projectmesa/mesa/pull/2336
 ### 🧪 Experimental features
 * Encapsulate cell movement in properties by @quaquel in https://github.com/projectmesa/mesa/pull/2333
 * experimental: Integrate PropertyLayers into cell space by @EwoutH in https://github.com/projectmesa/mesa/pull/2319
+* Generalize CellAgent by @Corvince in https://github.com/projectmesa/mesa/pull/2292
 ### 🛠 Enhancements made
 * Reduce core dependencies, split in optional dependencies by @EwoutH in https://github.com/projectmesa/mesa/pull/2265
 ### 🐛 Bugs fixed
@@ -36,6 +40,7 @@ We're very curious what you think, try it out and ask any questions or share any
 ### 🔧 Maintenance
 * tests: Resolve warnings by removing scheduler and updating arguments by @EwoutH in https://github.com/projectmesa/mesa/pull/2329
 * add super call to Model and remove self.schedule by @quaquel in https://github.com/projectmesa/mesa/pull/2334
+### Other changes
 * Deprecate `initialize_data_collector` by @EwoutH in https://github.com/projectmesa/mesa/pull/2327
 
 **Full Changelog**: https://github.com/projectmesa/mesa/compare/v3.0.0a5...v3.0.0b0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,45 @@
 ---
 title: Release History
 ---
+# 3.0.0b0 (2024-10-04)
+## Highlights
+We're proud to release the first Mesa 3.0 beta! This pre-release announces that we're ready for Mesa 3.0 to be tested by all our regular users. We try to not making breaking changes anymore, but focus on resolving bugs and imperfections.
+
+In this beta, not so much has changed as in the alphas (we're stabilizing, that's a good sign), but there are still a few notable things:
+- Agents now have to be initialized without their `unique_id`. See [#2328](https://github.com/projectmesa/mesa/pull/2328) and the [Migration guide](https://mesa.readthedocs.io/latest/migration_guide.html#automatic-assignment-of-unique-id-to-agents).
+- We reduced the core dependencies of Mesa, so that's a lighter and simpler install. You can now use extras to install the dependencies, for example add `[viz]` to install all visualisation dependencies: `pip install -U --pre mesa[viz]`. See [#2265](https://github.com/projectmesa/mesa/pull/2265) for details.
+- The [Mesa Overview](https://mesa.readthedocs.io/latest/overview.html) as fully updated for 3.0. We highly recommend reading though it!
+- We made some more progress on the experimental Cell Space, adding movement and integrating the PropertyLayer. Development continues during the betas and
+
+We plan to release one or two more beta's in the coming weeks, and tag a release candidate and Mesa 3.0 late October. In the [v3.0 milestone](https://github.com/projectmesa/mesa/milestone/43) are the critical items on our todo-list.
+
+You can install this pre-release as usual with:
+
+```bash
+pip install --upgrade --pre mesa
+```
+We're very curious what you think, try it out and ask any questions or share any feedback [here](https://github.com/projectmesa/mesa/discussions/2338)!
+
+## What's Changed
+### ⚠️ Breaking changes
+* update `Agent.__init__` to remove deprecation warning by @quaquel in https://github.com/projectmesa/mesa/pull/2328
+### 🧪 Experimental features
+* Encapsulate cell movement in properties by @quaquel in https://github.com/projectmesa/mesa/pull/2333
+* experimental: Integrate PropertyLayers into cell space by @EwoutH in https://github.com/projectmesa/mesa/pull/2319
+### 🛠 Enhancements made
+* Reduce core dependencies, split in optional dependencies by @EwoutH in https://github.com/projectmesa/mesa/pull/2265
+### 🐛 Bugs fixed
+* viz: stop running and disable buttons when model.running is False by @wang-boyu in https://github.com/projectmesa/mesa/pull/2332
+### 📜 Documentation improvements
+* docs: Update overview for Mesa 3.0 by @EwoutH in https://github.com/projectmesa/mesa/pull/2317
+* Readthedocs: Add version switch and update URL by @EwoutH in https://github.com/projectmesa/mesa/pull/2324
+### 🔧 Maintenance
+* tests: Resolve warnings by removing scheduler and updating arguments by @EwoutH in https://github.com/projectmesa/mesa/pull/2329
+* add super call to Model and remove self.schedule by @quaquel in https://github.com/projectmesa/mesa/pull/2334
+* Deprecate `initialize_data_collector` by @EwoutH in https://github.com/projectmesa/mesa/pull/2327
+
+**Full Changelog**: https://github.com/projectmesa/mesa/compare/v3.0.0a5...v3.0.0b0
+
 # 3.0.0a5 (2024-09-21)
 ## Highlights
 Mesa v3.0 alpha 5 release contains many quality of life updates, a big new feature for the DataCollector and a major deprecation.

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 __title__ = "mesa"
-__version__ = "3.0.0a5"
+__version__ = "3.0.0b0"
 __license__ = "Apache 2.0"
 _this_year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
 __copyright__ = f"Copyright {_this_year} Project Mesa Team"


### PR DESCRIPTION
Update version and release notes for our first 3.0 beta release, Mesa `3.0.0b0`!

Beta's are different from Alpha's that we actively invite all users to test this release. We try to not make big breaking changes anymore, and we actively work on patching the last bugs and imperfections and addressing any lacking documentation.

Draft release [available here](https://github.com/projectmesa/mesa/releases/tag/untagged-d21faf865ade0ff19a24). I plan to release tomorrow morning (CET).

Not really relevant for this PR, but proposed timeline:
- Friday 4th: Mesa 3.0 beta 0
- Friday 11th: Mesa 3.0 beta 1
- Friday 18th: Mesa 3.0 release candidate
- Friday 25th: Mesa 3.0 stable release