### PR TITLE
Basic bugfix for bug ContinuousSpace.get_neighbors

### DIFF
--- a/mesa/examples/basic/boid_flockers/agents.py
+++ b/mesa/examples/basic/boid_flockers/agents.py
@@ -58,7 +58,8 @@ class Boid(Agent):
 
     def step(self):
         """Get the Boid's neighbors, compute the new vector, and move accordingly."""
-        self.neighbors = self.model.space.get_neighbors(self.pos, self.vision, False)
+        neighbors = self.model.space.get_neighbors(self.pos, self.vision, True)
+        self.neighbors = [n for n in neighbors if n is not self]
 
         # If no neighbors, maintain current direction
         if not self.neighbors:

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1415,6 +1415,11 @@ class ContinuousSpace:
                             coordinates. i.e. if you are searching for the
                             neighbors of a given agent, True will include that
                             agent in the results.
+
+        Notes:
+            If 1 or more agents are located on pos, include_center=True will remove these agents
+            from the results.
+
         """
         if self._agent_points is None:
             self._build_agent_cache()


### PR DESCRIPTION
This is a basic solution to #2592. In short, `ContinuousSpace.get_neighbors` takes an optional `include_center` keyword argument. If this is set to true, all agents on center will be removed, potentially missing neighbors. For details, see #2592.

This takes the most basic approach:
1. Document the behavior explicitly.
2. Update the boids example to not include center and explicitly filter out self. 

The reason for this basic fix is that any proper fix would be backward incompatible. Proper solutions would require distinguishing between getting agents in radius of a given coordinate and getting neighbors for a given agent. This would involve changing method names and changing signatures. 