### PR TITLE
Fix: running Mesa in Docker with Schelling model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /opt/mesa
 
 EXPOSE 8765/tcp
 
-RUN pip3 install -e /opt/mesa[all]
+RUN pip3 install -e /opt/mesa[rec]
 
 CMD ["sh", "-c", "cd $MODEL_DIR && solara run app.py --host=0.0.0.0"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ FROM python:bookworm
 LABEL maintainer="rht <rhtbot@protonmail.com>"
 
 # To use this Dockerfile:
-# 1. `docker build . -t mymesa_image`
-# 2. `docker run --name mymesa_instance -p 8765:8765 -it mymesa_image`
+# 1. `docker build . -t mesa_image`
+# 2. `docker run --name mesa_instance -p 8765:8765 -it mesa_image`
 # 3. In your browser, visit http://127.0.0.1:8765
 #
 # Currently, this Dockerfile defaults to running the Schelling model, as an
@@ -19,7 +19,7 @@ LABEL maintainer="rht <rhtbot@protonmail.com>"
 # `docker run --name mymesa_instance -p 8765:8765 -e MODEL_DIR=/mesa-examples/examples/sugarscape_cg -it mymesa_image`
 # Note: the model directory MUST contain an app.py file.
 
-ENV MODEL_DIR=/mesa-examples/examples/schelling_experimental
+ENV MODEL_DIR=/opt/mesa/mesa/examples/basic/schelling
 
 # Don't buffer output:
 # https://docs.python.org/3.10/using/cmdline.html?highlight=pythonunbuffered#envvar-PYTHONUNBUFFERED
@@ -29,10 +29,11 @@ WORKDIR /opt/mesa
 
 COPY . /opt/mesa
 
-RUN cd / && git clone https://github.com/projectmesa/mesa-examples.git
-
 EXPOSE 8765/tcp
 
-RUN pip3 install -e /opt/mesa
+RUN pip3 install -e /opt/mesa[all]
 
 CMD ["sh", "-c", "cd $MODEL_DIR && solara run app.py --host=0.0.0.0"]
+
+# To check file system:
+# docker exec -it mesa_instance bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # We can't use slim because we need either git/wget/curl to
 # download mesa-examples, and so installing them requires
 # updating the system anyway.
-# We can't use alpine because NumPy doesn't support musllinux yet.
-# But it's in the RC version https://github.com/numpy/numpy/issues/20089.
 FROM python:bookworm
-LABEL maintainer="rht <rhtbot@protonmail.com>"
+LABEL maintainer="projectmesa maintainers@projectmesa.dev"
 
 # To use this Dockerfile:
 # 1. `docker build . -t mesa_image`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
       # within the current directory.
       # E.g. if it is at my-model, then you specify it as
       # /opt/mesa/my-model.
-      MODEL_DIR: /mesa-examples/examples/schelling_experimental
+      MODEL_DIR: /opt/mesa/mesa/examples/basic/schelling
     ports:
       - 8765:8765


### PR DESCRIPTION
## Summary
This pull request addresses issues with the existing Docker configuration, including missing dependencies and untested references to the mesa-examples repository. The updates ensure that the Mesa Schelling model runs correctly with Solara visualization in Docker on port 8765.

## Bug / Issue
1. Missing Dependencies: The original Dockerfile did not install the mesa[all] package, which led to a solara not found error when attempting to run the docker compose.
2. Outdated Example Repository: The mesa-examples repository referenced in the original Dockerfile contains broken visualization modules and no longer includes the Schelling model.
3. Impact: Users were unable to run the Schelling model or any visualizations successfully using the provided Docker configuration.

## Implementation
1. Dependencies Fix: Updated the Dockerfile to ensure mesa[all] is installed, which includes all necessary dependencies for Solara-based visualization.
2. Updated Model Reference:
Replaced the mesa-examples repository reference with the mesa.examples module, specifically pointing to the built-in Schelling model:
```
ENV MODEL_DIR=/opt/mesa/mesa/examples/basic/schelling
```

## Testing
1. Started the container using docker compose:
```
docker compose up -d
```
2. Verified that the Schelling model runs correctly with a working visualization.

