### PR TITLE
Fix for mistaken removal of _draw_grid

### DIFF
--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -55,6 +55,8 @@ def SpaceMatplotlib(
     # https://stackoverflow.com/questions/67524641/convert-multiple-isinstance-checks-to-structural-pattern-matching
     match space:
         case mesa.space._Grid():
+            _draw_grid(space, space_ax, agent_portrayal, propertylayer_portrayal, model)
+        case mesa.space.ContinuousSpace():
             _draw_continuous_space(space, space_ax, agent_portrayal, model)
         case mesa.space.NetworkGrid():
             _draw_network_grid(space, space_ax, agent_portrayal)


### PR DESCRIPTION
As pointed out by @wang-boyu in #2386, there was a small mistake. I collapsed the drawing of continuous space and old style grid spaces. This fixes that mistake. 



ps. I'll try to get some basic unit testing in place for the visualization stuff in the coming days. 