### PR TITLE
examples: Fix schelling viz

### DIFF
--- a/mesa/examples/basic/schelling/app.py
+++ b/mesa/examples/basic/schelling/app.py
@@ -26,7 +26,7 @@ model_params = {
     "height": 20,
 }
 
-model1 = Schelling(20, 20, 0.8, 0.2, 3)
+model1 = Schelling()
 
 HappyPlot = make_plot_component({"happy": "tab:green"})
 


### PR DESCRIPTION
Fix the Schelling visualisation. Default arguments are already defined in the model.py, and the visualisation crashed probably because of the order having changed.

Before:
```
  File "C:\Users\Ewout\.virtualenvs\Py312\Lib\site-packages\mesa\examples\basic\schelling\agents.py", line 20, in step
    similar = sum(1 for neighbor in neighbors if neighbor.type == self.type)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ewout\.virtualenvs\Py312\Lib\site-packages\mesa\examples\basic\schelling\agents.py", line 20, in <genexpr>
    similar = sum(1 for neighbor in neighbors if neighbor.type == self.type)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ewout\.virtualenvs\Py312\Lib\site-packages\mesa\space.py", line 371, in iter_neighbors
    for x, y in self.get_neighborhood(pos, moore, include_center, radius):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ewout\.virtualenvs\Py312\Lib\site-packages\mesa\space.py", line 309, in get_neighborhood
    x_range = range(x - radius, x + radius + 1)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
```
After:
![image](https://github.com/user-attachments/assets/0a604aaf-1203-4c6f-adfe-b04d1e5ad81d)
