### PR TITLE
Add Model.rng for SPEC-7 compliant numpy random number generation

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -45,11 +45,11 @@ class Model:
     """
 
     def __init__(
-            self,
-            *args: Any,
-            seed: float | None = None,
-            rng: RNGLike | SeedLike | None = None,
-            **kwargs: Any,
+        self,
+        *args: Any,
+        seed: float | None = None,
+        rng: RNGLike | SeedLike | None = None,
+        **kwargs: Any,
     ) -> None:
         """Create a new model.
 
@@ -65,7 +65,7 @@ class Model:
             kwargs: keyword arguments to pass onto super
 
         Notes:
-            you have to pass either seed or rng, but not both. 
+            you have to pass either seed or rng, but not both.
 
         """
         super().__init__(*args, **kwargs)
@@ -76,17 +76,18 @@ class Model:
             raise ValueError("you have to pass either rng or seed, not both")
         elif seed is None and rng is None:
             pass
-        elif seed is None:
+        elif seed is None or rng is None:
             seed = rng
-        elif rng is None:
-            seed = rng
-
 
         self.rng: np.random.Generator = np.random.default_rng(rng)
-        self._rng: dict = self.rng.bit_generator.state  # this allows for reproducing the rng
+        self._rng: dict = (
+            self.rng.bit_generator.state
+        )  # this allows for reproducing the rng
 
         self.random = random.Random(seed)
-        self._random = self.random.getstate()[1] # this allows for reproducing stdlib.random
+        self._random = self.random.getstate()[
+            1
+        ]  # this allows for reproducing stdlib.random
 
         # Wrap the user-defined step method
         self._user_step = self.step
@@ -235,11 +236,11 @@ class Model:
         self.rng = np.random.default_rng(rng)
 
     def initialize_data_collector(
-            self,
-            model_reporters=None,
-            agent_reporters=None,
-            agenttype_reporters=None,
-            tables=None,
+        self,
+        model_reporters=None,
+        agent_reporters=None,
+        agenttype_reporters=None,
+        tables=None,
     ) -> None:
         """Initialize the data collector for the model.
 

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -82,9 +82,7 @@ class Model:
             rng = seed
 
         self.rng: np.random.Generator = np.random.default_rng(rng)
-        self._rng: dict = (
-            self.rng.bit_generator.state
-        )  # this allows for reproducing the rng
+        self._rng: dict = self.rng.bit_generator.state # this allows for reproducing the rng
 
         if seed is None:
             seed = int(self.rng.integers(np.iinfo(np.int32).max))
@@ -237,6 +235,7 @@ class Model:
             seed: A new seed for the RNG; if None, reset using the current seed
         """
         self.rng = np.random.default_rng(rng)
+        self._rng = self.rng.bit_generator.state
 
     def initialize_data_collector(
         self,

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -45,11 +45,11 @@ class Model:
     """
 
     def __init__(
-        self,
-        *args: Any,
-        seed: float | None = None,
-        rng: RNGLike | SeedLike | None = None,
-        **kwargs: Any,
+            self,
+            *args: Any,
+            seed: float | None = None,
+            rng: RNGLike | SeedLike | None = None,
+            **kwargs: Any,
     ) -> None:
         """Create a new model.
 
@@ -64,19 +64,29 @@ class Model:
                   `numpy.random.default_rng` to instantiate a `Generator`.
             kwargs: keyword arguments to pass onto super
 
+        Notes:
+            you have to pass either seed or rng, but not both. 
+
         """
         super().__init__(*args, **kwargs)
         self.running = True
         self.steps: int = 0
 
-        self._seed = seed
-        if self._seed is None:
-            # We explicitly specify the seed here so that we know its value in advance.
-            self._seed = random.random()
-        self.rng: np.random.Generator = np.random.default_rng(rng)
-        self._rng: dict = self.rng.__getstate__()  # this allows for reproducing the rng
+        if (seed is not None) and (rng is not None):
+            raise ValueError("you have to pass either rng or seed, not both")
+        elif seed is None and rng is None:
+            pass
+        elif seed is None:
+            seed = rng
+        elif rng is None:
+            seed = rng
 
