### PR TITLE
reimplementation of draw_voroinoi

### DIFF
--- a/mesa/experimental/cell_space/voronoi.py
+++ b/mesa/experimental/cell_space/voronoi.py
@@ -186,7 +186,6 @@ class VoronoiGrid(DiscreteSpace):
         random: Random | None = None,
         cell_klass: type[Cell] = Cell,
         capacity_function: callable = round_float,
-        cell_coloring_property: str | None = None,
     ) -> None:
         """A Voronoi Tessellation Grid.
 
@@ -200,7 +199,7 @@ class VoronoiGrid(DiscreteSpace):
             random (Random): random number generator
             cell_klass (type[Cell]): type of cell class
             capacity_function (Callable): function to compute (int) capacity according to (float) area
-            cell_coloring_property (str): voronoi visualization polygon fill property
+
         """
         super().__init__(capacity=capacity, random=random, cell_klass=cell_klass)
         self.centroids_coordinates = centroids_coordinates
@@ -215,7 +214,6 @@ class VoronoiGrid(DiscreteSpace):
         self.triangulation = None
         self.voronoi_coordinates = None
         self.capacity_function = capacity_function
-        self.cell_coloring_property = cell_coloring_property
 
         self._connect_cells()
         self._build_cell_polygons()
@@ -266,4 +264,3 @@ class VoronoiGrid(DiscreteSpace):
             polygon_area = self._compute_polygon_area(polygon)
             self._cells[region].properties["area"] = polygon_area
             self._cells[region].capacity = self.capacity_function(polygon_area)
-            self._cells[region].properties[self.cell_coloring_property] = 0

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -20,7 +20,7 @@ from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import LinearSegmentedColormap, Normalize, to_rgba
-from matplotlib.patches import RegularPolygon
+from matplotlib.patches import RegularPolygon, Polygon
 
 import mesa
 from mesa.experimental.cell_space import (
@@ -501,7 +501,8 @@ def draw_continuous_space(
 
 
 def draw_voronoi_grid(
-    space: VoronoiGrid, agent_portrayal: Callable, ax: Axes | None = None, **kwargs
+    space: VoronoiGrid, agent_portrayal: Callable, ax: Axes | None = None,
+    draw_grid: bool = True, **kwargs
 ):
     """Visualize a voronoi grid.
 
@@ -509,6 +510,7 @@ def draw_voronoi_grid(
         space: the space to visualize
         agent_portrayal: a callable that is called with the agent and returns a dict
         ax: a Matplotlib Axes instance. If none is provided a new figure and ax will be created using plt.subplots
+        draw_grid: whether to draw the grid or not
         kwargs: additional keyword arguments passed to ax.scatter
 
     Returns:
@@ -541,16 +543,20 @@ def draw_voronoi_grid(
 
     _scatter(ax, arguments, **kwargs)
 
-    for cell in space.all_cells:
-        polygon = cell.properties["polygon"]
-        ax.fill(
-            *zip(*polygon),
-            alpha=min(1, cell.properties[space.cell_coloring_property]),
-            c="red",
-            zorder=0,
-        )  # Plot filled polygon
-        ax.plot(*zip(*polygon), color="black")  # Plot polygon edges in black
+    def setup_voroinoimesh(cells):
+        patches = []
+        for cell in cells:
+            patch = Polygon(cell.properties["polygon"])
+            patches.append(patch)
+        mesh = PatchCollection(
+            patches, edgecolor="k", facecolor=(1, 1, 1, 0), linestyle="dotted", lw=1
+        )
+        return mesh
 
+    if draw_grid:
+        ax.add_collection(
+            setup_voroinoimesh(space.all_cells.cells)
+        )
     return ax
 
 


### PR DESCRIPTION
This reimplements `draw_voroinoi` and makes it behave identically to `draw_hexgrids`. This, therefore, removes `cell_coloring_property ` from the Voronoi grid. It also adds the `draw_grid` boolean to `draw_voroinoi` which is also available for all other discrete spaces. 

Any future work on further developing the API for controlling how to draw a space itself such as #2438 and #2557, now at least can start from an underlying consistent code base.

**Before**
![Unknown](https://github.com/user-attachments/assets/c7df75dd-4228-4bdc-8667-cbd49f8caa90)


**After**
![Unknown2](https://github.com/user-attachments/assets/f880fae2-57ef-4473-ae02-a7348605aa62)



Closes #2437 and #2549