### PR TITLE
fix: register agent after creating unique_id and pos attributes

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -62,9 +62,9 @@ class Agent:
         super().__init__(*args, **kwargs)
 
         self.model: Model = model
-        self.model.register_agent(self)
         self.unique_id: int = next(self._ids[model])
         self.pos: Position | None = None
+        self.model.register_agent(self)
 
     def remove(self) -> None:
         """Remove and delete the agent from the model."""


### PR DESCRIPTION
One gis example uses agent's `unique_id` to compare and hash agents: https://github.com/projectmesa/mesa-examples/blob/5758b6504fb26a2af05d861f29d32a81a07200f6/gis/agents_and_networks/src/agent/building.py#L34-L40

It was working until https://github.com/projectmesa/mesa/pull/2328, in which the call to `self.model.register_agent(self)` in `Agent.__init__()` was moved from _below_ `self.unique_id = next(self._ids[model])` to _above_ it.

As a result, in the gis example we now have the following error message:

```bash
File "/Users/boyu/GitHubProjects/mesa-examples/gis/agents_and_networks/src/agent/building.py", line 23, in __init__
    super().__init__(model=model, geometry=geometry, crs=crs)
  File "/Users/boyu/GitHubProjects/mesa-examples/venv/lib/python3.12/site-packages/mesa_geo/geoagent.py", line 36, in __init__
    Agent.__init__(self, model)
  File "/Users/boyu/GitHubProjects/mesa-examples/venv/lib/python3.12/site-packages/mesa/agent.py", line 65, in __init__
    self.model.register_agent(self)
  File "/Users/boyu/GitHubProjects/mesa-examples/venv/lib/python3.12/site-packages/mesa/model.py", line 145, in register_agent
    self._agents[agent] = None
    ~~~~~~~~~~~~^^^^^^^
  File "/Users/boyu/GitHubProjects/mesa-examples/gis/agents_and_networks/src/agent/building.py", line 40, in __hash__
    return hash(self.unique_id)
                ^^^^^^^^^^^^^^
AttributeError: 'Building' object has no attribute 'unique_id'
```

This PR should fix it. But I'm not very sure whether this will cause any trouble.