### PR TITLE
Move mesa.experimental_cell to mesa.discrete_space

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -84,4 +84,4 @@ jobs:
     - name: Test examples
       run: |
         cd mesa-examples
-        pytest -rA -Werror -Wdefault::FutureWarning test_examples.py
+        pytest -rA -Werror -Wdefault::FutureWarning -Wi:DeprecationWarning test_examples.py

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -84,4 +84,4 @@ jobs:
     - name: Test examples
       run: |
         cd mesa-examples
-        pytest -rA -Werror -Wdefault::FutureWarning -Wi:DeprecationWarning test_examples.py
+        pytest -rA -Werror -Wdefault::FutureWarning -Wi::DeprecationWarning test_examples.py

--- a/docs/apis/api_main.md
+++ b/docs/apis/api_main.md
@@ -7,6 +7,7 @@ model
 agent
 time
 space
+discrete_space
 datacollection
 batchrunner
 visualization

--- a/docs/apis/discrete_space.md
+++ b/docs/apis/discrete_space.md
@@ -1,0 +1,41 @@
+## Discrete Space
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.__init__
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.cell
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.cell_agent
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.cell_collection
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.discrete_space
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.grid
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.network
+   :members:
+```
+
+```{eval-rst}
+.. automodule:: experimental.cell_space.voronoi
+   :members:
+```

--- a/docs/apis/discrete_space.md
+++ b/docs/apis/discrete_space.md
@@ -1,41 +1,41 @@
 ## Discrete Space
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.__init__
+.. automodule:: mesa.discrete_space.__init__
    :members:
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.cell
+.. automodule:: mesa.discrete_space.cell
    :members:
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.cell_agent
+.. automodule:: mesa.discrete_space.cell_agent
    :members:
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.cell_collection
+.. automodule:: mesa.discrete_space.cell_collection
    :members:
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.discrete_space
+.. automodule:: mesa.discrete_space.discrete_space
    :members:
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.grid
+.. automodule:: mesa.discrete_space.grid
    :members:
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.network
+.. automodule:: mesa.discrete_space.network
    :members:
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.cell_space.voronoi
+.. automodule:: mesa.discrete_space.voronoi
    :members:
 ```

--- a/docs/apis/experimental.md
+++ b/docs/apis/experimental.md
@@ -1,47 +1,6 @@
 # Experimental
 This namespace contains experimental features. These are under development, and their API is not necessarily stable.
 
