### PR TITLE
Update docstring of SimEvent

### DIFF
--- a/mesa/experimental/devs/eventlist.py
+++ b/mesa/experimental/devs/eventlist.py
@@ -33,6 +33,12 @@ class SimulationEvent:
         function_args (list[Any]): Argument for the function
         function_kwargs (Dict[str, Any]): Keyword arguments for the function
 
+
+    Notes:
+        simulation events use a weak reference to the callable. Therefore, you cannot pass a lamda function in fn.
+        A simulation event where the callable no longer exists (e.g., because the agent has been removed from the model)
+        will fail silently.
+
     """
 
     _ids = itertools.count()


### PR DESCRIPTION
In response to [this feedback on the beta](https://github.com/projectmesa/mesa/discussions/2338#discussioncomment-11044515), this PR adds a notes to SimEvent to explicitly point out that using lambda's in `SimEvent` won't work. 