### PR TITLE
space: Add note that Grids are maintenance only

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -3,12 +3,12 @@
 Objects used to add a spatial component to a model.
 
 .. note::
-    All Grid classes (:class:`_Grid`, :class:`SingleGrid`, :class:`MultiGrid`, 
-    :class:`HexGrid`, etc.) are now in maintenance-only mode. While these classes remain 
-    fully supported, new development occurs in the experimental cell space module 
+    All Grid classes (:class:`_Grid`, :class:`SingleGrid`, :class:`MultiGrid`,
+    :class:`HexGrid`, etc.) are now in maintenance-only mode. While these classes remain
+    fully supported, new development occurs in the experimental cell space module
     (:mod:`mesa.experimental.cell_space`).
-    
-    The :class:`PropertyLayer` and :class:`ContinuousSpace` classes remain fully supported 
+
+    The :class:`PropertyLayer` and :class:`ContinuousSpace` classes remain fully supported
     and actively developed.
 
 Classes

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -2,10 +2,21 @@
 
 Objects used to add a spatial component to a model.
 
-* Grid: base grid, which creates a rectangular grid.
-* SingleGrid: extension to Grid which strictly enforces one agent per cell.
-* MultiGrid: extension to Grid where each cell can contain a set of agents.
-* HexGrid: extension to Grid to handle hexagonal neighbors.
+.. note::
+    All Grid classes (:class:`_Grid`, :class:`SingleGrid`, :class:`MultiGrid`, 
+    :class:`HexGrid`, etc.) are now in maintenance-only mode. While these classes remain 
+    fully supported, new development occurs in the experimental cell space module 
+    (:mod:`mesa.experimental.cell_space`).
+    
+    The :class:`PropertyLayer` and :class:`ContinuousSpace` classes remain fully supported 
+    and actively developed.
+
+Classes
+-------
+* PropertyLayer: A data layer that can be added to Grids to store cell properties
+* SingleGrid: a Grid which strictly enforces one agent per cell.
+* MultiGrid: a Grid where each cell can contain a set of agents.
+* HexGrid: a Grid to handle hexagonal neighbors.
 * ContinuousSpace: a two-dimensional space where each agent has an arbitrary position of `float`'s.
 * NetworkGrid: a network where each node contains zero or more agents.
 """


### PR DESCRIPTION
Add a note to the space module level docstring that the Grids are maintenance only.

Also add the PropertyLayer to the classes and remove the Grid, since that's now private (and has been for a while).

Now looks like this:
![image](https://github.com/user-attachments/assets/b4ee484d-274d-4742-9f46-3cee7c4a093d)