### PR TITLE
Add sample and choices to CellCollection

### DIFF
--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Visualization Tutorial"
+   "source": [
+    "# Visualization Tutorial"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -51,10 +53,18 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mesa version: 3.1.0\n"
+     ]
+    }
+   ],
    "source": [
     "import mesa\n",
     "print(f\"Mesa version: {mesa.__version__}\")\n",
@@ -66,10 +76,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [],
-   "execution_count": null,
    "source": [
     "def agent_portrayal(agent):\n",
     "    return {\n",
@@ -79,15 +89,17 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "In addition to the portrayal method, we instantiate the model parameters, some of which are modifiable by user inputs. In this case, the number of agents, N, is specified as a slider of integers."
+   "metadata": {},
+   "source": [
+    "In addition to the portrayal method, we instantiate the model parameters, some of which are modifiable by user inputs. In this case, the number of agents, N, is specified as a slider of integers."
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
-   "execution_count": null,
    "source": [
     "model_params = {\n",
     "    \"n\": {\n",
@@ -104,8 +116,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Next, we instantiate the visualization object which (by default) displays the grid containing the agents, and timeseries of values computed by the model's data collector. In this example, we specify the Gini coefficient.\n",
     "\n",
@@ -118,10 +130,28 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a906b76fdb74d2784c4f152f18931e7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "Cannot show widget. You probably want to rerun the code cell above (<i>Click in the code cell, and press Shift+Enter <kbd>⇧</kbd>+<kbd>↩</kbd></i>)."
+      ],
+      "text/plain": [
+       "Cannot show ipywidgets in text"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Create initial model instance\n",
     "model1 = MoneyModel(50, 10, 10)\n",
@@ -140,8 +170,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Part 2 - Dynamic Agent Representation \n",
     "\n",
@@ -155,10 +185,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import mesa\n",
     "print(f\"Mesa version: {mesa.__version__}\")\n",
@@ -169,10 +199,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def agent_portrayal(agent):\n",
     "    size = 10\n",
@@ -197,10 +227,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Create initial model instance\n",
     "model1 = MoneyModel(50, 10, 10)\n",
@@ -219,8 +249,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Part 3 - Custom Components \n",
     "\n",
@@ -236,10 +266,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import mesa\n",
     "print(f\"Mesa version: {mesa.__version__}\")\n",
@@ -253,10 +283,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def agent_portrayal(agent):\n",
     "    size = 10\n",
@@ -281,15 +311,17 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "Next, we update our solara frontend to use this new component"
+   "metadata": {},
+   "source": [
+    "Next, we update our solara frontend to use this new component"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "@solara.component\n",
     "def Histogram(model):\n",
@@ -306,10 +338,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Create initial model instance\n",
     "model1 = MoneyModel(50, 10, 10)\n",
@@ -320,12 +352,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-29T19:38:49.471838Z",
      "start_time": "2024-10-29T19:38:47.897295Z"
     }
    },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bc71b89ee5684038a194eee4c36f4a4c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "Cannot show widget. You probably want to rerun the code cell above (<i>Click in the code cell, and press Shift+Enter <kbd>⇧</kbd>+<kbd>↩</kbd></i>)."
+      ],
+      "text/plain": [
+       "Cannot show ipywidgets in text"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "page = SolaraViz(\n",
     "    model1,\n",
@@ -335,27 +387,7 @@
     ")\n",
     "# This is required to render the visualization in the Jupyter notebook\n",
     "page"
-   ],
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Cannot show ipywidgets in text"
-      ],
-      "text/html": [
-       "Cannot show widget. You probably want to rerun the code cell above (<i>Click in the code cell, and press Shift+Enter <kbd>⇧</kbd>+<kbd>↩</kbd></i>)."
-      ],
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "bc71b89ee5684038a194eee4c36f4a4c"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "execution_count": 12
+   ]
   },
   {
    "cell_type": "markdown",
@@ -366,35 +398,35 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-29T19:38:49.505725Z",
      "start_time": "2024-10-29T19:38:49.472599Z"
     }
    },
-   "source": [
-    "Histogram(model1)"
-   ],
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "Cannot show ipywidgets in text"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0491f167a1434a92b78535078bd082a8",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/html": [
        "Cannot show widget. You probably want to rerun the code cell above (<i>Click in the code cell, and press Shift+Enter <kbd>⇧</kbd>+<kbd>↩</kbd></i>)."
       ],
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "0491f167a1434a92b78535078bd082a8"
-      }
+      "text/plain": [
+       "Cannot show ipywidgets in text"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
     }
    ],
