### PR TITLE
Bugfix for Solara deepcopy bug

### DIFF
--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -42,7 +42,7 @@ def post_process(ax):
 
 
 # Create initial model instance
-model1 = BoltzmannWealthModel(50, 10, 10)
+model = BoltzmannWealthModel(50, 10, 10)
 
 # Create visualization elements. The visualization elements are solara components
 # that receive the model instance as a "prop" and display it in a certain way.
@@ -61,7 +61,7 @@ GiniPlot = make_plot_component("Gini")
 # solara run app.py
 # It will automatically update and display any changes made to this file
 page = SolaraViz(
-    model1,
+    model,
     components=[SpaceGraph, GiniPlot],
     model_params=model_params,
     name="Boltzmann Wealth Model",

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -1,3 +1,7 @@
+import sys
+import os.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../')))
+
 from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
 from mesa.visualization import (
     SolaraViz,
@@ -19,6 +23,11 @@ model_params = {
         "min": 10,
         "max": 100,
         "step": 1,
+    },
+    "seed": {
+        "type": "InputText",
+        "value": 42,
+        "label": "Random Seed",
     },
     "width": 10,
     "height": 10,

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -1,10 +1,3 @@
-import os.path
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../"))
-)
-
 from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
 from mesa.visualization import (
     SolaraViz,

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -1,6 +1,9 @@
-import sys
 import os.path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../')))
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../"))
+)
 
 from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealthModel
 from mesa.visualization import (

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -298,6 +298,7 @@ def ModelCreator(model, user_params, model_parameters):
         - The component provides an interface for adjusting user-defined parameters and reseeding the model.
 
     """
+
     def on_change(name, value):
         new_model_parameters = {**model_parameters.value, name: value}
         model.value = model.value.__class__(**new_model_parameters)

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -113,11 +113,12 @@ def SolaraViz(
         [model.value],
     )
     user_params, fixed_params = split_model_params(model_params)
-    model_parameters = solara.use_reactive({
+    model_parameters = solara.use_reactive(
+        {
             **fixed_params,
             **{k: v.get("value") for k, v in user_params.items()},
-        })
-
+        }
+    )
 
     with solara.AppBar():
         solara.AppBarTitle(name if name else model.value.__class__.__name__)
@@ -304,8 +305,6 @@ def ModelCreator(model, user_params, model_parameters):
         model_parameters.value = new_model_parameters
 
     UserInputs(user_params, on_change=on_change)
-
-
 
 
 def _check_model_params(init_func, model_params):

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -178,7 +178,11 @@ JupyterViz = SolaraViz
 
 
 @solara.component
-def ModelController(model: solara.Reactive[Model], model_parameters: dict | solara.Reactive[dict] = None, play_interval: int=100):
+def ModelController(
+    model: solara.Reactive[Model],
+    model_parameters: dict | solara.Reactive[dict] = None,
+    play_interval: int = 100,
+):
     """Create controls for model execution (step, play, pause, reset).
 
     Args:

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -175,7 +175,7 @@ JupyterViz = SolaraViz
 
 @solara.component
 def ModelController(
-    model: solara.Reactive[Model],
+    model: solara.Reactive[Model], *,
     model_parameters: dict | solara.Reactive[dict] = None,
     play_interval: int = 100,
 ):
@@ -271,7 +271,7 @@ def check_param_is_fixed(param):
 @solara.component
 def ModelCreator(
     model: solara.Reactive[Model],
-    user_params: dict,
+    user_params: dict, *,
     model_parameters: dict | solara.Reactive[dict] = None,
 ):
     """Solara component for creating and managing a model instance with user-defined parameters.

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -115,9 +115,15 @@ def SolaraViz(
 
     with solara.Sidebar(), solara.Column():
         with solara.Card("Controls"):
-            ModelController(model, model_parameters=reactive_model_parameters, play_interval=play_interval)
+            ModelController(
+                model,
+                model_parameters=reactive_model_parameters,
+                play_interval=play_interval,
+            )
         with solara.Card("Model Parameters"):
-            ModelCreator(model, model_params, model_parameters=reactive_model_parameters)
+            ModelCreator(
+                model, model_params, model_parameters=reactive_model_parameters
+            )
         with solara.Card("Information"):
             ShowSteps(model.value)
 
@@ -263,7 +269,11 @@ def check_param_is_fixed(param):
 
 
 @solara.component
-def ModelCreator(model: solara.Reactive[Model], user_params: dict, model_parameters: dict | solara.Reactive[dict] = None):
+def ModelCreator(
+    model: solara.Reactive[Model],
+    user_params: dict,
+    model_parameters: dict | solara.Reactive[dict] = None,
+):
     """Solara component for creating and managing a model instance with user-defined parameters.
 
     This component allows users to create a model instance with specified parameters and seed.
@@ -304,8 +314,10 @@ def ModelCreator(model: solara.Reactive[Model], user_params: dict, model_paramet
     user_params, fixed_params = split_model_params(user_params)
 
     # set model_parameters to the default values for all parameters
-    model_parameters.value = {**fixed_params,
-                              **{k: v.get("value") for k, v in user_params.items()}}
+    model_parameters.value = {
+        **fixed_params,
+        **{k: v.get("value") for k, v in user_params.items()},
+    }
 
     def on_change(name, value):
         new_model_parameters = {**model_parameters.value, name: value}

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -175,7 +175,8 @@ JupyterViz = SolaraViz
 
 @solara.component
 def ModelController(
-    model: solara.Reactive[Model], *,
+    model: solara.Reactive[Model],
+    *,
     model_parameters: dict | solara.Reactive[dict] = None,
     play_interval: int = 100,
 ):
@@ -271,7 +272,8 @@ def check_param_is_fixed(param):
 @solara.component
 def ModelCreator(
     model: solara.Reactive[Model],
-    user_params: dict, *,
+    user_params: dict,
+    *,
     model_parameters: dict | solara.Reactive[dict] = None,
 ):
     """Solara component for creating and managing a model instance with user-defined parameters.

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -109,20 +109,37 @@ def SolaraViz(
 
     solara.use_effect(connect_to_model, [model.value])
 
+
+    solara.use_effect(
+        lambda: _check_model_params(model.value.__class__.__init__, fixed_params),
+        [model.value],
+    )
+
+    user_params, fixed_params = split_model_params(model_params)
+
+    model_parameters, set_model_parameters = solara.use_state(
+        {
+            **fixed_params,
+            **{k: v.get("value") for k, v in user_params.items()},
+        }
+    )
+
+    def on_change(name, value):
+        new_model_parameters = {**model_parameters, name: value}
+        model.value = model.value.__class__(**new_model_parameters)
+        set_model_parameters(new_model_parameters)
+
+
     with solara.AppBar():
         solara.AppBarTitle(name if name else model.value.__class__.__name__)
 
     with solara.Sidebar(), solara.Column():
         with solara.Card("Controls"):
-            ModelController(model, play_interval)
+            ModelController(model, model_parameters, play_interval=play_interval)
 
         if model_params is not None:
             with solara.Card("Model Parameters"):
-                ModelCreator(
-                    model,
-                    model_params,
-                    seed=seed,
-                )
+                UserInputs(user_params, on_change=on_change)
         with solara.Card("Information"):
             ShowSteps(model.value)
 
@@ -173,7 +190,7 @@ JupyterViz = SolaraViz
 
 
 @solara.component
-def ModelController(model: solara.Reactive[Model], play_interval=100):
+def ModelController(model: solara.Reactive[Model], model_parameters, play_interval=100):
     """Create controls for model execution (step, play, pause, reset).
 
     Args:
@@ -182,15 +199,17 @@ def ModelController(model: solara.Reactive[Model], play_interval=100):
     """
     playing = solara.use_reactive(False)
     running = solara.use_reactive(True)
-    original_model = solara.use_reactive(None)
+    # original_model = solara.use_reactive(None)
 
-    def save_initial_model():
-        """Save the initial model for comparison."""
-        original_model.set(copy.deepcopy(model.value))
-        playing.value = False
-        force_update()
 
-    solara.use_effect(save_initial_model, [model.value])
+
+    # def save_initial_model():
+    #     """Save the initial model for comparison."""
+    #     original_model.set(copy.deepcopy(model.value))
+    #     playing.value = False
+    #     force_update()
+    #
+    # solara.use_effect(save_initial_model, [model.value])
 
     async def step():
         while playing.value and running.value:
@@ -210,7 +229,7 @@ def ModelController(model: solara.Reactive[Model], play_interval=100):
         """Reset the model to its initial state."""
         playing.value = False
         running.value = True
-        model.value = copy.deepcopy(original_model.value)
+        model.value = model.value = model.value.__class__(**model_parameters)
 
     def do_play_pause():
         """Toggle play/pause."""
@@ -268,58 +287,58 @@ def check_param_is_fixed(param):
         return True
 
 
-@solara.component
-def ModelCreator(model, model_params, seed=1):
-    """Solara component for creating and managing a model instance with user-defined parameters.
-
-    This component allows users to create a model instance with specified parameters and seed.
-    It provides an interface for adjusting model parameters and reseeding the model's random
-    number generator.
-
-    Args:
-        model (solara.Reactive[Model]): A reactive model instance. This is the main model to be created and managed.
-        model_params (dict): Dictionary of model parameters. This includes both user-adjustable parameters and fixed parameters.
-        seed (int, optional): Initial seed for the random number generator. Defaults to 1.
-
-    Returns:
-        solara.component: A Solara component that renders the model creation and management interface.
-
-    Example:
-        >>> model = solara.reactive(MyModel())
-        >>> model_params = {
-        >>>     "param1": {"type": "slider", "value": 10, "min": 0, "max": 100},
-        >>>     "param2": {"type": "slider", "value": 5, "min": 1, "max": 10},
-        >>> }
-        >>> creator = ModelCreator(model, model_params)
-        >>> creator
-
-    Notes:
-        - The `model_params` argument should be a dictionary where keys are parameter names and values either fixed values
-          or are dictionaries containing parameter details such as type, value, min, and max.
-        - The `seed` argument ensures reproducibility by setting the initial seed for the model's random number generator.
-        - The component provides an interface for adjusting user-defined parameters and reseeding the model.
-
-    """
-    solara.use_effect(
-        lambda: _check_model_params(model.value.__class__.__init__, fixed_params),
-        [model.value],
-    )
-
-    user_params, fixed_params = split_model_params(model_params)
-
-    model_parameters, set_model_parameters = solara.use_state(
-        {
-            **fixed_params,
-            **{k: v.get("value") for k, v in user_params.items()},
-        }
-    )
-
-    def on_change(name, value):
-        new_model_parameters = {**model_parameters, name: value}
-        model.value = model.value.__class__(**new_model_parameters)
-        set_model_parameters(new_model_parameters)
-
-    UserInputs(user_params, on_change=on_change)
+# @solara.component
+# def ModelCreator(model, model_params, seed=1):
+#     """Solara component for creating and managing a model instance with user-defined parameters.
+#
+#     This component allows users to create a model instance with specified parameters and seed.
+#     It provides an interface for adjusting model parameters and reseeding the model's random
+#     number generator.
+#
+#     Args:
+#         model (solara.Reactive[Model]): A reactive model instance. This is the main model to be created and managed.
+#         model_params (dict): Dictionary of model parameters. This includes both user-adjustable parameters and fixed parameters.
+#         seed (int, optional): Initial seed for the random number generator. Defaults to 1.
+#
+#     Returns:
+#         solara.component: A Solara component that renders the model creation and management interface.
+#
+#     Example:
+#         >>> model = solara.reactive(MyModel())
+#         >>> model_params = {
+#         >>>     "param1": {"type": "slider", "value": 10, "min": 0, "max": 100},
+#         >>>     "param2": {"type": "slider", "value": 5, "min": 1, "max": 10},
+#         >>> }
+#         >>> creator = ModelCreator(model, model_params)
+#         >>> creator
+#
+#     Notes:
+#         - The `model_params` argument should be a dictionary where keys are parameter names and values either fixed values
+#           or are dictionaries containing parameter details such as type, value, min, and max.
+#         - The `seed` argument ensures reproducibility by setting the initial seed for the model's random number generator.
+#         - The component provides an interface for adjusting user-defined parameters and reseeding the model.
+#
+#     """
+#     solara.use_effect(
+#         lambda: _check_model_params(model.value.__class__.__init__, fixed_params),
+#         [model.value],
+#     )
+#
+#     user_params, fixed_params = split_model_params(model_params)
+#
+#     model_parameters, set_model_parameters = solara.use_state(
+#         {
+#             **fixed_params,
+#             **{k: v.get("value") for k, v in user_params.items()},
+#         }
+#     )
+#
+#     def on_change(name, value):
+#         new_model_parameters = {**model_parameters, name: value}
+#         model.value = model.value.__class__(**new_model_parameters)
+#         set_model_parameters(new_model_parameters)
+#
+#
 
 
 def _check_model_params(init_func, model_params):
@@ -405,6 +424,12 @@ def UserInputs(user_params, on_change=None):
             )
         elif input_type == "Checkbox":
             solara.Checkbox(
+                label=label,
+                on_value=change_handler,
+                value=options.get("value"),
+            )
+        elif input_type == "InputText":
+            solara.InputText(
                 label=label,
                 on_value=change_handler,
                 value=options.get("value"),

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -88,6 +88,8 @@ def SolaraViz(
     """
     if components == "default":
         components = [components_altair.make_space_altair()]
+    if model_params is None:
+        model_params = {}
 
     # Convert model to reactive
     if not isinstance(model, solara.Reactive):

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -24,7 +24,6 @@ See the Visualization Tutorial and example models for more details.
 from __future__ import annotations
 
 import asyncio
-import copy
 import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
@@ -109,7 +108,6 @@ def SolaraViz(
 
     solara.use_effect(connect_to_model, [model.value])
 
-
     solara.use_effect(
         lambda: _check_model_params(model.value.__class__.__init__, fixed_params),
         [model.value],
@@ -128,7 +126,6 @@ def SolaraViz(
         new_model_parameters = {**model_parameters, name: value}
         model.value = model.value.__class__(**new_model_parameters)
         set_model_parameters(new_model_parameters)
-
 
     with solara.AppBar():
         solara.AppBarTitle(name if name else model.value.__class__.__name__)
@@ -200,8 +197,6 @@ def ModelController(model: solara.Reactive[Model], model_parameters, play_interv
     playing = solara.use_reactive(False)
     running = solara.use_reactive(True)
     # original_model = solara.use_reactive(None)
-
-
 
     # def save_initial_model():
     #     """Save the initial model for comparison."""

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -178,17 +178,19 @@ JupyterViz = SolaraViz
 
 
 @solara.component
-def ModelController(model: solara.Reactive[Model], model_parameters, play_interval=100):
+def ModelController(model: solara.Reactive[Model], model_parameters: dict | solara.Reactive[dict] = None, play_interval: int=100):
     """Create controls for model execution (step, play, pause, reset).
 
     Args:
-        model (solara.Reactive[Model]): Reactive model instance
-        play_interval (int, optional): Interval for playing the model steps in milliseconds.
+        model: Reactive model instance
         model_parameters: Reactive parameters for (re-)instantiating a model.
+        play_interval: Interval for playing the model steps in milliseconds.
 
     """
     playing = solara.use_reactive(False)
     running = solara.use_reactive(True)
+    if model_parameters is None:
+        model_parameters = solara.use_reactive({})
 
     async def step():
         while playing.value and running.value:

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -195,6 +195,8 @@ def ModelController(model: solara.Reactive[Model], model_parameters, play_interv
     Args:
         model (solara.Reactive[Model]): Reactive model instance
         play_interval (int, optional): Interval for playing the model steps in milliseconds.
+        model_parameters: Parameters for (re-)instantiating a model.
+
     """
     playing = solara.use_reactive(False)
     running = solara.use_reactive(True)

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -298,7 +298,6 @@ def ModelCreator(model, user_params, model_parameters):
         - The component provides an interface for adjusting user-defined parameters and reseeding the model.
 
     """
-
     def on_change(name, value):
         new_model_parameters = {**model_parameters.value, name: value}
         model.value = model.value.__class__(**new_model_parameters)

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -116,7 +116,10 @@ def test_call_space_drawer(mocker):  # noqa: D103
     # initialize with space drawer unspecified (use default)
     # component must be rendered for code to run
     solara.render(
-        SolaraViz(model, components=[make_mpl_space_component(agent_portrayal)], )
+        SolaraViz(
+            model,
+            components=[make_mpl_space_component(agent_portrayal)],
+        )
     )
     # should call default method with class instance and agent portrayal
     mock_space_matplotlib.assert_called_with(

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -101,7 +101,11 @@ def test_call_space_drawer(mocker):  # noqa: D103
         mesa.visualization.components.altair_components, "SpaceAltair"
     )
 
-    model = mesa.Model()
+    class MockModel(mesa.Model):
+        def __init__(self, seed=None):
+            super().__init__(seed=seed)
+
+    model = MockModel()
     mocker.patch.object(mesa.Model, "__init__", return_value=None)
 
     agent_portrayal = {
@@ -112,7 +116,7 @@ def test_call_space_drawer(mocker):  # noqa: D103
     # initialize with space drawer unspecified (use default)
     # component must be rendered for code to run
     solara.render(
-        SolaraViz(model, components=[make_mpl_space_component(agent_portrayal)])
+        SolaraViz(model, components=[make_mpl_space_component(agent_portrayal)], )
     )
     # should call default method with class instance and agent portrayal
     mock_space_matplotlib.assert_called_with(


### PR DESCRIPTION
This removes the deepcopy operation from SolaraViz. This changes the behavior. The current behavior is that when reset is hit, the model is reset to the original model passed when initializing SolaraViz. Getting rid of deepcopy implies that this behavior cannot be maintained. So, I replace it here by resetting the model to whatever the current values are for the model parameters (i.e., the user controllable settings, combined with the passed fixed values). 

I also added (but this can be its own PR) an extra user input field for a TextInput. This allows for recreating the seed input that we had before #2454.

If we agree on this PR, we might revert #2378. 

In passing, I fixed another bug: if model_params was not specified SolaraViz would error in _check_params. 

closes #2427

