### PR TITLE
bug fixes for draw_property_layers

### DIFF
--- a/mesa/examples/advanced/sugarscape_g1mt/app.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/app.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath("../../../.."))
-
-
 import numpy as np
 import solara
 from matplotlib.figure import Figure

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -181,8 +181,9 @@ def draw_property_layers(
         property_layers = space._mesa_property_layers
 
     for layer_name, portrayal in propertylayer_portrayal.items():
+        print(layer_name)
         layer = property_layers.get(layer_name, None)
-        if not isinstance(layer, PropertyLayer):
+        if not isinstance(layer, PropertyLayer | mesa.experimental.cell_space.property_layer.PropertyLayer):
             continue
 
         data = layer.data.astype(float) if layer.data.dtype == bool else layer.data
@@ -212,7 +213,7 @@ def draw_property_layers(
                 layer_name, [(0, 0, 0, 0), (*rgba_color[:3], alpha)]
             )
             im = ax.imshow(
-                rgba_data.transpose(1, 0, 2),
+                rgba_data,
                 origin="lower",
             )
             if colorbar:
@@ -226,7 +227,7 @@ def draw_property_layers(
             if isinstance(cmap, list):
                 cmap = LinearSegmentedColormap.from_list(layer_name, cmap)
             im = ax.imshow(
-                data.T,
+                data,
                 cmap=cmap,
                 alpha=alpha,
                 vmin=vmin,


### PR DESCRIPTION
While trying to update sugarscape to use `draw_property_layer`, I encountered a few bugs.
1. The integration into cell spaces includes its own version of `PropertyLayer`, so the `isinstance` check needs to account for this.
2. There was a transpose in the imshow that should have been removed as part of the larger matplotlib visualization overhaul because there `draw_property_layer ` shifted to using `origin="lower"`
3. In the sugarscape update (#2546) I forgot to remove some path stuff from app.py. 