### PR TITLE
Code coverage: ignore experimental and visualization

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -6,8 +6,8 @@ coverage:
         threshold: 1%
 
 ignore:
-  - "experimental/**"
   - "benchmarks/**"
-  - "visualization/**"
+  - "mesa/experimental/**"
+  - "mesa/visualization/**"
 
 comment: off

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -6,7 +6,8 @@ coverage:
         threshold: 1%
 
 ignore:
-  - "**experimental/"
+  - "experimental/**"
   - "benchmarks/**"
+  - "visualization/**"
 
 comment: off


### PR DESCRIPTION
As raised by @EwoutH frequent failing codecov tests can easily lead to missing other test failures. 

This PR fixes the "experimental" ignore, because we can be more lenient with experimental features and introduces a "visualization" ignore. Code coverage is mostly meaningful for unit tests, but unit testing visualization code is not always helpful. We still should do something about testing our visualization, but this should primarily aim at integration tests, not unit tests.

