### PR TITLE
examples/gol: Add initial fraction alive, add sliders to viz

### DIFF
--- a/mesa/examples/basic/conways_game_of_life/app.py
+++ b/mesa/examples/basic/conways_game_of_life/app.py
@@ -20,12 +20,34 @@ def post_process(ax):
 
 
 model_params = {
-    "width": 50,
-    "height": 50,
+    "width": {
+        "type": "SliderInt",
+        "value": 50,
+        "label": "Width",
+        "min": 5,
+        "max": 60,
+        "step": 1,
+    },
+    "height": {
+        "type": "SliderInt",
+        "value": 50,
+        "label": "Height",
+        "min": 5,
+        "max": 60,
+        "step": 1,
+    },
+    "initial_fraction_alive": {
+        "type": "SliderFloat",
+        "value": 0.2,
+        "label": "Cells initially alive",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+    },
 }
 
 # Create initial model instance
-model1 = ConwaysGameOfLife(50, 50)
+model1 = ConwaysGameOfLife()
 
 # Create visualization elements. The visualization elements are solara components
 # that receive the model instance as a "prop" and display it in a certain way.

--- a/mesa/examples/basic/conways_game_of_life/model.py
+++ b/mesa/examples/basic/conways_game_of_life/model.py
@@ -6,7 +6,7 @@ from mesa.space import SingleGrid
 class ConwaysGameOfLife(Model):
     """Represents the 2-dimensional array of cells in Conway's Game of Life."""
 
-    def __init__(self, width=50, height=50, seed=None):
+    def __init__(self, width=50, height=50, initial_fraction_alive=0.2, seed=None):
         """Create a new playing area of (width, height) cells."""
         super().__init__(seed=seed)
         # Use a simple grid, where edges wrap around.
@@ -16,7 +16,7 @@ class ConwaysGameOfLife(Model):
         # ALIVE and some to DEAD.
         for _contents, (x, y) in self.grid.coord_iter():
             cell = Cell((x, y), self)
-            if self.random.random() < 0.1:
+            if self.random.random() < initial_fraction_alive:
                 cell.state = cell.ALIVE
             self.grid.place_agent(cell, (x, y))
 


### PR DESCRIPTION
Improve the Game of Life examples:
- Add a initial_fraction_alive keyword argument for the how many cells are alive at the start
- Add sliders for width, height and the initial fraction alive.

![image](https://github.com/user-attachments/assets/7f1a70f0-9be5-449d-8b7d-bd310355ede8)
