### PR TITLE
fixes weakref bug in shuffe_do

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -294,15 +294,17 @@ class AgentSet(MutableSet, Sequence):
 
         It's a fast, optimized version of calling shuffle() followed by do().
         """
-        agents = list(self._agents.keys())
-        self.random.shuffle(agents)
+        weakrefs = list(self._agents.keyrefs())
+        self.random.shuffle(weakrefs)
 
         if isinstance(method, str):
-            for agent in agents:
-                getattr(agent, method)(*args, **kwargs)
+            for ref in weakrefs:
+                if (agent := ref()) is not None:
+                    getattr(agent, method)(*args, **kwargs)
         else:
-            for agent in agents:
-                method(agent, *args, **kwargs)
+            for ref in weakrefs:
+                if (agent := ref()) is not None:
+                    method(agent, *args, **kwargs)
 
         return self
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -473,6 +473,29 @@ def test_agentset_shuffle_do():
     ), "The order should be different after shuffle_do"
 
 
+    class AgentWithRemove(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.is_alive = True
+
+        def remove(self):
+            super().remove()
+            self.is_alive = False
+
+        def step(self):
+            if not self.is_alive:
+                raise Exception
+
+            agent_to_remove = self.random.choice(self.model.agents)
+
+            if agent_to_remove is not self:
+                agent_to_remove.remove()
+
+    model = Model(seed=32)
+    for _ in range(100):
+        AgentWithRemove(model)
+    model.agents.shuffle_do("step")
+
 def test_agentset_get_attribute():
     """Test AgentSet.get for attributes."""
     model = Model()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -472,7 +472,6 @@ def test_agentset_shuffle_do():
         original_order != shuffled_order
     ), "The order should be different after shuffle_do"
 
-
     class AgentWithRemove(Agent):
         def __init__(self, model):
             super().__init__(model)
@@ -495,6 +494,7 @@ def test_agentset_shuffle_do():
     for _ in range(100):
         AgentWithRemove(model)
     model.agents.shuffle_do("step")
+
 
 def test_agentset_get_attribute():
     """Test AgentSet.get for attributes."""


### PR DESCRIPTION
if one agent removes another agent, it could still be activated by shuffle_do. This adds a unit test to spot the bug and contains the fix.

# longer explanation
shuffle_do used `agents = list(self._agents.keys())`. This returns a list of hardrefs to all agents. So if `agents[0]` removes `agents[1]`, it will be removed from the model, but it is still activated in `shuffle_do`. we had the same bug before in shuffle in january. 