### PR TITLE
Pass through model.rgn in agent analogous to model.random

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -21,6 +21,8 @@ from random import Random
 # mypy
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+import numpy as np
+
 if TYPE_CHECKING:
     # We ensure that these are not imported during runtime to prevent cyclic
     # dependency.
@@ -85,9 +87,13 @@ class Agent:
 
     @property
     def random(self) -> Random:
-        """Return a seeded rng."""
+        """Return a seeded stdlib rng."""
         return self.model.random
 
+    @property
+    def rng(self) -> np.random.Generator:
+        """Return a seeded np.random rng."""
+        return self.model.rng
 
 class AgentSet(MutableSet, Sequence):
     """A collection class that represents an ordered set of agents within an agent-based model (ABM).

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -95,6 +95,7 @@ class Agent:
         """Return a seeded np.random rng."""
         return self.model.rng
 
+
 class AgentSet(MutableSet, Sequence):
     """A collection class that represents an ordered set of agents within an agent-based model (ABM).
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -161,6 +161,12 @@ def test_agent_membership():
     assert agents[0] in agentset
     assert AgentTest(model) not in agentset
 
+def test_agent_rng():
+    model = Model(seed=42)
+    agent = Agent(model)
+    assert agent.random is model.random
+    assert agent.rng is model.rng
+
 
 def test_agent_add_remove_discard():
     """Test adding, removing and discarding agents from AgentSet."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -161,6 +161,7 @@ def test_agent_membership():
     assert agents[0] in agentset
     assert AgentTest(model) not in agentset
 
+
 def test_agent_rng():
     model = Model(seed=42)
     agent = Agent(model)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -163,6 +163,7 @@ def test_agent_membership():
 
 
 def test_agent_rng():
+    """Test whether agent.random and agent.rng are equal to model.random and model.rng."""
     model = Model(seed=42)
     agent = Agent(model)
     assert agent.random is model.random


### PR DESCRIPTION
This is a follow up PR from #2352. It adds a new property to Agent: `Agent.rng`. Implementation wise it is identical to `Agent.random.` This PR also explicitly adds tests for both properties.  