### PR TITLE
viz: Automatically visualize Cell color attributes in cell space

### DIFF
--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -271,8 +271,10 @@ def draw_orthogonal_grid(
 
     # First draw cell colors if they exist
     if hasattr(space, "all_cells"):  # Check if it's a cell space
-        cell_colors = np.full((space.height, space.width, 4), [1, 1, 1, 0])  # Transparent default
-        
+        cell_colors = np.full(
+            (space.height, space.width, 4), [1, 1, 1, 0]
+        )  # Transparent default
+
         for cell in space.all_cells:
             if hasattr(cell, "color"):
                 x, y = cell.coordinate
@@ -285,9 +287,9 @@ def draw_orthogonal_grid(
                         UserWarning,
                         stacklevel=2,
                     )
-        
+
         # Plot the cell colors
-        ax.imshow(cell_colors, origin='lower', interpolation='nearest')
+        ax.imshow(cell_colors, origin="lower", interpolation="nearest")
 
     # gather agent data
     s_default = (180 / max(space.width, space.height)) ** 2
@@ -308,6 +310,7 @@ def draw_orthogonal_grid(
             ax.axhline(y, color="gray", linestyle=":")
 
     return ax
+
 
 def draw_hex_grid(
     space: HexGrid,
@@ -338,20 +341,20 @@ def draw_hex_grid(
     if hasattr(space, "all_cells"):
         patches = []
         offset = math.sqrt(0.75)
-        
+
         for cell in space.all_cells:
             x, y = cell.coordinate
             if y % 2 == 0:
                 x += 0.5
             y *= offset
-            
+
             hex_patch = RegularPolygon(
                 (x, y),
                 numVertices=6,
                 radius=math.sqrt(1 / 3),
                 orientation=np.radians(120),
             )
-            
+
             if hasattr(cell, "color"):
                 try:
                     hex_patch.set_facecolor(cell.color)
@@ -361,12 +364,12 @@ def draw_hex_grid(
                         UserWarning,
                         stacklevel=2,
                     )
-                    hex_patch.set_facecolor('none')
+                    hex_patch.set_facecolor("none")
             else:
-                hex_patch.set_facecolor('none')
-                
+                hex_patch.set_facecolor("none")
+
             patches.append(hex_patch)
-        
+
         # Add colored hexagons
         cell_collection = PatchCollection(patches, match_original=True)
         ax.add_collection(cell_collection)


### PR DESCRIPTION
### Summary
Adds automatic visualization of a Cell's `color` attribute in Mesa's matplotlib-based visualization. When a Cell has a `color` attribute set to any valid matplotlib color, it will now be automatically displayed in the visualization without requiring manual configuration.

### Motive
Currently, visualizing properties of Cells in cell spaces requires manual configuration of the visualization code. This can be cumbersome, especially for the common case of wanting to display cells in different colors. By automatically detecting and visualizing the `color` attribute, we make it much easier for users to create visually informative cell-based models.

The PR aligns with Mesa's philosophy of providing sensible defaults while maintaining flexibility - users can still override the visualization behavior if needed, but get reasonable visualization out of the box.

### Implementation
The implementation modifies the `draw_orthogonal_grid()` and `draw_hex_grid()` functions to:

1. Check if the space is a cell space by testing for `all_cells` attribute
2. For each cell, check for a `color` attribute
3. For orthogonal grids:
   - Create a color matrix initialized as transparent 
   - Convert cell colors to RGBA format
   - Display using imshow before drawing agents/grid
4. For hex grids:
   - Create hexagon patches for each cell
   - Set face colors based on cell colors
   - Use PatchCollection for efficient rendering
5. Handle invalid colors gracefully with warnings
6. Preserve proper layering (cells behind agents and grid)

Changes are backward compatible - spaces without cells or cells without colors are rendered exactly as before.

### Usage Examples

Simple usage:
```python
class ForestCell(Cell):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.is_burning = False
        self.color = "green"  # Initial color
        
    def step(self):
        if self.is_burning:
            self.color = "red"  # Cell turns red when burning
        elif any(n.is_burning for n in self.neighbors):
            self.is_burning = True
```

The visualization automatically shows green cells turning red as fire spreads, no additional visualization code needed.

Screenshots comparing visualization:

Before (manually configuring colors):
```python
def draw_cells(model):
    colors = []
    for cell in model.grid.all_cells:
        if cell.is_burning:
            colors.append("red")
        else:
            colors.append("green") 
    # Manual color plotting code...
```

After (automatic color visualization):
```python 
# No manual visualization code needed!
# Just set cell.color and it appears automatically
```

TODO: [Screenshots]

### Additional Notes
- Colors can be specified in any [format](https://matplotlib.org/stable/users/explain/colors/colors.html) matplotlib accepts (names, hex codes, RGB tuples, etc.)
- Alpha/transparency is supported through RGBA colors or alpha specification
- Invalid colors produce warnings but don't break visualization
- Feature adds minimal overhead - color checks only happen for cell spaces
- Future work could extend this to other cell properties beyond color

Closes #2557