### PR TITLE
Add Interactive Play Interval Control to Mesa Visualization

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -111,7 +111,7 @@ def SolaraViz(
         with solara.Card("Controls"):
             solara.SliderInt(
                 label="Play Interval (ms)",
-                value=reactive_play_interval.value,
+                value=reactive_play_interval,
                 on_value=lambda v: reactive_play_interval.set(v),
                 min=1,
                 max=500,
@@ -121,14 +121,14 @@ def SolaraViz(
                 ModelController(
                     model,
                     model_parameters=reactive_model_parameters,
-                    play_interval=reactive_play_interval.value,
+                    play_interval=reactive_play_interval,
                 )
             else:
                 SimulatorController(
                     model,
                     simulator,
                     model_parameters=reactive_model_parameters,
-                    play_interval=reactive_play_interval.value,
+                    play_interval=reactive_play_interval,
                 )
         with solara.Card("Model Parameters"):
             ModelCreator(
@@ -188,7 +188,7 @@ def ModelController(
     model: solara.Reactive[Model],
     *,
     model_parameters: dict | solara.Reactive[dict] = None,
-    play_interval: int = 100,
+    play_interval: int | solara.Reactive[int] = 100,
 ):
     """Create controls for model execution (step, play, pause, reset).
 
@@ -206,7 +206,7 @@ def ModelController(
 
     async def step():
         while playing.value and running.value:
-            await asyncio.sleep(play_interval / 1000)
+            await asyncio.sleep(play_interval.value / 1000)
             do_step()
 
     solara.lab.use_task(
@@ -258,7 +258,7 @@ def SimulatorController(
     simulator,
     *,
     model_parameters: dict | solara.Reactive[dict] = None,
-    play_interval: int = 100,
+    play_interval: int | solara.Reactive[int] = 100,
 ):
     """Create controls for model execution (step, play, pause, reset).
 
@@ -277,7 +277,7 @@ def SimulatorController(
 
     async def step():
         while playing.value and running.value:
-            await asyncio.sleep(play_interval / 1000)
+            await asyncio.sleep(play_interval.value / 1000)
             do_step()
 
     solara.lab.use_task(

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -102,24 +102,33 @@ def SolaraViz(
 
     # set up reactive model_parameters shared by ModelCreator and ModelController
     reactive_model_parameters = solara.use_reactive({})
+    reactive_play_interval = solara.use_reactive(play_interval)
 
     with solara.AppBar():
         solara.AppBarTitle(name if name else model.value.__class__.__name__)
 
     with solara.Sidebar(), solara.Column():
         with solara.Card("Controls"):
+            solara.SliderInt(
+                label="Play Interval (ms)",
+                value=reactive_play_interval.value,
+                on_value=lambda v: reactive_play_interval.set(v),
+                min=1,
+                max=500,
+                step=10,
+            )
             if not isinstance(simulator, Simulator):
                 ModelController(
                     model,
                     model_parameters=reactive_model_parameters,
-                    play_interval=play_interval,
+                    play_interval=reactive_play_interval.value,
                 )
             else:
                 SimulatorController(
                     model,
                     simulator,
                     model_parameters=reactive_model_parameters,
-                    play_interval=play_interval,
+                    play_interval=reactive_play_interval.value,
                 )
         with solara.Card("Model Parameters"):
             ModelCreator(


### PR DESCRIPTION
### Summary
This PR adds a slider control to dynamically adjust simulation speed in Mesa's visualization interface. #2497 

### Motive
- Fixed play interval was limiting user control
- Need flexible speed control for observing different phenomena

### Implementation
- Added play interval slider (1ms-500ms)
- Made interval reactive for real-time updates
- Updated controllers to use dynamic interval

### Usage Examples
The play interval slider appears automatically in the Controls panel of any Mesa visualization, no additional configuration needed.

- Before
![](https://github.com/user-attachments/assets/1dcf16ec-3662-4998-b425-b8f14c1bd545)
- After
![](https://github.com/user-attachments/assets/8cbd2dde-e7a7-4776-b36f-faebe153117c)

### Additional Notes
- Maintains backward compatibility
- Safe range limits prevent performance issues
