### PR TITLE
examples: Add required components keyword

### DIFF
--- a/mesa/examples/basic/boid_flockers/app.py
+++ b/mesa/examples/basic/boid_flockers/app.py
@@ -51,7 +51,7 @@ model = BoidFlockers()
 
 page = SolaraViz(
     model,
-    [make_space_component(agent_portrayal=boid_draw, backend="matplotlib")],
+    components=[make_space_component(agent_portrayal=boid_draw, backend="matplotlib")],
     model_params=model_params,
     name="Boid Flocking Model",
 )

--- a/mesa/examples/basic/virus_on_network/app.py
+++ b/mesa/examples/basic/virus_on_network/app.py
@@ -103,7 +103,7 @@ model1 = VirusOnNetwork()
 
 page = SolaraViz(
     model1,
-    [
+    components=[
         SpacePlot,
         StatePlot,
         get_resistant_susceptible_ratio,


### PR DESCRIPTION
SolaraViz now requires `components` to be a keyword argument, this adds it to the two example that didn't have that.

It also shows we really need to start testing our examples in CI.