### PR TITLE
solaraviz kwargs related bugfix 

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -351,9 +351,7 @@ def _check_model_params(init_func, model_params):
         ):
             raise ValueError(f"Missing required model parameter: {name}")
     for name in model_params:
-        if (name not in model_parameters
-           and "kwargs" not in model_parameters
-        ):
+        if name not in model_parameters and "kwargs" not in model_parameters:
             raise ValueError(f"Invalid model parameter: {name}")
 
 

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -347,6 +347,7 @@ def _check_model_params(init_func, model_params):
             model_parameters[name].default == inspect.Parameter.empty
             and name not in model_params
             and name != "self"
+            and name != "kwargs"
         ):
             raise ValueError(f"Missing required model parameter: {name}")
     for name in model_params:

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -351,7 +351,9 @@ def _check_model_params(init_func, model_params):
         ):
             raise ValueError(f"Missing required model parameter: {name}")
     for name in model_params:
-        if name not in model_parameters:
+        if (name not in model_parameters
+           and "kwargs" not in model_parameters
+        ):
             raise ValueError(f"Invalid model parameter: {name}")
 
 

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -191,7 +191,8 @@ def ModelController(
     playing = solara.use_reactive(False)
     running = solara.use_reactive(True)
     if model_parameters is None:
-        model_parameters = solara.use_reactive({})
+        model_parameters = {}
+    model_parameters = solara.use_reactive(model_parameters)
 
     async def step():
         while playing.value and running.value:
@@ -307,7 +308,8 @@ def ModelCreator(
 
     """
     if model_parameters is None:
-        model_parameters = solara.use_reactive({})
+        model_parameters = {}
+    model_parameters = solara.use_reactive(model_parameters)
 
     solara.use_effect(
         lambda: _check_model_params(model.value.__class__.__init__, fixed_params),

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -189,14 +189,10 @@ def test_model_param_checks():  # noqa: D103
     )
 
     # Test that model_params are accepted if model uses **kwargs
-    _check_model_params(
-        ModelWithKwargs.__init__, {"another_kwarg":6}
-    )
+    _check_model_params(ModelWithKwargs.__init__, {"another_kwarg": 6})
 
     # test hat kwargs are accepted even if no model_params are specified
-    _check_model_params(
-        ModelWithKwargs.__init__, {}
-    )
+    _check_model_params(ModelWithKwargs.__init__, {})
 
     # Test invalid parameter name raises ValueError
     with pytest.raises(ValueError, match="Invalid model parameter: invalid_param"):

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -180,7 +180,6 @@ def test_model_param_checks():  # noqa: D103
         def __init__(self, **kwargs):
             pass
 
-
     # Test that optional params can be omitted
     _check_model_params(ModelWithOptionalParams.__init__, {"required_param": 1})
 
@@ -190,12 +189,8 @@ def test_model_param_checks():  # noqa: D103
     )
 
     # Test that kwargs are accepted
-    _check_model_params(
-        ModelWithKwargs.__init__, {"another_kwarg":6}
-    )
-    _check_model_params(
-        ModelWithKwargs.__init__, {}
-    )
+    _check_model_params(ModelWithKwargs.__init__, {"another_kwarg": 6})
+    _check_model_params(ModelWithKwargs.__init__, {})
 
     # Test invalid parameter name raises ValueError
     with pytest.raises(ValueError, match="Invalid model parameter: invalid_param"):

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -188,9 +188,15 @@ def test_model_param_checks():  # noqa: D103
         ModelWithOptionalParams.__init__, {"required_param": 1, "optional_param": 5}
     )
 
-    # Test that kwargs are accepted
-    _check_model_params(ModelWithKwargs.__init__, {"another_kwarg": 6})
-    _check_model_params(ModelWithKwargs.__init__, {})
+    # Test that model_params are accepted if model uses **kwargs
+    _check_model_params(
+        ModelWithKwargs.__init__, {"another_kwarg":6}
+    )
+
+    # test hat kwargs are accepted even if no model_params are specified
+    _check_model_params(
+        ModelWithKwargs.__init__, {}
+    )
 
     # Test invalid parameter name raises ValueError
     with pytest.raises(ValueError, match="Invalid model parameter: invalid_param"):

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -176,12 +176,25 @@ def test_model_param_checks():  # noqa: D103
         def __init__(self, param1, param2):
             pass
 
+    class ModelWithKwargs:
+        def __init__(self, **kwargs):
+            pass
+
+
     # Test that optional params can be omitted
     _check_model_params(ModelWithOptionalParams.__init__, {"required_param": 1})
 
     # Test that optional params can be provided
     _check_model_params(
         ModelWithOptionalParams.__init__, {"required_param": 1, "optional_param": 5}
+    )
+
+    # Test that kwargs are accepted
+    _check_model_params(
+        ModelWithKwargs.__init__, {"another_kwarg":6}
+    )
+    _check_model_params(
+        ModelWithKwargs.__init__, {}
     )
 
     # Test invalid parameter name raises ValueError


### PR DESCRIPTION
If `MyModel .__init__()` uses `**kwargs` to allow additional optional model configuration this errors because of the parameter check introduced in #2454. This PR addresses this by excluding `kwargs` explicitly in `_check_model_params`.

In passing, it also removes a user warning related to [the conditional use of hooks](https://solara.dev/documentation/advanced/understanding/rules-of-hooks) introduced in #2460. 


This closes #2462.