### PR TITLE
Update some DeprecationWarnings to note they are removed in Mesa 3.1

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -146,7 +146,7 @@ You can access it by `Model.steps`, and it's internally in the datacollector, ba
 - The `Model._advance_time()` method is removed. This now happens automatically.
 
 #### Replacing Schedulers with AgentSet functionality
-The whole Time module in Mesa is deprecated, and all schedulers are being replaced with AgentSet functionality and the internal `Model.steps` counter. This allows much more flexibility in how to activate Agents and makes it explicit what's done exactly.
+The whole Time module in Mesa is deprecated and will be removed in Mesa 3.1. All schedulers should be replaced with AgentSet functionality and the internal `Model.steps` counter. This allows much more flexibility in how to activate Agents and makes it explicit what's done exactly.
 
 Here's how to replace each scheduler:
 

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -167,7 +167,7 @@ class AgentSet(MutableSet, Sequence):
         """
         if n is not None:
             warnings.warn(
-                "The parameter 'n' is deprecated. Use 'at_most' instead.",
+                "The parameter 'n' is deprecated and will be removed in Mesa 3.1. Use 'at_most' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -276,8 +276,9 @@ class AgentSet(MutableSet, Sequence):
             return_results = False
         else:
             warnings.warn(
-                "Using return_results is deprecated. Use AgenSet.do in case of return_results=False, and "
-                "AgentSet.map in case of return_results=True",
+                "Using return_results is deprecated and will be removed in Mesa 3.1."
+                "Use AgenSet.do in case of return_results=False, and AgentSet.map in case of return_results=True",
+                DeprecationWarning,
                 stacklevel=2,
             )
 

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -114,7 +114,7 @@ class Model:
 
     def next_id(self) -> int:  # noqa: D102
         warnings.warn(
-            "using model.next_id() is deprecated. Agents track their unique ID automatically",
+            "using model.next_id() is deprecated and will be removed in Mesa 3.1. Agents track their unique ID automatically",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -146,8 +146,8 @@ class Model:
     def get_agents_of_type(self, agenttype: type[Agent]) -> AgentSet:
         """Deprecated: Retrieves an AgentSet containing all agents of the specified type."""
         warnings.warn(
-            f"Model.get_agents_of_type() is deprecated, please replace get_agents_of_type({agenttype})"
-            f"with the property agents_by_type[{agenttype}].",
+            f"Model.get_agents_of_type() is deprecated and will be removed in Mesa 3.1."
+            f"Please replace get_agents_of_type({agenttype}) with the property agents_by_type[{agenttype}].",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -262,7 +262,7 @@ class Model:
 
         """
         warnings.warn(
-            "initialize_data_collector() is deprecated. Please use the DataCollector class directly. "
+            "initialize_data_collector() is deprecated and will be removed in Mesa 3.1. Please use the DataCollector class directly. "
             "by using `self.datacollector = DataCollector(...)`.",
             DeprecationWarning,
             stacklevel=2,

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -1,7 +1,7 @@
 """Mesa Time Module.
 
 .. warning::
-    The time module and all its Schedulers are deprecated and will be removed in a future version.
+    The time module and all its Schedulers are deprecated and will be removed in Mesa 3.1.
     They can be replaced with AgentSet functionality. See the migration guide for details:
     https://mesa.readthedocs.io/latest/migration_guide.html#time-and-schedulers
 
@@ -63,7 +63,7 @@ class BaseScheduler:
 
         """
         warnings.warn(
-            "The time module and all its Schedulers are deprecated and will be removed in a future version. "
+            "The time module and all its Schedulers are deprecated and will be removed in Mesa 3.1. "
             "They can be replaced with AgentSet functionality. See the migration guide for details. "
             "https://mesa.readthedocs.io/latest/migration_guide.html#time-and-schedulers",
             DeprecationWarning,
@@ -375,7 +375,7 @@ class RandomActivationByType(BaseScheduler):
 
 
 class DiscreteEventScheduler(BaseScheduler):
-    """This class has been deprecated and replaced by the functionality provided by experimental.devs."""
+    """This class has been removed and replaced by the functionality provided by experimental.devs."""
 
     def __init__(self, model: Model, time_step: TimeT = 1) -> None:
         """Initialize DiscreteEventScheduler.
@@ -387,5 +387,5 @@ class DiscreteEventScheduler(BaseScheduler):
         """
         super().__init__(model)
         raise Exception(
-            "DiscreteEventScheduler is deprecated in favor of the functionality provided by experimental.devs"
+            "DiscreteEventScheduler is removed in favor of the functionality provided by experimental.devs"
         )


### PR DESCRIPTION
This improves some of the DeprecationWarnings to make it explicit that certain features will be removed in Mesa 3.1. This communicated this clearly in line with our recommend [upgrade strategy](https://github.com/projectmesa/mesa/blob/main/docs/migration_guide.md#upgrade-strategy).

Features to already deprecated to be removed in Mesa 3.1:

1. **Time Module**: The entire `Time` module, including all schedulers, is deprecated and will be removed. Replacement with `AgentSet` functionality is recommended.
2. **Parameter `n` in `AgentSet.select`**: The `n` parameter is deprecated; use `at_most` instead.
3. **`return_results` in `AgentSet.do`**: The `return_results` option is deprecated; use `AgentSet.do` for `return_results=False` and `AgentSet.map` for `return_results=True`.
4. **Model's `next_id()` method**: `model.next_id()` is deprecated as agents now track their unique IDs automatically.
5. **`get_agents_of_type` in Model**: `Model.get_agents_of_type()` is deprecated; use the `agents_by_type` property instead.
6. **`initialize_data_collector()` method**: This method is deprecated; directly use the `DataCollector` class by setting `self.datacollector = DataCollector(...)`.
7. **`DiscreteEventScheduler`**: This class is removed, and users should use the functionality provided by `experimental.devs`.

Note this does not add new deprecations, is just updates some to message more clearly when they get removed.