-        self.random = random.Random(self._seed)
+
+        self.rng: np.random.Generator = np.random.default_rng(rng)
+        self._rng: dict = self.rng.bit_generator.state  # this allows for reproducing the rng
+
+        self.random = random.Random(seed)
+        self._random = self.random.getstate()[1] # this allows for reproducing stdlib.random
 
         # Wrap the user-defined step method
         self._user_step = self.step
@@ -225,11 +235,11 @@ class Model:
         self.rng = np.random.default_rng(rng)
 
     def initialize_data_collector(
-        self,
-        model_reporters=None,
-        agent_reporters=None,
-        agenttype_reporters=None,
-        tables=None,
+            self,
+            model_reporters=None,
+            agent_reporters=None,
+            agenttype_reporters=None,
+            tables=None,
     ) -> None:
         """Initialize the data collector for the model.
 

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -76,9 +76,7 @@ class Model:
             raise ValueError("you have to pass either rng or seed, not both")
         elif seed is None and rng is None:
             pass
-        elif seed is None or rng is None:
-            seed = rng
-        elif rng is None:
+        elif seed is None or rng is None or rng is None:
             seed = rng
 
         self.rng: np.random.Generator = np.random.default_rng(rng)

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -16,6 +16,12 @@ from typing import Any
 from mesa.agent import Agent, AgentSet
 from mesa.datacollection import DataCollector
 
+from collections.abc import Sequence
+import numpy as np
+
+SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
+RNGLike = np.random.Generator | np.random.BitGenerator
+
 
 class Model:
     """Base class for models in the Mesa ABM library.
@@ -28,7 +34,8 @@ class Model:
         running: A boolean indicating if the model should continue running.
         schedule: An object to manage the order and execution of agent steps.
         steps: the number of times `model.step()` has been called.
-        random: a seeded random number generator.
+        random: a seeded python.random number generator.
+        rng : a seeded numpy.random.Generator
 
     Notes:
         Model.agents returns the AgentSet containing all agents registered with the model. Changing
@@ -37,7 +44,8 @@ class Model:
 
     """
 
-    def __init__(self, *args: Any, seed: float | None = None, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, seed: float | None = None, rng: RNGLike | SeedLike | None = None,
+                 **kwargs: Any) -> None:
         """Create a new model.
 
         Overload this method with the actual code to initialize the model. Always start with super().__init__()
@@ -46,7 +54,11 @@ class Model:
         Args:
             args: arguments to pass onto super
             seed: the seed for the random number generator
+            rng : Pseudorandom number generator state. When `rng` is None, a new `numpy.random.Generator` is created
+                  using entropy from the operating system. Types other than `numpy.random.Generator` are passed to
+                  `numpy.random.default_rng` to instantiate a `Generator`.
             kwargs: keyword arguments to pass onto super
+
         """
         super().__init__(*args, **kwargs)
         self.running = True
@@ -54,9 +66,11 @@ class Model:
 
         self._seed = seed
         if self._seed is None:
-            # We explicitly specify the seed here so that we know its value in
-            # advance.
+            # We explicitly specify the seed here so that we know its value in advance.
             self._seed = random.random()
+        self.rng: np.random.Generator = np.random.default_rng(rng)
+        self._rng: dict = self.rng.__getstate__()  # this allows for reproducing the rng
+
         self.random = random.Random(self._seed)
 
         # Wrap the user-defined step method
@@ -197,12 +211,20 @@ class Model:
         self.random.seed(seed)
         self._seed = seed
 
+    def reset_rng(self, rng: RNGLike | SeedLike | None = None) -> None:
+        """Reset the model random number generator.
+
+        Args:
+            seed: A new seed for the RNG; if None, reset using the current seed
+        """
+        self.rng = np.random.default_rng(rng)
+
     def initialize_data_collector(
-        self,
-        model_reporters=None,
-        agent_reporters=None,
-        agenttype_reporters=None,
-        tables=None,
+            self,
+            model_reporters=None,
+            agent_reporters=None,
+            agenttype_reporters=None,
+            tables=None,
     ) -> None:
         """Initialize the data collector for the model.
 

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -78,16 +78,19 @@ class Model:
             pass
         elif seed is None or rng is None:
             seed = rng
