### PR TITLE
viz_tutorial: Fix BoltzmannWealthModel import

### DIFF
--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "# You can either define the BoltzmannWealthModel (aka MoneyModel) or install it\n",
     "\n",
-    "from mesa.examples.basic import BoltzmannWealthModel"
+    "from examples.basic import BoltzmannWealthModel"
    ]
   },
   {

--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -87,7 +87,7 @@
    "outputs": [],
    "source": [
     "model_params = {\n",
-    "    \"N\": {\n",
+    "    \"n\": {\n",
     "        \"type\": \"SliderInt\",\n",
     "        \"value\": 50,\n",
     "        \"label\": \"Number of agents:\",\n",


### PR DESCRIPTION
The currently working way to import examples seems to be:

```Python
from examples.basic import BoltzmannWealthModel
```

Not sure if we want to have it this way on the long term, since it could cause merge conflicts etc.

Rendered docs: https://mesa--2383.org.readthedocs.build/2383/tutorials/visualization_tutorial.html