### PR TITLE
Updates to Epstein example

### DIFF
--- a/mesa/examples/advanced/epstein_civil_violence/agents.py
+++ b/mesa/examples/advanced/epstein_civil_violence/agents.py
@@ -25,7 +25,6 @@ class EpsteinAgent(mesa.experimental.cell_space.CellAgent):
             self.move_to(new_pos)
 
 
-
 class Citizen(EpsteinAgent):
     """
     A member of the general population, may or may not be in active rebellion.
@@ -50,12 +49,7 @@ class Citizen(EpsteinAgent):
     """
 
     def __init__(
-            self,
-            model,
-            regime_legitimacy,
-            threshold,
-            vision,
-            arrest_prob_constant
+        self, model, regime_legitimacy, threshold, vision, arrest_prob_constant
     ):
         """
         Create a new Citizen.
@@ -160,10 +154,7 @@ class Cop(EpsteinAgent):
         self.update_neighbors()
         active_neighbors = []
         for agent in self.neighbors:
-            if (
-                    isinstance(agent, Citizen)
-                    and agent.state == CitizenState.ACTIVE
-            ):
+            if isinstance(agent, Citizen) and agent.state == CitizenState.ACTIVE:
                 active_neighbors.append(agent)
         if active_neighbors:
             arrestee = self.random.choice(active_neighbors)

--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -16,8 +16,9 @@ COP_COLOR = "#000000"
 agent_colors = {
     CitizenState.ACTIVE: "#FE6100",
     CitizenState.QUIET: "#648FFF",
-    CitizenState.ARRESTED: "#808080"
+    CitizenState.ARRESTED: "#808080",
 }
+
 
 def citizen_cop_portrayal(agent):
     if agent is None:

--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -12,10 +12,12 @@ from mesa.visualization import (
 )
 
 COP_COLOR = "#000000"
-QUIET_COLOR = "#648FFF"
-ACTIVE_COLOR = "#FE6100"
-ARRESTED_COLOR = "#808080"
 
+agent_colors = {
+    CitizenState.ACTIVE: "#FE6100",
+    CitizenState.QUIET: "#648FFF",
+    CitizenState.ARRESTED: "#808080"
+}
 
 def citizen_cop_portrayal(agent):
     if agent is None:
@@ -26,14 +28,7 @@ def citizen_cop_portrayal(agent):
     }
 
     if isinstance(agent, Citizen):
-        match agent.state:
-            case CitizenState.ACTIVE:
-                color = ACTIVE_COLOR
-            case CitizenState.QUIET:
-                color = QUIET_COLOR
-            case CitizenState.ARRESTED:
-                color = ARRESTED_COLOR
-        portrayal["color"] = color
+        portrayal["color"] = agent_colors[agent.state]
     elif isinstance(agent, Cop):
         portrayal["color"] = COP_COLOR
 

--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -1,4 +1,9 @@
-from mesa.examples.advanced.epstein_civil_violence.agents import Citizen, Cop
+import sys
+import os.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../')))
+
+
+from mesa.examples.advanced.epstein_civil_violence.agents import Citizen, Cop, CitizenState
 from mesa.examples.advanced.epstein_civil_violence.model import EpsteinCivilViolence
 from mesa.visualization import (
     Slider,
@@ -8,10 +13,9 @@ from mesa.visualization import (
 )
 
 COP_COLOR = "#000000"
-AGENT_QUIET_COLOR = "#648FFF"
-AGENT_REBEL_COLOR = "#FE6100"
-JAIL_COLOR = "#808080"
-JAIL_SHAPE = "rect"
+QUIET_COLOR = "#648FFF"
+ACTIVE_COLOR = "#FE6100"
+ARRESTED_COLOR = "#808080"
 
 
 def citizen_cop_portrayal(agent):
@@ -20,29 +24,19 @@ def citizen_cop_portrayal(agent):
 
     portrayal = {
         "size": 25,
-        "shape": "s",  # square marker
     }
 
     if isinstance(agent, Citizen):
-        color = (
-            AGENT_QUIET_COLOR if agent.condition == "Quiescent" else AGENT_REBEL_COLOR
-        )
-        color = JAIL_COLOR if agent.jail_sentence else color
-        shape = JAIL_SHAPE if agent.jail_sentence else "circle"
+        match agent.state:
+            case CitizenState.ACTIVE:
+                color = ACTIVE_COLOR
+            case CitizenState.QUIET:
+                color = QUIET_COLOR
+            case CitizenState.ARRESTED:
+                color = ARRESTED_COLOR
         portrayal["color"] = color
-        portrayal["shape"] = shape
-        if shape == "s":
-            portrayal["w"] = 0.9
-            portrayal["h"] = 0.9
-        else:
-            portrayal["r"] = 0.5
-            portrayal["filled"] = False
-        portrayal["layer"] = 0
-
     elif isinstance(agent, Cop):
         portrayal["color"] = COP_COLOR
-        portrayal["r"] = 0.9
-        portrayal["layer"] = 1
 
     return portrayal
 
@@ -59,7 +53,7 @@ model_params = {
 }
 
 space_component = make_space_matplotlib(citizen_cop_portrayal)
-chart_component = make_plot_measure(["Quiescent", "Active", "Jailed"])
+chart_component = make_plot_measure([state.name.lower() for state in CitizenState])
 
 epstein_model = EpsteinCivilViolence()
 

--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -1,16 +1,4 @@
-import os.path
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../"))
-)
-
-
-from mesa.examples.advanced.epstein_civil_violence.agents import (
-    Citizen,
-    CitizenState,
-    Cop,
-)
+from mesa.examples.advanced.epstein_civil_violence.agents import Citizen, Cop, CitizenState
 from mesa.examples.advanced.epstein_civil_violence.model import EpsteinCivilViolence
 from mesa.visualization import (
     Slider,

--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -1,9 +1,16 @@
-import sys
 import os.path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../')))
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../"))
+)
 
 
-from mesa.examples.advanced.epstein_civil_violence.agents import Citizen, Cop, CitizenState
+from mesa.examples.advanced.epstein_civil_violence.agents import (
+    Citizen,
+    CitizenState,
+    Cop,
+)
 from mesa.examples.advanced.epstein_civil_violence.model import EpsteinCivilViolence
 from mesa.visualization import (
     Slider,

--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -1,4 +1,8 @@
-from mesa.examples.advanced.epstein_civil_violence.agents import Citizen, Cop, CitizenState
+from mesa.examples.advanced.epstein_civil_violence.agents import (
+    Citizen,
+    CitizenState,
+    Cop,
+)
 from mesa.examples.advanced.epstein_civil_violence.model import EpsteinCivilViolence
 from mesa.visualization import (
     Slider,

--- a/mesa/examples/advanced/epstein_civil_violence/model.py
+++ b/mesa/examples/advanced/epstein_civil_violence/model.py
@@ -57,11 +57,8 @@ class EpsteinCivilViolence(mesa.Model):
             'active': CitizenState.ACTIVE.name,
             'quiet': CitizenState.QUIET.name,
             'arrested': CitizenState.ARRESTED.name,
-            "Cops": self.count_cops
         }
         agent_reporters = {
-            "x": lambda a: a.cell.coordinate[0],
-            "y": lambda a: a.cell.coordinate[1],
             "jail_sentence": lambda a: getattr(a, "jail_sentence", None),
             "arrest_probability": lambda a: getattr(a, "arrest_probability", None),
         }
@@ -82,9 +79,7 @@ class EpsteinCivilViolence(mesa.Model):
             elif klass == Citizen:
                 citizen = Citizen(
                     self,
-                    hardship=self.random.random(),
                     regime_legitimacy=legitimacy,
-                    risk_aversion=self.random.random(),
                     threshold=active_threshold,
                     vision=citizen_vision,
                     arrest_prob_constant=arrest_prob_constant
@@ -107,15 +102,8 @@ class EpsteinCivilViolence(mesa.Model):
             self.running = False
 
     def _update_counts(self):
+        """Helper function for counting nr. of citizens in given state."""
         counts = self.agents_by_type[Citizen].groupby("state").count()
 
         for state in CitizenState:
             setattr(self, state.name, counts.get(state, 0))
-
-
-    @staticmethod
-    def count_cops(model):
-        """
-        Helper method to count jailed agents.
-        """
-        return len(model.agents_by_type[Cop])

--- a/mesa/examples/advanced/epstein_civil_violence/model.py
+++ b/mesa/examples/advanced/epstein_civil_violence/model.py
@@ -1,5 +1,9 @@
 import mesa
-from mesa.examples.advanced.epstein_civil_violence.agents import Citizen, Cop, CitizenState
+from mesa.examples.advanced.epstein_civil_violence.agents import (
+    Citizen,
+    CitizenState,
+    Cop,
+)
 
 
 class EpsteinCivilViolence(mesa.Model):
@@ -54,9 +58,9 @@ class EpsteinCivilViolence(mesa.Model):
         )
 
         model_reporters = {
-            'active': CitizenState.ACTIVE.name,
-            'quiet': CitizenState.QUIET.name,
-            'arrested': CitizenState.ARRESTED.name,
+            "active": CitizenState.ACTIVE.name,
+            "quiet": CitizenState.QUIET.name,
+            "arrested": CitizenState.ARRESTED.name,
         }
         agent_reporters = {
             "jail_sentence": lambda a: getattr(a, "jail_sentence", None),
@@ -69,9 +73,10 @@ class EpsteinCivilViolence(mesa.Model):
             raise ValueError("Cop density + citizen density must be less than 1")
 
         for cell in self.grid.all_cells:
-            klass = self.random.choices([Citizen, Cop, None],
-                                   cum_weights=[citizen_density,
-                                                citizen_density+cop_density, 1])[0]
+            klass = self.random.choices(
+                [Citizen, Cop, None],
+                cum_weights=[citizen_density, citizen_density + cop_density, 1],
+            )[0]
 
             if klass == Cop:
                 cop = Cop(self, vision=cop_vision, max_jail_term=max_jail_term)
@@ -82,7 +87,7 @@ class EpsteinCivilViolence(mesa.Model):
                     regime_legitimacy=legitimacy,
                     threshold=active_threshold,
                     vision=citizen_vision,
-                    arrest_prob_constant=arrest_prob_constant
+                    arrest_prob_constant=arrest_prob_constant,
                 )
                 citizen.move_to(cell)
 


### PR DESCRIPTION
This is an update to the Epstein model to address #2423. Next to shifting to a von Neumann grid, there are several other changes. 

1. A minor change in the arrest_probability calculation by using `round`. This is based on an extensive literature that shows that without it, the original Epstein results cannot be reproduced.
2. Shifting to using an enum for the state of the citizen (this has various knock-on consequences elsewhere in the code that make the code cleaner and shorter).
3. Rework of app.py to only use stuff that actually works when drawing new-style discrete grids. 

The net result is shown below.

<img width="1721" alt="Screenshot 2024-10-27 at 10 36 26" src="https://github.com/user-attachments/assets/419fdea0-229d-4357-b0f3-b29f485e3fce">