+        elif rng is None:
+            rng = seed
 
         self.rng: np.random.Generator = np.random.default_rng(rng)
         self._rng: dict = (
             self.rng.bit_generator.state
         )  # this allows for reproducing the rng
 
+        if seed is None:
+            seed = int(self.rng.integers(np.iinfo(np.int32).max))
+
         self.random = random.Random(seed)
-        self._random = self.random.getstate()[
-            1
-        ]  # this allows for reproducing stdlib.random
+        self._seed = seed  # this allows for reproducing stdlib.random
 
         # Wrap the user-defined step method
         self._user_step = self.step

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -9,15 +9,15 @@ from __future__ import annotations
 
 import random
 import warnings
+from collections.abc import Sequence
 
 # mypy
 from typing import Any
 
+import numpy as np
+
 from mesa.agent import Agent, AgentSet
 from mesa.datacollection import DataCollector
-
-from collections.abc import Sequence
-import numpy as np
 
 SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
 RNGLike = np.random.Generator | np.random.BitGenerator
@@ -44,8 +44,13 @@ class Model:
 
     """
 
-    def __init__(self, *args: Any, seed: float | None = None, rng: RNGLike | SeedLike | None = None,
-                 **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        seed: float | None = None,
+        rng: RNGLike | SeedLike | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Create a new model.
 
         Overload this method with the actual code to initialize the model. Always start with super().__init__()
@@ -220,11 +225,11 @@ class Model:
         self.rng = np.random.default_rng(rng)
 
     def initialize_data_collector(
-            self,
-            model_reporters=None,
-            agent_reporters=None,
-            agenttype_reporters=None,
-            tables=None,
+        self,
+        model_reporters=None,
+        agent_reporters=None,
+        agenttype_reporters=None,
+        tables=None,
     ) -> None:
         """Initialize the data collector for the model.
 

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -81,15 +81,21 @@ class Model:
                 self.rng.bit_generator.state
             )  # this allows for reproducing the rng
 
-            seed = int(self.rng.integers(np.iinfo(np.int32).max))
-            self.random = random.Random(seed)
+            try:
+                self.random = random.Random(rng)
+            except TypeError:
+                seed = int(self.rng.integers(np.iinfo(np.int32).max))
+                self.random = random.Random(seed)
             self._seed = seed  # this allows for reproducing stdlib.random
         elif rng is None:
             self.random = random.Random(seed)
             self._seed = seed  # this allows for reproducing stdlib.random
 
-            rng = self.random.randint(0, sys.maxsize)
-            self.rng: np.random.Generator = np.random.default_rng(rng)
+            try:
+                self.rng: np.random.Generator = np.random.default_rng(rng)
+            except TypeError:
+                rng = self.random.randint(0, sys.maxsize)
+                self.rng: np.random.Generator = np.random.default_rng(rng)
             self._rng = self.rng.bit_generator.state
 
         # Wrap the user-defined step method

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -77,7 +77,9 @@ class Model:
             raise ValueError("you have to pass either rng or seed, not both")
         elif seed is None:
             self.rng: np.random.Generator = np.random.default_rng(rng)
-            self._rng = self.rng.bit_generator.state  # this allows for reproducing the rng
+            self._rng = (
+                self.rng.bit_generator.state
+            )  # this allows for reproducing the rng
 
             seed = int(self.rng.integers(np.iinfo(np.int32).max))
             self.random = random.Random(seed)
@@ -89,7 +91,6 @@ class Model:
             rng = self.random.randint(0, sys.maxsize)
             self.rng: np.random.Generator = np.random.default_rng(rng)
             self._rng = self.rng.bit_generator.state
-
 
         # Wrap the user-defined step method
         self._user_step = self.step

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -76,8 +76,10 @@ class Model:
             raise ValueError("you have to pass either rng or seed, not both")
         elif seed is None and rng is None:
             pass