-## Cell Space
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.__init__
-   :members:
-```
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.cell
-   :members:
-```
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.cell_agent
-   :members:
-```
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.cell_collection
-   :members:
-```
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.discrete_space
-   :members:
-```
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.grid
-   :members:
-```
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.network
-   :members:
-```
-
-```{eval-rst}
-.. automodule:: experimental.cell_space.voronoi
-   :members:
-```
 
 ## Devs
 

--- a/mesa/discrete_space/__init__.py
+++ b/mesa/discrete_space/__init__.py
@@ -33,8 +33,6 @@ from mesa.discrete_space.network import Network
 from mesa.discrete_space.property_layer import PropertyLayer
 from mesa.discrete_space.voronoi import VoronoiGrid
 
-import warnings
-
 __all__ = [
     "Cell",
     "CellAgent",
@@ -50,6 +48,3 @@ __all__ = [
     "PropertyLayer",
     "VoronoiGrid",
 ]
-
-warnings.warn("you are importing from mesa.discrete_space,"
-              "all cell spaces have been moved to mesa.discrete_space", DeprecationWarning)

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -18,8 +18,8 @@ from functools import cache, cached_property
 from random import Random
 from typing import TYPE_CHECKING
 
-from mesa.experimental.cell_space.cell_agent import CellAgent
-from mesa.experimental.cell_space.cell_collection import CellCollection
+from mesa.discrete_space.cell_agent import CellAgent
+from mesa.discrete_space.cell_collection import CellCollection
 
 if TYPE_CHECKING:
     from mesa.agent import Agent

--- a/mesa/discrete_space/cell_agent.py
+++ b/mesa/discrete_space/cell_agent.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Protocol
 from mesa.agent import Agent
 
 if TYPE_CHECKING:
-    from mesa.experimental.cell_space import Cell
+    from mesa.discrete_space import Cell
 
 
 class HasCellProtocol(Protocol):

--- a/mesa/discrete_space/cell_collection.py
+++ b/mesa/discrete_space/cell_collection.py
@@ -23,8 +23,8 @@ from random import Random
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
-    from mesa.experimental.cell_space.cell import Cell
-    from mesa.experimental.cell_space.cell_agent import CellAgent
+    from mesa.discrete_space.cell import Cell
+    from mesa.discrete_space.cell_agent import CellAgent
 
 T = TypeVar("T", bound="Cell")
 

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -21,8 +21,8 @@ from random import Random
 from typing import Generic, TypeVar
 
 from mesa.agent import AgentSet
-from mesa.experimental.cell_space.cell import Cell
-from mesa.experimental.cell_space.cell_collection import CellCollection
+from mesa.discrete_space.cell import Cell
+from mesa.discrete_space.cell_collection import CellCollection
 
 T = TypeVar("T", bound=Cell)
 

--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -19,8 +19,8 @@ from itertools import product
 from random import Random
 from typing import Any, Generic, TypeVar
 
-from mesa.experimental.cell_space import Cell, DiscreteSpace
-from mesa.experimental.cell_space.property_layer import (
+from mesa.discrete_space import Cell, DiscreteSpace
+from mesa.discrete_space.property_layer import (
     HasPropertyLayers,
     PropertyDescriptor,
 )

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -15,8 +15,8 @@ or any environment where connectivity matters more than physical location.
 from random import Random
 from typing import Any
 
-from mesa.experimental.cell_space.cell import Cell
-from mesa.experimental.cell_space.discrete_space import DiscreteSpace
+from mesa.discrete_space.cell import Cell
+from mesa.discrete_space.discrete_space import DiscreteSpace
 
 
 class Network(DiscreteSpace[Cell]):

--- a/mesa/discrete_space/property_layer.py
+++ b/mesa/discrete_space/property_layer.py
@@ -21,7 +21,7 @@ from typing import Any, TypeVar
 
 import numpy as np
 
-from mesa.experimental.cell_space import Cell
+from mesa.discrete_space import Cell
 
 Coordinate = Sequence[int]
 T = TypeVar("T", bound=Cell)

--- a/mesa/discrete_space/voronoi.py
+++ b/mesa/discrete_space/voronoi.py
@@ -18,8 +18,8 @@ from random import Random
 
 import numpy as np
 
-from mesa.experimental.cell_space.cell import Cell
-from mesa.experimental.cell_space.discrete_space import DiscreteSpace
+from mesa.discrete_space.cell import Cell
+from mesa.discrete_space.discrete_space import DiscreteSpace
 
 
 class Delaunay:

--- a/mesa/examples/advanced/epstein_civil_violence/agents.py
+++ b/mesa/examples/advanced/epstein_civil_violence/agents.py
@@ -10,7 +10,7 @@ class CitizenState(Enum):
     ARRESTED = 3
 
 
-class EpsteinAgent(mesa.experimental.cell_space.CellAgent):
+class EpsteinAgent(mesa.discrete_space.CellAgent):
     def update_neighbors(self):
         """
         Look around and see who my neighbors are

--- a/mesa/examples/advanced/epstein_civil_violence/model.py
+++ b/mesa/examples/advanced/epstein_civil_violence/model.py
@@ -53,7 +53,7 @@ class EpsteinCivilViolence(mesa.Model):
         self.movement = movement
         self.max_iters = max_iters
 
-        self.grid = mesa.experimental.cell_space.OrthogonalVonNeumannGrid(
+        self.grid = mesa.discrete_space.OrthogonalVonNeumannGrid(
             (width, height), capacity=1, torus=True, random=self.random
         )
 

--- a/mesa/examples/advanced/pd_grid/agents.py
+++ b/mesa/examples/advanced/pd_grid/agents.py
@@ -1,4 +1,4 @@
-from mesa.experimental.cell_space import CellAgent
+from mesa.discrete_space import CellAgent
 
 
 class PDAgent(CellAgent):

--- a/mesa/examples/advanced/pd_grid/model.py
+++ b/mesa/examples/advanced/pd_grid/model.py
@@ -1,6 +1,6 @@
 import mesa
 from mesa.examples.advanced.pd_grid.agents import PDAgent
-from mesa.experimental.cell_space import OrthogonalMooreGrid
+from mesa.discrete_space import OrthogonalMooreGrid
 
 
 class PdGrid(mesa.Model):

--- a/mesa/examples/advanced/pd_grid/model.py
+++ b/mesa/examples/advanced/pd_grid/model.py
@@ -1,6 +1,6 @@
 import mesa
-from mesa.examples.advanced.pd_grid.agents import PDAgent
 from mesa.discrete_space import OrthogonalMooreGrid
+from mesa.examples.advanced.pd_grid.agents import PDAgent
 
 
 class PdGrid(mesa.Model):

--- a/mesa/examples/advanced/sugarscape_g1mt/agents.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/agents.py
@@ -1,6 +1,6 @@
 import math
 
-from mesa.experimental.cell_space import CellAgent
+from mesa.discrete_space import CellAgent
 
 
 # Helper function

--- a/mesa/examples/advanced/sugarscape_g1mt/model.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/model.py
@@ -4,8 +4,8 @@ import numpy as np
 
 import mesa
 from mesa.examples.advanced.sugarscape_g1mt.agents import Trader
-from mesa.experimental.cell_space import OrthogonalVonNeumannGrid
-from mesa.experimental.cell_space.property_layer import PropertyLayer
+from mesa.discrete_space import OrthogonalVonNeumannGrid
+from mesa.discrete_space.property_layer import PropertyLayer
 
 
 # Helper Functions

--- a/mesa/examples/advanced/sugarscape_g1mt/model.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/model.py
@@ -3,9 +3,9 @@ from pathlib import Path
 import numpy as np
 
 import mesa
-from mesa.examples.advanced.sugarscape_g1mt.agents import Trader
 from mesa.discrete_space import OrthogonalVonNeumannGrid
 from mesa.discrete_space.property_layer import PropertyLayer
+from mesa.examples.advanced.sugarscape_g1mt.agents import Trader
 
 
 # Helper Functions

--- a/mesa/examples/advanced/wolf_sheep/agents.py
+++ b/mesa/examples/advanced/wolf_sheep/agents.py
@@ -1,4 +1,4 @@
-from mesa.experimental.cell_space import CellAgent, FixedAgent
+from mesa.discrete_space import CellAgent, FixedAgent
 
 
 class Animal(CellAgent):

--- a/mesa/examples/advanced/wolf_sheep/model.py
+++ b/mesa/examples/advanced/wolf_sheep/model.py
@@ -13,8 +13,8 @@ import math
 
 from mesa import Model
 from mesa.datacollection import DataCollector
-from mesa.examples.advanced.wolf_sheep.agents import GrassPatch, Sheep, Wolf
 from mesa.discrete_space import OrthogonalVonNeumannGrid
+from mesa.examples.advanced.wolf_sheep.agents import GrassPatch, Sheep, Wolf
 from mesa.experimental.devs import ABMSimulator
 
 

--- a/mesa/examples/advanced/wolf_sheep/model.py
+++ b/mesa/examples/advanced/wolf_sheep/model.py
@@ -14,7 +14,7 @@ import math
 from mesa import Model
 from mesa.datacollection import DataCollector
 from mesa.examples.advanced.wolf_sheep.agents import GrassPatch, Sheep, Wolf
-from mesa.experimental.cell_space import OrthogonalVonNeumannGrid
+from mesa.discrete_space import OrthogonalVonNeumannGrid
 from mesa.experimental.devs import ABMSimulator
 
 

--- a/mesa/experimental/__init__.py
+++ b/mesa/experimental/__init__.py
@@ -15,6 +15,6 @@ Notes:
     - Features graduate from experimental status once their APIs are stabilized
 """
 
-from mesa.experimental import cell_space, continuous_space, devs, mesa_signals
+from mesa.experimental import continuous_space, devs, mesa_signals
 
-__all__ = ["cell_space", "continuous_space", "devs", "mesa_signals"]
+__all__ = ["continuous_space", "devs", "mesa_signals"]

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -52,7 +52,7 @@ __all__ = [
 ]
 
 warnings.warn(
-    "you are importing from mesa.discrete_space, "
+    "you are importing from mesa.experimental.cell_space, "
     "all cell spaces have been moved to mesa.discrete_space",
     DeprecationWarning,
     stacklevel=2,

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -15,6 +15,8 @@ like resource growth, pollution diffusion, or infrastructure networks. The cell
 space system is experimental and under active development.
 """
 
+import warnings
+
 from mesa.discrete_space.cell import Cell
 from mesa.discrete_space.cell_agent import (
     CellAgent,
@@ -33,8 +35,6 @@ from mesa.discrete_space.network import Network
 from mesa.discrete_space.property_layer import PropertyLayer
 from mesa.discrete_space.voronoi import VoronoiGrid
 
-import warnings
-
 __all__ = [
     "Cell",
     "CellAgent",
@@ -51,5 +51,8 @@ __all__ = [
     "VoronoiGrid",
 ]
 
-warnings.warn("you are importing from mesa.discrete_space,"
-              "all cell spaces have been moved to mesa.discrete_space", DeprecationWarning)
+warnings.warn(
+    "you are importing from mesa.discrete_space,"
+    "all cell spaces have been moved to mesa.discrete_space",
+    DeprecationWarning,
+)

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -51,6 +51,7 @@ __all__ = [
     "VoronoiGrid",
 ]
 
+
 warnings.warn(
     "you are importing from mesa.experimental.cell_space, "
     "all cell spaces have been moved to mesa.discrete_space",

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -51,8 +51,6 @@ __all__ = [
     "VoronoiGrid",
 ]
 
-warnings.warn(
-    "you are importing from mesa.discrete_space,"
-    "all cell spaces have been moved to mesa.discrete_space",
-    DeprecationWarning,
-)
+warnings.warn("you are importing from mesa.discrete_space,"
+              "all cell spaces have been moved to mesa.discrete_space", DeprecationWarning,
+              stacklevel=2,)

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -52,7 +52,7 @@ __all__ = [
 ]
 
 warnings.warn(
-    "you are importing from mesa.discrete_space,"
+    "you are importing from mesa.discrete_space, "
     "all cell spaces have been moved to mesa.discrete_space",
     DeprecationWarning,
     stacklevel=2,

--- a/mesa/experimental/cell_space/__init__.py
+++ b/mesa/experimental/cell_space/__init__.py
@@ -51,6 +51,9 @@ __all__ = [
     "VoronoiGrid",
 ]
 
-warnings.warn("you are importing from mesa.discrete_space,"
-              "all cell spaces have been moved to mesa.discrete_space", DeprecationWarning,
-              stacklevel=2,)
+warnings.warn(
+    "you are importing from mesa.discrete_space,"
+    "all cell spaces have been moved to mesa.discrete_space",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -6,7 +6,7 @@ Objects used to add a spatial component to a model.
     All Grid classes (:class:`_Grid`, :class:`SingleGrid`, :class:`MultiGrid`,
     :class:`HexGrid`, etc.) are now in maintenance-only mode. While these classes remain
     fully supported, new development occurs in the experimental cell space module
-    (:mod:`mesa.experimental.cell_space`).
+    (:mod:`mesa.discrete_space`).
 
     The :class:`PropertyLayer` and :class:`ContinuousSpace` classes remain fully supported
     and actively developed.

--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -8,7 +8,7 @@ import solara
 with contextlib.suppress(ImportError):
     import altair as alt
 
-from mesa.experimental.cell_space import DiscreteSpace, Grid
+from mesa.discrete_space import DiscreteSpace, Grid
 from mesa.space import ContinuousSpace, _Grid
 from mesa.visualization.utils import update_counter
 

--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -5,7 +5,6 @@ import warnings
 import altair as alt
 import solara
 
-
 from mesa.discrete_space import DiscreteSpace, Grid
 from mesa.space import ContinuousSpace, _Grid
 from mesa.visualization.utils import update_counter

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -23,7 +23,7 @@ from matplotlib.colors import LinearSegmentedColormap, Normalize, to_rgba
 from matplotlib.patches import Polygon, RegularPolygon
 
 import mesa
-from mesa.experimental.cell_space import (
+from mesa.discrete_space import (
     OrthogonalMooreGrid,
     OrthogonalVonNeumannGrid,
     VoronoiGrid,
@@ -39,8 +39,8 @@ from mesa.space import (
 )
 
 OrthogonalGrid = SingleGrid | MultiGrid | OrthogonalMooreGrid | OrthogonalVonNeumannGrid
-HexGrid = HexSingleGrid | HexMultiGrid | mesa.experimental.cell_space.HexGrid
-Network = NetworkGrid | mesa.experimental.cell_space.Network
+HexGrid = HexSingleGrid | HexMultiGrid | mesa.discrete_space.HexGrid
+Network = NetworkGrid | mesa.discrete_space.Network
 
 
 def collect_agent_data(
@@ -132,7 +132,7 @@ def draw_space(
     # https://stackoverflow.com/questions/67524641/convert-multiple-isinstance-checks-to-structural-pattern-matching
     match space:
         # order matters here given the class structure of old-style grid spaces
-        case HexSingleGrid() | HexMultiGrid() | mesa.experimental.cell_space.HexGrid():
+        case HexSingleGrid() | HexMultiGrid() | mesa.discrete_space.HexGrid():
             draw_hex_grid(space, agent_portrayal, ax=ax, **space_drawing_kwargs)
         case (
             mesa.space.SingleGrid()
@@ -141,7 +141,7 @@ def draw_space(
             | mesa.space.MultiGrid()
         ):
             draw_orthogonal_grid(space, agent_portrayal, ax=ax, **space_drawing_kwargs)
-        case mesa.space.NetworkGrid() | mesa.experimental.cell_space.Network():
+        case mesa.space.NetworkGrid() | mesa.discrete_space.Network():
             draw_network(space, agent_portrayal, ax=ax, **space_drawing_kwargs)
         case (
             mesa.space.ContinuousSpace()
@@ -186,7 +186,7 @@ def draw_property_layers(
         layer = property_layers.get(layer_name, None)
         if not isinstance(
             layer,
-            PropertyLayer | mesa.experimental.cell_space.property_layer.PropertyLayer,
+            PropertyLayer | mesa.discrete_space.property_layer.PropertyLayer,
         ):
             continue
 

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from mesa import Model
-from mesa.experimental.cell_space import (
+from mesa.discrete_space import (
     Cell,
     CellAgent,
     CellCollection,


### PR DESCRIPTION
As part of the stabilization of cell spaces, this PR moves everything to `mesa.discrete_space`. I have kept the `mesa.experimental.cell_space`, which should continue to function but will issue a deprecation warning. 

I updated all tests and all examples that use cell spaces. 