### PR TITLE
experimental init: Fix Solara import by making it lazy

### DIFF
--- a/mesa/experimental/__init__.py
+++ b/mesa/experimental/__init__.py
@@ -2,6 +2,9 @@
 
 from mesa.experimental import cell_space
 
-from .solara_viz import JupyterViz, Slider, SolaraViz, make_text
-
-__all__ = ["cell_space", "JupyterViz", "SolaraViz", "make_text", "Slider"]
+try:
+    from .solara_viz import JupyterViz, Slider, SolaraViz, make_text
+    __all__ = ["cell_space", "JupyterViz", "Slider", "SolaraViz", "make_text"]
+except ImportError:
+    print("Could not import SolaraViz. If you need it, install with 'pip install --pre mesa[viz]'")
+    __all__ = ["cell_space"]

--- a/mesa/experimental/__init__.py
+++ b/mesa/experimental/__init__.py
@@ -4,7 +4,10 @@ from mesa.experimental import cell_space
 
 try:
     from .solara_viz import JupyterViz, Slider, SolaraViz, make_text
+
     __all__ = ["cell_space", "JupyterViz", "Slider", "SolaraViz", "make_text"]
 except ImportError:
-    print("Could not import SolaraViz. If you need it, install with 'pip install --pre mesa[viz]'")
+    print(
+        "Could not import SolaraViz. If you need it, install with 'pip install --pre mesa[viz]'"
+    )
     __all__ = ["cell_space"]


### PR DESCRIPTION
In the experimental `__init__.py`, it always tries to import the "old" solara_viz module, even if it's not needed because only the cell space is used. This PR wraps that in a try block to also allow using the experimental cell space without Solara installed.

Quick and dirty fix for https://github.com/projectmesa/mesa/issues/2343, follow up after https://github.com/projectmesa/mesa/pull/2265, unblocks https://github.com/projectmesa/mesa-examples/pull/198.