-        elif seed is None or rng is None or rng is None:
+        elif seed is None:
             seed = rng
+        elif rng is None:
+            rng = seed
 
         self.rng: np.random.Generator = np.random.default_rng(rng)
         self._rng: dict = (

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -79,7 +79,7 @@ class Model:
         elif seed is None or rng is None:
             seed = rng
         elif rng is None:
-            rng = seed
+            seed = rng
 
         self.rng: np.random.Generator = np.random.default_rng(rng)
         self._rng: dict = (

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -82,7 +82,9 @@ class Model:
             rng = seed
 
         self.rng: np.random.Generator = np.random.default_rng(rng)
-        self._rng: dict = self.rng.bit_generator.state # this allows for reproducing the rng
+        self._rng: dict = (
+            self.rng.bit_generator.state
+        )  # this allows for reproducing the rng
 
         if seed is None:
             seed = int(self.rng.integers(np.iinfo(np.int32).max))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -48,6 +48,24 @@ def test_reset_randomizer(newseed=42):
     assert model._seed == newseed
 
 
+def test_reset_rng(newseed=42):
+    """Test resetting the random seed on the model."""
+    model = Model(rng=5)
+    old_rng = model.rng.__getstate__()
+
+    model.reset_rng(rng=6)
+    new_rng = model.rng.__getstate__()
+
+    assert old_rng != new_rng
+
+    old_rng = new_rng
+    model.reset_rng()
+    new_rng = model.rng.__getstate__()
+
+    assert old_rng != new_rng
+
+
+
 def test_agent_types():
     """Test Mode.agent_types property."""
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -51,10 +51,10 @@ def test_reset_randomizer(newseed=42):
 def test_reset_rng(newseed=42):
     """Test resetting the random seed on the model."""
     model = Model(rng=5)
-    old_rng = model.rng.__getstate__()
+    old_rng = model._rng
 
     model.reset_rng(rng=6)
-    new_rng = model.rng.__getstate__()
+    new_rng = model._rng
 
     assert old_rng != new_rng
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -65,7 +65,6 @@ def test_reset_rng(newseed=42):
     assert old_rng != new_rng
 
 
-
 def test_agent_types():
     """Test Mode.agent_types property."""
 


### PR DESCRIPTION
This PR adds a [SPEC 7](https://scientific-python.org/specs/spec-0007/) compliant numpy random number generator to the Model class. 

**Implementation**
I have chosen a straightforward approach. I have added an additional optional keyword argument `rng` that can be used to seed the `numpy.random.Generator` instance when instantiating a model. I have also added 2 new attributes to `Model`: `rng` and `_rng`. The first is the generator which can be used analogously to model.random. The second is `_rng` which is the dictionary describing the state of the numpy.random.Generator instance. Knowing this dict allows for reproducibility.

The code itself and e.g., the typing behavior is lifted straight from SPEC 7.  

At the moment, a user has to pass either seed or rng, but not both which will raise a value error. The value passed for the one will be used for the other as well. If this argument is invalid, a valid integer based seed/rng number will be generated instead. What does this mean practically: if you pass seed we start with seeding `random.Random`. We try to use seed also for `numpy.random.default_rng`. If this raises a type error because seed is not valid here (e.g., seed is a float). Instead, we draw a valid integer via the seeded `random.Random()`. It works the same way if you only pass rng. So we create a Generator, try to use rgn for `random.Random`. If this failes because it is e.g. an ArrayLike sequence of ints, we draw a random int to use for `random.Random(()`


**What's next?**
At present, I have not touched the existing random throughout the code base. SPEC 7 is only about numpy and does not imply anything for python.random. It is for me an open question whether we should completely deprecate python.random throughout mesa in favor of numpy.random. I am inclined to be in favor of making this change because the quality of the random number generators in numpy is superior (long story about mersene twister's "bad" behavior when seeded with non 32 bit numbers or with adjacent numbers in case of seed analysis). However, this requires a substantial effort throughout the code base and might come with a performance penalty. What do others think and should we do this before MESA 3.0 becomes stable?