### PR TITLE
example: Add input sliders to Sugerscape viz

### DIFF
--- a/mesa/examples/advanced/sugarscape_g1mt/app.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/app.py
@@ -4,7 +4,7 @@ from matplotlib.figure import Figure
 
 from mesa.examples.advanced.sugarscape_g1mt.agents import Trader
 from mesa.examples.advanced.sugarscape_g1mt.model import SugarscapeG1mt
-from mesa.visualization import SolaraViz, make_plot_component
+from mesa.visualization import Slider, SolaraViz, make_plot_component
 
 
 def SpaceDrawer(model):
@@ -49,13 +49,29 @@ def SpaceDrawer(model):
 model_params = {
     "width": 50,
     "height": 50,
+    # Population parameters
+    "initial_population": Slider(
+        "Initial Population", value=200, min=50, max=500, step=10
+    ),
+    # Agent endowment parameters
+    "endowment_min": Slider("Min Initial Endowment", value=25, min=5, max=30, step=1),
+    "endowment_max": Slider("Max Initial Endowment", value=50, min=30, max=100, step=1),
+    # Metabolism parameters
+    "metabolism_min": Slider("Min Metabolism", value=1, min=1, max=3, step=1),
+    "metabolism_max": Slider("Max Metabolism", value=5, min=3, max=8, step=1),
+    # Vision parameters
+    "vision_min": Slider("Min Vision", value=1, min=1, max=3, step=1),
+    "vision_max": Slider("Max Vision", value=5, min=3, max=8, step=1),
+    # Trade parameter
+    "enable_trade": {"type": "Checkbox", "value": True, "label": "Enable Trading"},
 }
 
-model1 = SugarscapeG1mt(50, 50)
+model1 = SugarscapeG1mt()
 
 page = SolaraViz(
     model1,
     components=[SpaceDrawer, make_plot_component(["Trader", "Price"])],
+    model_params=model_params,
     name="Sugarscape {G1, M, T}",
     play_interval=150,
 )


### PR DESCRIPTION
Add input sliders and a checkbox to the Sugerscape visualisation SolaraViz app.py.

![image](https://github.com/user-attachments/assets/d5443ac4-d70d-4ab3-a293-a5e53b1b044a)

Closes #2486.