### PR TITLE
Ruff basic examples

### DIFF
--- a/benchmarks/BoltzmannWealth/boltzmann_wealth.py
+++ b/benchmarks/BoltzmannWealth/boltzmann_wealth.py
@@ -70,7 +70,7 @@ class BoltzmannWealth(mesa.Model):
             n: the number of steps for which to run the model
 
         """
-        for _i in range(n):
+        for _ in range(n):
             self.step()
 
 

--- a/examples/basic/boid_flockers/agents.py
+++ b/examples/basic/boid_flockers/agents.py
@@ -1,10 +1,10 @@
-from mesa import Agent
 import numpy as np
+
+from mesa import Agent
 
 
 class Boid(Agent):
-    """
-    A Boid-style flocker agent.
+    """A Boid-style flocker agent.
 
     The agent follows three behaviors to flock:
         - Cohesion: steering towards neighboring agents.
@@ -28,8 +28,7 @@ class Boid(Agent):
         separate=0.015,
         match=0.05,
     ):
-        """
-        Create a new Boid flocker agent.
+        """Create a new Boid flocker agent.
 
         Args:
             speed: Distance to move per step.
@@ -51,10 +50,7 @@ class Boid(Agent):
         self.neighbors = None
 
     def step(self):
-        """
-        Get the Boid's neighbors, compute the new vector, and move accordingly.
-        """
-
+        """Get the Boid's neighbors, compute the new vector, and move accordingly."""
         self.neighbors = self.model.space.get_neighbors(self.pos, self.vision, False)
         n = 0
         match_vector, separation_vector, cohere = np.zeros((3, 2))

--- a/examples/basic/boid_flockers/app.py
+++ b/examples/basic/boid_flockers/app.py
@@ -1,6 +1,7 @@
 from model import BoidFlockers
-from mesa.visualization import SolaraViz, make_space_matplotlib
-from mesa.visualization import Slider
+
+from mesa.visualization import Slider, SolaraViz, make_space_matplotlib
+
 
 def boid_draw(agent):
     if not agent.neighbors:  # Only for the first Frame
@@ -12,6 +13,7 @@ def boid_draw(agent):
         return {"color": "red", "size": 20}
     elif neighbors >= 2:
         return {"color": "green", "size": 20}
