### PR TITLE
Release notes: Add example category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,6 +19,9 @@ changelog:
     - title: 🐛 Bugs fixed
       labels:
         - bug
+    - title: 🔍 Examples updated
+      labels:
+        - example
     - title: 📜 Documentation improvements
       labels:
         - docs


### PR DESCRIPTION
Update the release note generation configuration by adding an example category (below bugs and above docs).

This will enable PRs labeled with the "[example](https://github.com/projectmesa/mesa/issues?q=label%3Aexample+)" label to get listed (if they don't have other labels above it) in their own category in the release notes.

It will look something like:

![image](https://github.com/user-attachments/assets/e1c6b46a-9bee-4a30-9280-e7e263e41958)

See [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) for details about ordering and such.