### PR TITLE
Bump version to 3.0.0, remove 2.x references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ can be displayed in browser windows or Jupyter.*
 
 ## Using Mesa
 
-To install our latest stable release (2.4.x), run:
+To install our latest stable release (3.0.x), run:
 
 ``` bash
 pip install -U mesa
 ```
 
-To install our latest pre-release (3.0.0 alpha), run:
+To install our latest pre-release, run:
 
 ``` bash
 pip install -U --pre mesa
 ```
-With Mesa 3.0, we don't install all our dependencies anymore by default.
+Starting with Mesa 3.0, we don't install all our dependencies anymore by default.
 ```bash
 # You can customize the additional dependencies you need, if you want. Available are:
 pip install -U --pre mesa[network,viz]

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,14 +33,17 @@ Mesa allows users to quickly create agent-based models using built-in core compo
 
 ## Using Mesa
 ### Installation Options
-
-To install our latest stable release (2.4.x), run:
+To install our latest stable release (3.0.x), run:
 
 ```bash
 pip install -U mesa
 ```
+To also install our recommended dependencies:
+```bash
+pip install -U mesa[rec]
+```
 
-To install our latest Mesa 3.0 beta with recommended dependencies:
+To install our latest pre-release:
 
 ```bash
 pip install -U --pre mesa[rec]

--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -9,7 +9,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This version of the visualisation tutorial is updated for Mesa 3.0, and works with Mesa `3.0.0a4` and above. If you are using Mesa 2.3.x, check out the [stable version](https://mesa.readthedocs.io/stable/tutorials/visualization_tutorial.html) of this tutorial on Readthedocs.*\n",
+    "*This version of the visualisation tutorial is updated for Mesa 3.0, and works with Mesa `3.0.0` and above.*\n",
     "\n",
     "> **Note:** SolaraViz is experimental and still in active development for Mesa 3.0. While we attempt to minimize them, there might be API breaking changes between Mesa 3.0 and 3.1. There won't be breaking changes between Mesa 3.0.x patch releases.\n",
     "\n",

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 __title__ = "mesa"
-__version__ = "3.0.0rc0"
+__version__ = "3.0.0"
 __license__ = "Apache 2.0"
 _this_year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
 __copyright__ = f"Copyright {_this_year} Project Mesa Team"


### PR DESCRIPTION
Bumps the Mesa version to 3.0.0, and updates or removes references to 2.x being our latest stable release.

I thought I would need to update more references, it's actually quite clean!