-   "execution_count": 13
+   "source": [
+    "Histogram(model1)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -422,7 +454,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.0"
   },
   "nbsphinx": {
    "execute": "never"

--- a/mesa/experimental/cell_space/cell_collection.py
+++ b/mesa/experimental/cell_space/cell_collection.py
@@ -110,6 +110,38 @@ class CellCollection(Generic[T]):
         """
         return self.random.choice(list(self.agents))
 
+
+    def sample_random_cells(self, k:int=1, counts:list|None=None) -> list[Cell]:
+        """Sample k unique cells from the cell collection.
+
+        See random.sample for more information.
+
+        Args:
+            k: number of cells to sample
+            counts: The number of repeated elements, see random.sample for more details
+
+        Returns:
+            a list of sampled cells
+
+        """
+        return self.random.sample(self.cells, k, counts=counts)
+
+    def choices_random_cells(self, weights: list|None=None, cum_weights:list|None=None, k:int=1) -> list[Cell]:
+        """Return a k sized list of population elements chosen with replacement.
+
+        See random.choices for more information.
+
+        Args:
+            weights: weights for each cell
+            cum_weights: cumulative weights for each cell
+            k: number of cells to sample
+
+        Returns:
+            a list of chosen cells
+
+        """
+        return self.random.choices(list(self._cells.keys()), weights=weights, cum_weights=cum_weights, k=k)
+
     def select(
         self,
         filter_func: Callable[[T], bool] | None = None,

--- a/mesa/experimental/cell_space/cell_collection.py
+++ b/mesa/experimental/cell_space/cell_collection.py
@@ -110,8 +110,7 @@ class CellCollection(Generic[T]):
         """
         return self.random.choice(list(self.agents))
 
-
-    def sample_random_cells(self, k:int=1, counts:list|None=None) -> list[Cell]:
+    def sample_random_cells(self, k: int = 1, counts: list | None = None) -> list[Cell]:
         """Sample k unique cells from the cell collection.
 
         See random.sample for more information.
@@ -126,7 +125,9 @@ class CellCollection(Generic[T]):
         """
         return self.random.sample(self.cells, k, counts=counts)
 
-    def choices_random_cells(self, weights: list|None=None, cum_weights:list|None=None, k:int=1) -> list[Cell]:
+    def choices_random_cells(
+        self, weights: list | None = None, cum_weights: list | None = None, k: int = 1
+    ) -> list[Cell]:
         """Return a k sized list of population elements chosen with replacement.
 
         See random.choices for more information.
@@ -140,7 +141,9 @@ class CellCollection(Generic[T]):
             a list of chosen cells
 
         """
-        return self.random.choices(list(self._cells.keys()), weights=weights, cum_weights=cum_weights, k=k)
+        return self.random.choices(
+            list(self._cells.keys()), weights=weights, cum_weights=cum_weights, k=k
+        )
 
     def select(
         self,

--- a/mesa/experimental/cell_space/cell_collection.py
+++ b/mesa/experimental/cell_space/cell_collection.py
@@ -97,7 +97,11 @@ class CellCollection(Generic[T]):
         return itertools.chain.from_iterable(self._cells.values())
 
     def select_random_cell(self) -> T:
-        """Select a random cell."""
+        """Select a random cell.
+
+        See Python's random.choice at python.docs.org for more information.
+
+        """
         return self.random.choice(self.cells)
 
     def select_random_agent(self) -> CellAgent:
@@ -113,7 +117,7 @@ class CellCollection(Generic[T]):
     def sample_random_cells(self, k: int = 1, counts: list | None = None) -> list[Cell]:
         """Sample k unique cells from the cell collection.
 
-        See random.sample for more information.
+        See Python's random.sample at python.docs.org for more information.
 
         Args:
             k: number of cells to sample
@@ -130,7 +134,7 @@ class CellCollection(Generic[T]):
     ) -> list[Cell]:
         """Return a k sized list of population elements chosen with replacement.
 
-        See random.choices for more information.
+        See Python's random.choices at python.docs.org for more information
 
         Args:
             weights: weights for each cell

--- a/mesa/experimental/cell_space/cell_collection.py
+++ b/mesa/experimental/cell_space/cell_collection.py
@@ -146,7 +146,7 @@ class CellCollection(Generic[T]):
 
         """
         return self.random.choices(
-            list(self._cells.keys()), weights=weights, cum_weights=cum_weights, k=k
+            self.cells, weights=weights, cum_weights=cum_weights, k=k
         )
 
     def select(

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -601,6 +601,12 @@ def test_cell_collection():
     cells = collection.select()
     assert len(cells) == len(collection)
 
+    cells = collection.sample_random_cells(k=10)
+    assert len(cells) == 10
+
+    cells = collection.choices_random_cells(k=5)
+    assert len(cells) == 5
+
 
 def test_empty_cell_collection():
     """Test that CellCollection properly handles empty collections."""


### PR DESCRIPTION
This adds 2 new methods to cell collection: `sample_random_cells` and `choices_random_cells`. These methods make it possible to sample cells with or without replacement from a cell collection. This closes #2530. 

Implementation-wise, the methods are CellCollection specific wrappers around `random.sample` and `random.choices`.  Note also that both methods return a list. A CellCollection cannot contain duplicates (it is, in essence, a fixed set). But both sampling and choices can return duplicates, so we cannot return a cell collection. 

The main use case for these methods is in conjunction with the `Agent.create_agents`. You can. now do

```Python
class MyAgent(CellAgent):
    def __init__(self, model, cell):
        super().__init__(model)
        self.cell = cell

# let's create 10 agents, placed in 10 random empty cells
MyAgent.create_agents(model, 10, self.space.empties.sample_random_cells(k=10))

# let's create 10 agents, placed in 10 random cells
MyAgent.create_agents(model, 10, self.space.all_cells.choices_random_cells(k=10))


```

