### PR TITLE
cell_space: Allow CellCollection to be empty

### DIFF
--- a/mesa/experimental/cell_space/cell_collection.py
+++ b/mesa/experimental/cell_space/cell_collection.py
@@ -48,8 +48,10 @@ class CellCollection(Generic[T]):
         else:
             self._cells = {cell: cell.agents for cell in cells}
 
-        #
-        self._capacity: int = next(iter(self._cells.keys())).capacity
+        # Get capacity from first cell if collection is not empty
+        self._capacity: int | None = (
+            next(iter(self._cells.keys())).capacity if self._cells else None
+        )
 
         if random is None:
             warnings.warn(

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -583,6 +583,40 @@ def test_cell_collection():
     assert len(cells) == len(collection)
 
 
+def test_empty_cell_collection():
+    """Test that CellCollection properly handles empty collections."""
+    rng = random.Random(42)
+
+    # Test initializing with empty collection
+    collection = CellCollection([], random=rng)
+    assert len(collection) == 0
+    assert collection._capacity is None
+    assert list(collection.cells) == []
+    assert list(collection.agents) == []
+
+    # Test selecting from empty collection
+    selected = collection.select(lambda cell: True)
+    assert len(selected) == 0
+    assert selected._capacity is None
+
+    # Test filtering to empty collection
+    n = 10
+    full_collection = CellCollection(
+        [Cell((i,), random=rng) for i in range(n)], random=rng
+    )
+    assert len(full_collection) == n
+
+    # Filter to empty collection
+    empty_result = full_collection.select(lambda cell: False)
+    assert len(empty_result) == 0
+    assert empty_result._capacity is None
+
+    # Test at_most with empty collection
+    at_most_result = full_collection.select(lambda cell: False, at_most=5)
+    assert len(at_most_result) == 0
+    assert at_most_result._capacity is None
+
+
 ### PropertyLayer tests
 def test_property_layer_integration():
     """Test integration of PropertyLayer with DiscrateSpace and Cell."""


### PR DESCRIPTION
Sometimes a CellCollection needs to be empty, especially after filtering with `.select()`. However, the code would raise a StopIteration error trying to get `capacity` from the first cell. This PR handles empty collections gracefully.

### Summary
Fix StopIteration error when creating empty CellCollections by allowing `capacity` to be None when there are no cells.

### Bug / Issue
Creating a CellCollection with no cells (after filtering) raises StopIteration:
```python
# This raises StopIteration if no cells meet the condition
cells = neighbors.select(lambda cell: not any(isinstance(obj, Wolf) for obj in cell.agents))
```

### Implementation
Check for empty collection before accessing first cell's capacity:
```python
self._capacity: int | None = (
    next(iter(self._cells.keys())).capacity if self._cells else None
)
```

### Testing
- Verify empty CellCollection creation
- Test select() with no matching cells
- Check behavior of empty collection methods