### PR TITLE
Bugfix for non deterministic rng behavior

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -94,7 +94,7 @@ class Model:
             self._seed = seed  # this allows for reproducing stdlib.random
 
             try:
-                self.rng: np.random.Generator = np.random.default_rng(rng)
+                self.rng: np.random.Generator = np.random.default_rng(seed)
             except TypeError:
                 rng = self.random.randint(0, sys.maxsize)
                 self.rng: np.random.Generator = np.random.default_rng(rng)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 """Tests for model.py."""
+
 import numpy as np
 
 from mesa.agent import Agent, AgentSet
@@ -39,7 +40,14 @@ def test_seed(seed=23):
     assert model._seed == seed
 
     assert Model(seed=42).random.random() == Model(seed=42).random.random()
-    assert np.all(Model(seed=42).rng.random(10,) == Model(seed=42).rng.random(10,))
+    assert np.all(
+        Model(seed=42).rng.random(
+            10,
+        )
+        == Model(seed=42).rng.random(
+            10,
+        )
+    )
 
 
 def test_reset_randomizer(newseed=42):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 """Tests for model.py."""
+import numpy as np
 
 from mesa.agent import Agent, AgentSet
 from mesa.model import Model
@@ -36,6 +37,9 @@ def test_seed(seed=23):
     model2 = Model(seed=seed + 1)
     assert model2._seed == seed + 1
     assert model._seed == seed
+
+    assert Model(seed=42).random.random() == Model(seed=42).random.random()
+    assert np.all(Model(seed=42).rng.random(10,) == Model(seed=42).rng.random(10,))
 
 
 def test_reset_randomizer(newseed=42):


### PR DESCRIPTION
This fixes a bug in how the numpy rng is seeded. If instantiating a model with `Model(seed=42)`, rng should default to 42, not `None`. The net result of this bug is that at the moment,  `Model(seed=42) will leave the numpy rgn undeterministic. This adds an explicit test to ensure that both model.random and model.rng behave in a deterministic manner when seeded with the same initial value and fixes the bug. 