### PR TITLE
Add convenience properties for grid width and height

### DIFF
--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -22,7 +22,21 @@ class Grid(DiscreteSpace[T], Generic[T]):
         random (Random): the random number generator
         _try_random (bool): whether to get empty cell be repeatedly trying random cell
 
+    Notes:
+        width and height are accessible via properties, higher dimensions can be retrieved via dimensions
+
     """
+
+    @property
+    def width(self) -> int:
+        """convenience access to the width of the grid."""
+        return self.dimensions[0]
+
+    @property
+    def height(self) -> int:
+        """convenience access to the height of the grid."""
+        return self.dimensions[1]
+
 
     def __init__(
         self,

--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -29,14 +29,13 @@ class Grid(DiscreteSpace[T], Generic[T]):
 
     @property
     def width(self) -> int:
-        """convenience access to the width of the grid."""
+        """Convenience access to the width of the grid."""
         return self.dimensions[0]
 
     @property
     def height(self) -> int:
-        """convenience access to the height of the grid."""
+        """Convenience access to the height of the grid."""
         return self.dimensions[1]
-
 
     def __init__(
         self,


### PR DESCRIPTION
90% of all use cases of grid will be 2D so it is convenient to have easy access to the width and the height of the grid. 

While porting the examples over to the experimental grid spaces, I frequently need to write `self.grid.dimensions[0]` etc. This makes it a bit more readable because I can just do `self.grid.width` etc.