### PR TITLE
Make example import absolute

### DIFF
--- a/mesa/examples/basic/boid_flockers/app.py
+++ b/mesa/examples/basic/boid_flockers/app.py
@@ -1,6 +1,5 @@
-from mesa.visualization import Slider, SolaraViz, make_space_matplotlib
-
 from mesa.examples.basic.boid_flockers.model import BoidFlockers
+from mesa.visualization import Slider, SolaraViz, make_space_matplotlib
 
 
 def boid_draw(agent):

--- a/mesa/examples/basic/boid_flockers/app.py
+++ b/mesa/examples/basic/boid_flockers/app.py
@@ -1,6 +1,6 @@
 from mesa.visualization import Slider, SolaraViz, make_space_matplotlib
 
-from .model import BoidFlockers
+from mesa.examples.basic.boid_flockers.model import BoidFlockers
 
 
 def boid_draw(agent):

--- a/mesa/examples/basic/boid_flockers/model.py
+++ b/mesa/examples/basic/boid_flockers/model.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import mesa
 
-from .agents import Boid
+from mesa.examples.basic.boid_flockers.agents import Boid
 
 
 class BoidFlockers(mesa.Model):

--- a/mesa/examples/basic/boid_flockers/model.py
+++ b/mesa/examples/basic/boid_flockers/model.py
@@ -7,7 +7,6 @@ Uses numpy arrays to represent vectors.
 import numpy as np
 
 import mesa
-
 from mesa.examples.basic.boid_flockers.agents import Boid
 
 

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -1,10 +1,9 @@
+from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
 from mesa.visualization import (
     SolaraViz,
     make_plot_measure,
     make_space_matplotlib,
 )
-
-from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
 
 
 def agent_portrayal(agent):

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -4,7 +4,7 @@ from mesa.visualization import (
     make_space_matplotlib,
 )
 
-from .model import BoltzmannWealthModel
+from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
 
 
 def agent_portrayal(agent):

--- a/mesa/examples/basic/boltzmann_wealth_model/model.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/model.py
@@ -1,6 +1,6 @@
 import mesa
 
-from .agents import MoneyAgent
+from mesa.examples.basic.boltzmann_wealth_model.agents import MoneyAgent
 
 
 class BoltzmannWealthModel(mesa.Model):

--- a/mesa/examples/basic/boltzmann_wealth_model/model.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/model.py
@@ -1,5 +1,4 @@
 import mesa
-
 from mesa.examples.basic.boltzmann_wealth_model.agents import MoneyAgent
 
 

--- a/mesa/examples/basic/conways_game_of_life/app.py
+++ b/mesa/examples/basic/conways_game_of_life/app.py
@@ -4,7 +4,8 @@ import altair as alt
 import numpy as np
 import pandas as pd
 import streamlit as st
-from model import ConwaysGameOfLife
+
+from mesa.examples.basic.conways_game_of_life.model import ConwaysGameOfLife
 
 model = st.title("Conway's Game of Life")
 num_ticks = st.slider("Select number of Steps", min_value=1, max_value=100, value=50)

--- a/mesa/examples/basic/conways_game_of_life/model.py
+++ b/mesa/examples/basic/conways_game_of_life/model.py
@@ -1,7 +1,7 @@
 from mesa import Model
 from mesa.space import SingleGrid
 
-from .agents import Cell
+from mesa.examples.basic.conways_game_of_life.agents import Cell
 
 
 class ConwaysGameOfLife(Model):

--- a/mesa/examples/basic/conways_game_of_life/model.py
+++ b/mesa/examples/basic/conways_game_of_life/model.py
@@ -1,7 +1,6 @@
 from mesa import Model
-from mesa.space import SingleGrid
-
 from mesa.examples.basic.conways_game_of_life.agents import Cell
+from mesa.space import SingleGrid
 
 
 class ConwaysGameOfLife(Model):

--- a/mesa/examples/basic/schelling/app.py
+++ b/mesa/examples/basic/schelling/app.py
@@ -7,7 +7,7 @@ from mesa.visualization import (
     make_space_matplotlib,
 )
 
-from .model import Schelling
+from mesa.examples.basic.schelling.model import Schelling
 
 
 def get_happy_agents(model):

--- a/mesa/examples/basic/schelling/app.py
+++ b/mesa/examples/basic/schelling/app.py
@@ -1,13 +1,12 @@
 import solara
 
+from mesa.examples.basic.schelling.model import Schelling
 from mesa.visualization import (
     Slider,
     SolaraViz,
     make_plot_measure,
     make_space_matplotlib,
 )
-
-from mesa.examples.basic.schelling.model import Schelling
 
 
 def get_happy_agents(model):

--- a/mesa/examples/basic/schelling/model.py
+++ b/mesa/examples/basic/schelling/model.py
@@ -1,6 +1,5 @@
 import mesa
 from mesa import Model
-
 from mesa.examples.basic.schelling.agents import SchellingAgent
 
 

--- a/mesa/examples/basic/schelling/model.py
+++ b/mesa/examples/basic/schelling/model.py
@@ -1,7 +1,7 @@
 import mesa
 from mesa import Model
 
-from .agents import SchellingAgent
+from mesa.examples.basic.schelling.agents import SchellingAgent
 
 
 class Schelling(Model):

--- a/mesa/examples/basic/virus_on_network/app.py
+++ b/mesa/examples/basic/virus_on_network/app.py
@@ -6,7 +6,7 @@ from matplotlib.ticker import MaxNLocator
 
 from mesa.visualization import Slider, SolaraViz, make_space_matplotlib
 
-from .model import State, VirusOnNetwork, number_infected
+from mesa.examples.basic.virus_on_network.model import State, VirusOnNetwork, number_infected
 
 
 def agent_portrayal(graph):

--- a/mesa/examples/basic/virus_on_network/app.py
+++ b/mesa/examples/basic/virus_on_network/app.py
@@ -4,9 +4,12 @@ import solara
 from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
 
+from mesa.examples.basic.virus_on_network.model import (
+    State,
+    VirusOnNetwork,
+    number_infected,
+)
 from mesa.visualization import Slider, SolaraViz, make_space_matplotlib
-
-from mesa.examples.basic.virus_on_network.model import State, VirusOnNetwork, number_infected
 
 
 def agent_portrayal(graph):

--- a/mesa/examples/basic/virus_on_network/model.py
+++ b/mesa/examples/basic/virus_on_network/model.py
@@ -4,8 +4,7 @@ import networkx as nx
 
 import mesa
 from mesa import Model
-
-from mesa.examples.basic.virus_on_network.agents import (State, VirusAgent)
+from mesa.examples.basic.virus_on_network.agents import State, VirusAgent
 
 
 def number_state(model, state):

--- a/mesa/examples/basic/virus_on_network/model.py
+++ b/mesa/examples/basic/virus_on_network/model.py
@@ -5,7 +5,7 @@ import networkx as nx
 import mesa
 from mesa import Model
 
-from .agents import State, VirusAgent
+from mesa.examples.basic.virus_on_network.agents import (State, VirusAgent)
 
 
 def number_state(model, state):


### PR DESCRIPTION
As discussed in #2381, the current relative imports with the examples create a problem. This at least makes things run again by using absolute imports. 