### PR TITLE
allow components as a positional argument again

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -43,10 +43,10 @@ if TYPE_CHECKING:
 @solara.component
 def SolaraViz(
     model: Model | solara.Reactive[Model],
-    *,
     components: list[reacton.core.Component]
     | list[Callable[[Model], reacton.core.Component]]
     | Literal["default"] = "default",
+    *,
     play_interval: int = 100,
     simulator: Simulator | None = None,
     model_params=None,


### PR DESCRIPTION
Followup on #2485 

I missed this in the code review. I think "components" should also be allowed as a positional argument. Thats at least how I usually use it when playing around. My mental model is that "model" and "components" are required arguments, which should always be provided and the other arguments can be provided, but in no specific order. The counter argument is that components also have a default value ("default"), so my mental model is not fully correct since its not strictly required. @quaquel  whats your stance on this? 