### PR TITLE
added empty iterable checks and updated tests

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -106,9 +106,16 @@ def _make_model_kwargs(
     Parameters
     ----------
     parameters : Mapping[str, Union[Any, Iterable[Any]]]
-        Single or multiple values for each model parameter name
+        Single or multiple values for each model parameter name.
 
-    Returns:
+        Allowed values for each parameter:
+        - A single value (e.g., `32`, `"relu"`).
+        - A non-empty iterable (e.g., `[0.01, 0.1]`, `["relu", "sigmoid"]`).
+
+        Not allowed:
+        - Empty lists or empty iterables (e.g., `[]`, `()`, etc.). These should be removed manually.
+
+    Returns
     -------
     List[Dict[str, Any]]
         A list of all kwargs combinations.
@@ -118,6 +125,10 @@ def _make_model_kwargs(
         if isinstance(values, str):
             # The values is a single string, so we shouldn't iterate over it.
             all_values = [(param, values)]
+        elif isinstance(values, list | tuple | set) and len(values) == 0:
+            # If it's an empty iterable, raise an error
+            raise ValueError(f"Parameter '{param}' contains an empty iterable, which is not allowed.")
+        
         else:
             try:
                 all_values = [(param, value) for value in values]

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -115,7 +115,7 @@ def _make_model_kwargs(
         Not allowed:
         - Empty lists or empty iterables (e.g., `[]`, `()`, etc.). These should be removed manually.
 
-    Returns
+    Returns:
     -------
     List[Dict[str, Any]]
         A list of all kwargs combinations.
@@ -127,8 +127,10 @@ def _make_model_kwargs(
             all_values = [(param, values)]
         elif isinstance(values, list | tuple | set) and len(values) == 0:
             # If it's an empty iterable, raise an error
-            raise ValueError(f"Parameter '{param}' contains an empty iterable, which is not allowed.")
-        
+            raise ValueError(
+                f"Parameter '{param}' contains an empty iterable, which is not allowed."
+            )
+
         else:
             try:
                 all_values = [(param, value) for value in values]

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -26,7 +26,6 @@ def test_make_model_kwargs():  # noqa: D103
 
 def test_batch_run_with_params_with_empty_content():
     """Test handling of empty iterables in model kwargs."""
-    
     # If "a" is a single value and "b" is an empty list (should raise error for the empty list)
     parameters_with_empty_list = {
         "a": 3,
@@ -35,7 +34,9 @@ def test_batch_run_with_params_with_empty_content():
 
     try:
         _make_model_kwargs(parameters_with_empty_list)
-        raise AssertionError("Expected ValueError for empty iterable but no error was raised.")
+        raise AssertionError(
+            "Expected ValueError for empty iterable but no error was raised."
+        )
     except ValueError as e:
         assert "contains an empty iterable" in str(e)
 
@@ -47,7 +48,9 @@ def test_batch_run_with_params_with_empty_content():
 
     try:
         _make_model_kwargs(parameters_with_empty_b)
-        raise AssertionError("Expected ValueError for empty iterable but no error was raised.")
+        raise AssertionError(
+            "Expected ValueError for empty iterable but no error was raised."
+        )
     except ValueError as e:
         assert "contains an empty iterable" in str(e)
 

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -24,6 +24,34 @@ def test_make_model_kwargs():  # noqa: D103
     assert _make_model_kwargs({"a": "value"}) == [{"a": "value"}]
 
 
+def test_batch_run_with_params_with_empty_content():
+    """Test handling of empty iterables in model kwargs."""
+    
+    # If "a" is a single value and "b" is an empty list (should raise error for the empty list)
+    parameters_with_empty_list = {
+        "a": 3,
+        "b": [],
+    }
+
+    try:
+        _make_model_kwargs(parameters_with_empty_list)
+        raise AssertionError("Expected ValueError for empty iterable but no error was raised.")
+    except ValueError as e:
+        assert "contains an empty iterable" in str(e)
+
+    # If "a" is a iterable and "b" is an empty list (should still raise error)
+    parameters_with_empty_b = {
+        "a": [1, 2],
+        "b": [],
+    }
+
+    try:
+        _make_model_kwargs(parameters_with_empty_b)
+        raise AssertionError("Expected ValueError for empty iterable but no error was raised.")
+    except ValueError as e:
+        assert "contains an empty iterable" in str(e)
+
+
 class MockAgent(Agent):
     """Minimalistic agent implementation for testing purposes."""
 


### PR DESCRIPTION
## Summary
Fixed the handling of empty iterables in _make_model_kwargs. Now raises a ValueError when an empty list is passed.

## Bug / Issue
Closes https://github.com/projectmesa/mesa/issues/2108.
Empty iterables weren't properly handled.

## Implementation
Updated `_make_model_kwargs` to raise a ValueError for empty iterables.
added a new function `test_batch_run_with_params_with_empty_content()` for testing.