### PR TITLE
expand ax.scatter kwargs that can be used

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -177,20 +177,20 @@ def agent_portrayal(agent):
 
 model_params = {
     "N": {
-       "type": "SliderInt",
-       "value": 50,
-       "label": "Number of agents:",
-       "min": 10,
-       "max": 100,
-       "step": 1,
+        "type": "SliderInt",
+        "value": 50,
+        "label": "Number of agents:",
+        "min": 10,
+        "max": 100,
+        "step": 1,
    }
 }
 
 page = SolaraViz(
     MyModel,
     [
-       make_space_component(agent_portrayal),
-       make_plot_component("mean_age")
+        make_space_component(agent_portrayal),
+        make_plot_component("mean_age")
     ],
     model_params=model_params
 )

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -2,6 +2,7 @@ from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthMode
 from mesa.visualization import (
     SolaraViz,
     make_space_component,
+    make_plot_component
 )
 
 
@@ -40,7 +41,7 @@ model1 = BoltzmannWealthModel(50, 10, 10)
 SpaceGraph = make_space_component(
     agent_portrayal, cmap="viridis", vmin=0, vmax=10, post_process=post_process
 )
-GiniPlot = make_plot_measure("Gini")
+GiniPlot = make_plot_component("Gini")
 
 # Create the SolaraViz page. This will automatically create a server and display the
 # visualization elements in a web browser.

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -7,7 +7,7 @@ from mesa.visualization import (
 
 
 def agent_portrayal(agent):
-    color = agent.wealth
+    color = agent.wealth  # we are using a colormap to translate wealth to color
     return {"color": color}
 
 

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -24,8 +24,10 @@ model_params = {
     "height": 10,
 }
 
+
 def post_process(ax):
     ax.get_figure().colorbar(ax.collections[0], label="wealth", ax=ax)
+
 
 # Create initial model instance
 model1 = BoltzmannWealthModel(50, 10, 10)
@@ -35,7 +37,9 @@ model1 = BoltzmannWealthModel(50, 10, 10)
 # Under the hood these are just classes that receive the model instance.
 # You can also author your own visualization elements, which can also be functions
 # that receive the model instance and return a valid solara component.
-SpaceGraph = make_space_component(agent_portrayal, cmap='viridis', vmin=0, vmax=10, post_process=post_process)
+SpaceGraph = make_space_component(
+    agent_portrayal, cmap="viridis", vmin=0, vmax=10, post_process=post_process
+)
 GiniPlot = make_plot_measure("Gini")
 
 # Create the SolaraViz page. This will automatically create a server and display the

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -1,9 +1,5 @@
 from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
-from mesa.visualization import (
-    SolaraViz,
-    make_space_component,
-    make_plot_component
-)
+from mesa.visualization import SolaraViz, make_plot_component, make_space_component
 
 
 def agent_portrayal(agent):

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -7,12 +7,8 @@ from mesa.visualization import (
 
 
 def agent_portrayal(agent):
-    size = 10
-    color = "tab:red"
-    if agent.wealth > 0:
-        size = 50
-        color = "tab:blue"
-    return {"size": size, "color": color}
+    color = agent.wealth
+    return {"color": color}
 
 
 model_params = {
@@ -28,6 +24,9 @@ model_params = {
     "height": 10,
 }
 
+def post_process(ax):
+    ax.get_figure().colorbar(ax.collections[0], label="wealth", ax=ax)
+
 # Create initial model instance
 model1 = BoltzmannWealthModel(50, 10, 10)
 
@@ -36,7 +35,7 @@ model1 = BoltzmannWealthModel(50, 10, 10)
 # Under the hood these are just classes that receive the model instance.
 # You can also author your own visualization elements, which can also be functions
 # that receive the model instance and return a valid solara component.
-SpaceGraph = make_space_component(agent_portrayal)
+SpaceGraph = make_space_component(agent_portrayal, cmap='viridis', vmin=0, vmax=10, post_process=post_process)
 GiniPlot = make_plot_measure("Gini")
 
 # Create the SolaraViz page. This will automatically create a server and display the

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -1,7 +1,6 @@
 from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
 from mesa.visualization import (
     SolaraViz,
-    make_plot_component,
     make_space_component,
 )
 

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -300,7 +300,7 @@ def draw_orthogonal_grid(
     agent_portrayal: Callable,
     ax: Axes | None = None,
     draw_grid: bool = True,
-    **kwargs
+    **kwargs,
 ):
     """Visualize a orthogonal grid.
 
@@ -347,7 +347,7 @@ def draw_hex_grid(
     agent_portrayal: Callable,
     ax: Axes | None = None,
     draw_grid: bool = True,
-    **kwargs
+    **kwargs,
 ):
     """Visualize a hex grid.
 
@@ -438,7 +438,7 @@ def draw_network(
     draw_grid: bool = True,
     layout_alg=nx.spring_layout,
     layout_kwargs=None,
-    **kwargs
+    **kwargs,
 ):
     """Visualize a network space.
 
@@ -503,8 +503,7 @@ def draw_network(
 
 
 def draw_continuous_space(
-    space: ContinuousSpace, agent_portrayal: Callable, ax: Axes | None = None,
-    **kwargs
+    space: ContinuousSpace, agent_portrayal: Callable, ax: Axes | None = None, **kwargs
 ):
     """Visualize a continuous space.
 
@@ -551,8 +550,7 @@ def draw_continuous_space(
 
 
 def draw_voroinoi_grid(
-    space: VoronoiGrid, agent_portrayal: Callable, ax: Axes | None = None,
-    **kwargs
+    space: VoronoiGrid, agent_portrayal: Callable, ax: Axes | None = None, **kwargs
 ):
     """Visualize a voronoi grid.
 
@@ -608,7 +606,7 @@ def draw_voroinoi_grid(
 def _scatter(ax: Axes, arguments, **kwargs):
     """Helper function for plotting the agents.
 
-    Args
+    Args:
         ax: a Matplotlib Axes instance
         arguments: the agents specific arguments for platting
         additional keyword arguments for ax.scatter

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -300,6 +300,7 @@ def draw_orthogonal_grid(
     agent_portrayal: Callable,
     ax: Axes | None = None,
     draw_grid: bool = True,
+    **kwargs
 ):
     """Visualize a orthogonal grid.
 
@@ -308,6 +309,7 @@ def draw_orthogonal_grid(
         agent_portrayal: a callable that is called with the agent and returns a dict
         ax: a Matplotlib Axes instance. If none is provided a new figure and ax will be created using plt.subplots
         draw_grid: whether to draw the grid
+        kwargs: additional keyword arguments passed to ax.scatter
 
     Returns:
         Returns the Axes object with the plot drawn onto it.
@@ -324,7 +326,7 @@ def draw_orthogonal_grid(
     arguments = collect_agent_data(space, agent_portrayal, size=s_default)
 
     # plot the agents
-    _scatter(ax, arguments)
+    _scatter(ax, arguments, **kwargs)
 
     # further styling
     ax.set_xlim(-0.5, space.width - 0.5)
@@ -345,6 +347,7 @@ def draw_hex_grid(
     agent_portrayal: Callable,
     ax: Axes | None = None,
     draw_grid: bool = True,
+    **kwargs
 ):
     """Visualize a hex grid.
 
@@ -353,6 +356,7 @@ def draw_hex_grid(
         agent_portrayal: a callable that is called with the agent and returns a dict
         ax: a Matplotlib Axes instance. If none is provided a new figure and ax will be created using plt.subplots
         draw_grid: whether to draw the grid
+        kwargs: additional keyword arguments passed to ax.scatter
 
     Returns:
         Returns the Axes object with the plot drawn onto it.
@@ -385,7 +389,7 @@ def draw_hex_grid(
     arguments["loc"] = loc
 
     # plot the agents
-    _scatter(ax, arguments)
+    _scatter(ax, arguments, **kwargs)
 
     # further styling and adding of grid
     ax.set_xlim(-1, space.width + 0.5)
@@ -434,6 +438,7 @@ def draw_network(
     draw_grid: bool = True,
     layout_alg=nx.spring_layout,
     layout_kwargs=None,
+    **kwargs
 ):
     """Visualize a network space.
 
@@ -444,6 +449,7 @@ def draw_network(
         draw_grid: whether to draw the grid
         layout_alg: a networkx layout algorithm or other callable with the same behavior
         layout_kwargs: a dictionary of keyword arguments for the layout algorithm
+        kwargs: additional keyword arguments passed to ax.scatter
 
     Returns:
         Returns the Axes object with the plot drawn onto it.
@@ -479,7 +485,7 @@ def draw_network(
     arguments["loc"] = pos[arguments["loc"]]
 
     # plot the agents
-    _scatter(ax, arguments)
+    _scatter(ax, arguments, **kwargs)
 
     # further styling
     ax.set_axis_off()
@@ -497,7 +503,8 @@ def draw_network(
 
 
 def draw_continuous_space(
-    space: ContinuousSpace, agent_portrayal: Callable, ax: Axes | None = None
+    space: ContinuousSpace, agent_portrayal: Callable, ax: Axes | None = None,
+    **kwargs
 ):
     """Visualize a continuous space.
 
@@ -505,6 +512,7 @@ def draw_continuous_space(
         space: the space to visualize
         agent_portrayal: a callable that is called with the agent and returns a dict
         ax: a Matplotlib Axes instance. If none is provided a new figure and ax will be created using plt.subplots
+        kwargs: additional keyword arguments passed to ax.scatter
 
     Returns:
         Returns the Axes object with the plot drawn onto it.
@@ -527,7 +535,7 @@ def draw_continuous_space(
     arguments = collect_agent_data(space, agent_portrayal, size=s_default)
 
     # plot the agents
-    _scatter(ax, arguments)
+    _scatter(ax, arguments, **kwargs)
 
     # further visual styling
     border_style = "solid" if not space.torus else (0, (5, 10))
@@ -543,7 +551,8 @@ def draw_continuous_space(
 
 
 def draw_voroinoi_grid(
-    space: VoronoiGrid, agent_portrayal: Callable, ax: Axes | None = None
+    space: VoronoiGrid, agent_portrayal: Callable, ax: Axes | None = None,
+    **kwargs
 ):
     """Visualize a voronoi grid.
 
@@ -551,6 +560,7 @@ def draw_voroinoi_grid(
         space: the space to visualize
         agent_portrayal: a callable that is called with the agent and returns a dict
         ax: a Matplotlib Axes instance. If none is provided a new figure and ax will be created using plt.subplots
+        kwargs: additional keyword arguments passed to ax.scatter
 
     Returns:
         Returns the Axes object with the plot drawn onto it.
@@ -580,7 +590,7 @@ def draw_voroinoi_grid(
     ax.set_xlim(x_min - x_padding, x_max + x_padding)
     ax.set_ylim(y_min - y_padding, y_max + y_padding)
 
-    _scatter(ax, arguments)
+    _scatter(ax, arguments, **kwargs)
 
     for cell in space.all_cells:
         polygon = cell.properties["polygon"]
@@ -595,8 +605,16 @@ def draw_voroinoi_grid(
     return ax
 
 
-def _scatter(ax: Axes, arguments):
-    """Helper function for plotting the agents."""
+def _scatter(ax: Axes, arguments, **kwargs):
+    """Helper function for plotting the agents.
+
+    Args
+        ax: a Matplotlib Axes instance
+        arguments: the agents specific arguments for platting
+        additional keyword arguments for ax.scatter
+
+
+    """
     loc = arguments.pop("loc")
 
     x = loc[:, 0]
@@ -615,6 +633,7 @@ def _scatter(ax: Axes, arguments):
                 marker=mark,
                 zorder=z_order,
                 **{k: v[logical] for k, v in arguments.items()},
+                **kwargs,
             )
 
 

--- a/mesa/visualization/components/matplotlib.py
+++ b/mesa/visualization/components/matplotlib.py
@@ -609,8 +609,7 @@ def _scatter(ax: Axes, arguments, **kwargs):
     Args:
         ax: a Matplotlib Axes instance
         arguments: the agents specific arguments for platting
-        additional keyword arguments for ax.scatter
-
+        kwargs: additional keyword arguments for ax.scatter
 
     """
     loc = arguments.pop("loc")


### PR DESCRIPTION
#2430 added the possibility to pass keyword arguments on to the various draw functions. This builds on that by passing any keyword arguments not used explicitly in any of the draw functions on to `ax.scatter`. This can, for example, be used to set a custom colormap, control vmin, vmax etc., as shown in the updated Boltzmann wealth example (see below for a screenshot)


<img width="1712" alt="Screenshot 2024-10-30 at 20 02 09" src="https://github.com/user-attachments/assets/5846eb15-601e-4699-93b2-eca4e0b7c9cd">

Closes #1183.
