### PR TITLE
Added homophily ratio in basic schelling example

### DIFF
--- a/benchmarks/configurations.py
+++ b/benchmarks/configurations.py
@@ -35,7 +35,7 @@ configurations = {
             "parameters": {
                 "height": 40,
                 "width": 40,
-                "homophily": 3,
+                "homophily": 0.4,
                 "radius": 1,
                 "density": 0.625,
             },
@@ -47,7 +47,7 @@ configurations = {
             "parameters": {
                 "height": 100,
                 "width": 100,
-                "homophily": 8,
+                "homophily": 0.4,
                 "radius": 2,
                 "density": 0.8,
             },

--- a/benchmarks/configurations.py
+++ b/benchmarks/configurations.py
@@ -47,7 +47,7 @@ configurations = {
             "parameters": {
                 "height": 100,
                 "width": 100,
-                "homophily": 0.4,
+                "homophily": 1,
                 "radius": 2,
                 "density": 0.8,
             },

--- a/mesa/examples/basic/schelling/app.py
+++ b/mesa/examples/basic/schelling/app.py
@@ -26,7 +26,7 @@ model_params = {
     },
     "density": Slider("Agent density", 0.8, 0.1, 1.0, 0.1),
     "minority_pc": Slider("Fraction minority", 0.2, 0.0, 1.0, 0.05),
-    "homophily": Slider("Homophily", 0.3, 0.0, 0.8, 0.1),
+    "homophily": Slider("Homophily", 0.4, 0.0, 1.0, 0.1),
     "width": 20,
     "height": 20,
 }

--- a/mesa/examples/basic/schelling/app.py
+++ b/mesa/examples/basic/schelling/app.py
@@ -26,7 +26,7 @@ model_params = {
     },
     "density": Slider("Agent density", 0.8, 0.1, 1.0, 0.1),
     "minority_pc": Slider("Fraction minority", 0.2, 0.0, 1.0, 0.05),
-    "homophily": Slider("Homophily", 0.4, 0.0, 1.0, 0.1),
+    "homophily": Slider("Homophily", 0.4, 0.0, 1.0, 0.125),
     "width": 20,
     "height": 20,
 }

--- a/mesa/examples/basic/schelling/model.py
+++ b/mesa/examples/basic/schelling/model.py
@@ -9,11 +9,11 @@ class Schelling(Model):
 
     def __init__(
         self,
-        height: int = 40,
-        width: int = 40,
+        height: int = 20,
+        width: int = 20,
         density: float = 0.8,
         minority_pc: float = 0.5,
-        homophily: int = 3,
+        homophily: float = 0.4,
         radius: int = 1,
         seed=None,
     ):


### PR DESCRIPTION
Changed homophily comparing logic as per discussion in #2515.
Now homophily_ratio is checked for agents to be happy. homophily_ratio is similar neighboring agents divided by the total number of neighbors.