+
 
 model_params = {
     "population": Slider(

--- a/examples/basic/boid_flockers/model.py
+++ b/examples/basic/boid_flockers/model.py
@@ -1,19 +1,17 @@
-"""
-Flockers
+"""Flockers.
 =============================================================
 A Mesa implementation of Craig Reynolds's Boids flocker model.
 Uses numpy arrays to represent vectors.
 """
 
-import mesa
 import numpy as np
 from agents import Boid
 
+import mesa
+
 
 class BoidFlockers(mesa.Model):
-    """
-    Flocker model class. Handles agent creation, placement and scheduling.
-    """
+    """Flocker model class. Handles agent creation, placement and scheduling."""
 
     def __init__(
         self,
@@ -28,8 +26,7 @@ class BoidFlockers(mesa.Model):
         separate=0.015,
         match=0.05,
     ):
-        """
-        Create a new Flockers model.
+        """Create a new Flockers model.
 
         Args:
             population: Number of Boids
@@ -52,9 +49,7 @@ class BoidFlockers(mesa.Model):
         self.make_agents()
 
     def make_agents(self):
-        """
-        Create self.population agents, with random positions and starting headings.
-        """
+        """Create self.population agents, with random positions and starting headings."""
         for _ in range(self.population):
             x = self.random.random() * self.space.x_max
             y = self.random.random() * self.space.y_max

--- a/examples/basic/boltzmann_wealth_model/app.py
+++ b/examples/basic/boltzmann_wealth_model/app.py
@@ -17,7 +17,7 @@ def agent_portrayal(agent):
 
 
 model_params = {
-    "N": {
+    "n": {
         "type": "SliderInt",
         "value": 50,
         "label": "Number of agents:",

--- a/examples/basic/boltzmann_wealth_model/app.py
+++ b/examples/basic/boltzmann_wealth_model/app.py
@@ -1,9 +1,10 @@
+from model import BoltzmannWealthModel
+
 from mesa.visualization import (
     SolaraViz,
     make_plot_measure,
     make_space_matplotlib,
 )
-from model import BoltzmannWealthModel
 
 
 def agent_portrayal(agent):

--- a/examples/basic/boltzmann_wealth_model/model.py
+++ b/examples/basic/boltzmann_wealth_model/model.py
@@ -11,9 +11,9 @@ class BoltzmannWealthModel(mesa.Model):
     highly skewed distribution of wealth.
     """
 
-    def __init__(self, N=100, width=10, height=10):
+    def __init__(self, n=100, width=10, height=10):
         super().__init__()
-        self.num_agents = N
+        self.num_agents = n
         self.grid = mesa.space.MultiGrid(width, height, True)
 
         self.datacollector = mesa.DataCollector(
@@ -39,6 +39,6 @@ class BoltzmannWealthModel(mesa.Model):
     def compute_gini(self):
         agent_wealths = [agent.wealth for agent in self.agents]
         x = sorted(agent_wealths)
-        N = self.num_agents
-        B = sum(xi * (N - i) for i, xi in enumerate(x)) / (N * sum(x))
-        return 1 + (1 / N) - 2 * B
+        n = self.num_agents
+        b = sum(xi * (n - i) for i, xi in enumerate(x)) / (n * sum(x))
+        return 1 + (1 / n) - 2 * b

--- a/examples/basic/boltzmann_wealth_model/model.py
+++ b/examples/basic/boltzmann_wealth_model/model.py
@@ -1,5 +1,7 @@
-import mesa
 from agents import MoneyAgent
+
+import mesa
+
 
 class BoltzmannWealthModel(mesa.Model):
     """A simple model of an economy where agents exchange currency at random.
@@ -16,7 +18,7 @@ class BoltzmannWealthModel(mesa.Model):
 
         self.datacollector = mesa.DataCollector(
             model_reporters={"Gini": self.compute_gini},
-            agent_reporters={"Wealth": "wealth"}
+            agent_reporters={"Wealth": "wealth"},
         )
         # Create agents
         for _ in range(self.num_agents):

--- a/examples/basic/conways_game_of_life/agents.py
+++ b/examples/basic/conways_game_of_life/agents.py
@@ -8,9 +8,7 @@ class Cell(Agent):
     ALIVE = 1
 
     def __init__(self, pos, model, init_state=DEAD):
-        """
-        Create a cell, in the given state, at the given x, y position.
-        """
+        """Create a cell, in the given state, at the given x, y position."""
         super().__init__(model)
         self.x, self.y = pos
         self.state = init_state
@@ -25,14 +23,12 @@ class Cell(Agent):
         return self.model.grid.iter_neighbors((self.x, self.y), True)
 
     def determine_state(self):
-        """
-        Compute if the cell will be dead or alive at the next tick.  This is
+        """Compute if the cell will be dead or alive at the next tick.  This is
         based on the number of alive or dead neighbors.  The state is not
         changed here, but is just computed and stored in self._nextState,
         because our current state may still be necessary for our neighbors
         to calculate their next state.
         """
-
         # Get the neighbors and apply the rules on whether to be alive or dead
         # at the next tick.
         live_neighbors = sum(neighbor.isAlive for neighbor in self.neighbors)
@@ -47,7 +43,5 @@ class Cell(Agent):
                 self._nextState = self.ALIVE
 
     def assume_state(self):
-        """
-        Set the state to the new computed state -- computed in step().
-        """
+        """Set the state to the new computed state -- computed in step()."""
         self.state = self._nextState

--- a/examples/basic/conways_game_of_life/model.py
+++ b/examples/basic/conways_game_of_life/model.py
@@ -1,26 +1,21 @@
+from agents import Cell
+
 from mesa import Model
 from mesa.space import SingleGrid
 
-from agents import Cell
-
 
 class ConwaysGameOfLife(Model):
-    """
-    Represents the 2-dimensional array of cells in Conway's
-    Game of Life.
-    """
+    """Represents the 2-dimensional array of cells in Conway's Game of Life."""
 
     def __init__(self, width=50, height=50):
-        """
-        Create a new playing area of (width, height) cells.
-        """
+        """Create a new playing area of (width, height) cells."""
         super().__init__()
         # Use a simple grid, where edges wrap around.
         self.grid = SingleGrid(width, height, torus=True)
 
         # Place a cell at each location, with some initialized to
         # ALIVE and some to DEAD.
-        for contents, (x, y) in self.grid.coord_iter():
+        for _contents, (x, y) in self.grid.coord_iter():
             cell = Cell((x, y), self)
             if self.random.random() < 0.1:
                 cell.state = cell.ALIVE
@@ -29,10 +24,9 @@ class ConwaysGameOfLife(Model):
         self.running = True
 
     def step(self):
-        """
-        Perform the model step in two stages:
+        """Perform the model step in two stages:
         - First, all cells assume their next state (whether they will be dead or alive)
-        - Then, all cells change state to their next state
+        - Then, all cells change state to their next state.
         """
         self.agents.do("determine_state")
         self.agents.do("assume_state")

--- a/examples/basic/conways_game_of_life/portrayal.py
+++ b/examples/basic/conways_game_of_life/portrayal.py
@@ -1,6 +1,5 @@
 def portrayCell(cell):
-    """
-    This function is registered with the visualization server to be called
+    """This function is registered with the visualization server to be called
     each tick to indicate how to draw the cell in its current state.
     :param cell:  the cell in the simulation
     :return: the portrayal dictionary.

--- a/examples/basic/conways_game_of_life/server.py
+++ b/examples/basic/conways_game_of_life/server.py
@@ -1,7 +1,7 @@
-import mesa
-
 from model import ConwaysGameOfLife
 from portrayal import portrayCell
+
+import mesa
 
 # Make a world that is 50x50, on a 250x250 display.
 canvas_element = mesa.visualization.CanvasGrid(portrayCell, 50, 50, 250, 250)

--- a/examples/basic/schelling/agents.py
+++ b/examples/basic/schelling/agents.py
@@ -2,13 +2,10 @@ from mesa import Agent, Model
 
 
 class SchellingAgent(Agent):
-    """
-    Schelling segregation agent
-    """
+    """Schelling segregation agent."""
 
     def __init__(self, model: Model, agent_type: int) -> None:
-        """
-        Create a new Schelling agent.
+        """Create a new Schelling agent.
 
         Args:
            agent_type: Indicator for the agent's type (minority=1, majority=0)

--- a/examples/basic/schelling/app.py
+++ b/examples/basic/schelling/app.py
@@ -1,17 +1,16 @@
 import solara
+from model import Schelling
+
 from mesa.visualization import (
     Slider,
     SolaraViz,
     make_plot_measure,
     make_space_matplotlib,
 )
-from model import Schelling
 
 
 def get_happy_agents(model):
-    """
-    Display a text count of how many happy agents there are.
-    """
+    """Display a text count of how many happy agents there are."""
     return solara.Markdown(f"**Happy agents: {model.happy}**")
 
 

--- a/examples/basic/schelling/model.py
+++ b/examples/basic/schelling/model.py
@@ -1,13 +1,11 @@
+from agents import SchellingAgent
+
 import mesa
 from mesa import Model
 
-from agents import SchellingAgent
-
 
 class Schelling(Model):
-    """
-    Model class for the Schelling segregation model.
-    """
+    """Model class for the Schelling segregation model."""
 
     def __init__(
         self,
@@ -19,8 +17,7 @@ class Schelling(Model):
         minority_pc=0.2,
         seed=None,
     ):
-        """
-        Create a new Schelling model.
+        """Create a new Schelling model.
 
         Args:
             width, height: Size of the space.
@@ -30,7 +27,6 @@ class Schelling(Model):
             radius: Search radius for checking similarity
             seed: Seed for Reproducibility
         """
-
         super().__init__(seed=seed)
         self.homophily = homophily
         self.radius = radius
@@ -55,9 +51,7 @@ class Schelling(Model):
         self.datacollector.collect(self)
 
     def step(self):
-        """
-        Run one step of the model.
-        """
+        """Run one step of the model."""
         self.happy = 0  # Reset counter of happy agents
         self.agents.shuffle_do("step")
 

--- a/examples/basic/virus_on_network/agents.py
+++ b/examples/basic/virus_on_network/agents.py
@@ -1,5 +1,6 @@
-from mesa import Agent
 from enum import Enum
+
+from mesa import Agent
 
 
 class State(Enum):
@@ -9,9 +10,7 @@ class State(Enum):
 
 
 class VirusAgent(Agent):
-    """
-    Individual Agent definition and its properties/interaction methods
-    """
+    """Individual Agent definition and its properties/interaction methods."""
 
     def __init__(
         self,

--- a/examples/basic/virus_on_network/app.py
+++ b/examples/basic/virus_on_network/app.py
@@ -3,8 +3,9 @@ import math
 import solara
 from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
-from mesa.visualization import SolaraViz, Slider, make_space_matplotlib
 from model import State, VirusOnNetwork, number_infected
+
+from mesa.visualization import Slider, SolaraViz, make_space_matplotlib
 
 
 def agent_portrayal(graph):

--- a/examples/basic/virus_on_network/model.py
+++ b/examples/basic/virus_on_network/model.py
@@ -1,10 +1,10 @@
 import math
 
+import networkx as nx
+from agents import State, VirusAgent
+
 import mesa
 from mesa import Model
-import networkx as nx
-
-from agents import VirusAgent, State
 
 
 def number_state(model, state):
@@ -24,9 +24,7 @@ def number_resistant(model):
 
 
 class VirusOnNetwork(Model):
-    """
-    A virus model with some number of agents
-    """
+    """A virus model with some number of agents."""
 
     def __init__(
         self,
@@ -96,5 +94,5 @@ class VirusOnNetwork(Model):
         self.datacollector.collect(self)
 
     def run_model(self, n):
-        for i in range(n):
+        for _ in range(n):
             self.step()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ path = "mesa/__init__.py"
 # Hardcode to Python 3.10.
 # Reminder to update mesa-examples if the value below is changed.
 target-version = "py310"
-extend-exclude = ["docs", "build", "examples"]
+extend-exclude = ["docs", "build", "examples/advanced"]  # TODO: Remove examples/advanced
 
 [tool.ruff.lint]
 select = [
@@ -148,5 +148,8 @@ extend-ignore = [
   "ISC001", # ruff format asks to disable this feature
   "S311",   # Standard pseudo-random generators are not suitable for cryptographic purposes
 ]
+# Ignore all docstring errors in examples
+per-file-ignores = {"examples/*"= ["D"]}
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
Run ruff and ruff format on the basic examples. Follow-up on #2365, as requested.

I fixed all the non-docstring errors, but there are still 56 docstring errors left:
- **D100** Missing docstring in public module — 14 occurrences
- **D102** Missing docstring in public method — 15 occurrences
- **D103** Missing docstring in public function — 9 occurrences
- **D107** Missing docstring in `__init__` — 4 occurrences
- **D205** 1 blank line required between summary line and description — 5 occurrences
- **D417** Missing argument descriptions in the docstring for `__init__` — 3 occurrences
- **D101** Missing docstring in public class — 1 occurrence

For now we ignore them, but they can be unignored later if preferred.

Also update the `pyproject.toml` to enforce this (aeac384):
- Only exclude examples/advanced from ruff, to start running ruff on the basic examples.
- Ignore docstring errors in the example folder.