### PR TITLE
Only set model_parameters once

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -382,11 +382,17 @@ def ModelCreator(
     )
     user_params, fixed_params = split_model_params(user_params)
 
-    # set model_parameters to the default values for all parameters
-    model_parameters.value = {
-        **fixed_params,
-        **{k: v.get("value") for k, v in user_params.items()},
-    }
+    # Use solara.use_effect to run the initialization code only once
+    solara.use_effect(
+        # set model_parameters to the default values for all parameters
+        lambda: model_parameters.set(
+            {
+                **fixed_params,
+                **{k: v.get("value") for k, v in user_params.items()},
+            }
+        ),
+        [],
+    )
 
     def on_change(name, value):
         model_parameters.value = {**model_parameters.value, name: value}


### PR DESCRIPTION
## Summary
While working on a seed widget I saw a major bug in solara viz. Model_parameters get reset on every model reset. This is pretty serious and I think we need another bug release soon. 

## Bug / Issue
**Describe the bug**
Hitting "reset" in the ui resets the model, but also resets the model_parameters to their initial value. 

**To Reproduce**
Run Schelling example. Reduce agent density. Hit reset. Works as expected. Hit reset again. Density is now restored. 


## Implementation
Use solaras `use_effect` to initialize model_parameters only once.


[screen-capture.webm](https://github.com/user-attachments/assets/2bb82a8e-5552-40ca-9840-e4580a2c48aa)
