### PR TITLE
paper: Move rht from author to acknowledgements

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -23,8 +23,6 @@ authors:
   - name: Boyu Wang
     orcid: 0000-0001-9879-2138
     affiliation: "4"
-  - name: rht
-    affiliation: "5"
   - name: Jackie Kazil
     orcid: 0000-0002-8300-7384
     affiliation: "3"
@@ -37,8 +35,6 @@ affiliations:
     index: 3
   - name: University at Buffalo (Department of Geography)
     index: 4
-  - name: Independent Researcher
-    index: 5
 date: 30 December 2024
 bibliography: paper.bib
 
@@ -245,7 +241,8 @@ Mesa has grown into a complete ecosystem with extensions including:
 - [Mesa-Frames](https://github.com/projectmesa/mesa-frames) for high-performance simulations
 - A rich collection of community-contributed extensions, [example models](https://github.com/projectmesa/mesa-examples), and tutorials
 
-The advancements leading to Mesa 3 were developed by seven maintainers (the authors) and an active community with over 140 [contributors](https://github.com/projectmesa/mesa/graphs/contributors).
+# Acknowledgements
+The advancements leading to Mesa 3 were developed by six maintainers (the authors) and an active community with over 140 [contributors](https://github.com/projectmesa/mesa/graphs/contributors). We would especially like to thank [David Masad](https://github.com/dmasad) for his foundational work on Mesa and [rht](https://github.com/rht) for his work as maintainer in 2022 to 2024.
 
 # Conclusions
 Mesa 3 introduces significant advancements to the Python ABM framework, enhancing the core toolkit with greater control, interactivity, and speed for researchers. These notable improvements, paired with its foundational integration with the scientific Python ecosystem, modular architecture, and active community, make it an indispensable tool for researchers across disciplines working in Python who need to create and analyze agent-based models.


### PR DESCRIPTION
Since we haven't heard anything from rht, I don't think we can add him as an author without his consent. Like we discussed, we recognize him in the Acknowledgements instead.

@rht, if you still would like to be author on the Mesa JOSS paper, please let us know. The windows is still open for a short period.

I also added a shout-out to David's foundational work.