### PR TITLE
bugfix in global_benchmark.py

### DIFF
--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -7,13 +7,14 @@ import sys
 import time
 import timeit
 
-from configurations import configurations
-
-from mesa.experimental.devs.simulator import ABMSimulator
-
 # making sure we use this version of mesa and not one
 # also installed in site_packages or so.
 sys.path.insert(0, os.path.abspath(".."))
+
+from configurations import configurations
+from mesa.experimental.devs.simulator import ABMSimulator
+
+
 
 
 # Generic function to initialize and run a model

--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -12,9 +12,8 @@ import timeit
 sys.path.insert(0, os.path.abspath(".."))
 
 from configurations import configurations
+
 from mesa.experimental.devs.simulator import ABMSimulator
-
-
 
 
 # Generic function to initialize and run a model


### PR DESCRIPTION
This PR moves the `sys.insert` statement to be before any mesa imports. The old version resulted in potentially importing the examples from the installed version of mesa. 