### PR TITLE
remove remnants of mesa cli

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -68,7 +68,6 @@ model.step()
 
 You should see agents 1-5, activated in random order. See the [tutorial](tutorials/intro_tutorial) or API documentation for more detail on how to add model functionality.
 
-To bootstrap a new model install mesa and run `mesa startproject`
 
 ### AgentSet and model.agents
 Mesa 3.0 makes `model.agents` and the AgentSet class central in managing and activating agents.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,6 @@ docs = [
 homepage = "https://github.com/projectmesa/mesa"
 repository = "https://github.com/projectmesa/mesa"
 
-[project.scripts]
-mesa = "mesa.main:cli"
-
 [tool.hatch.build.targets.wheel]
 packages = ["mesa"]
 


### PR DESCRIPTION
In mesa 3.0, we removed the mesa command line interface and associated .py files. However, there were still some remnants of this remaining. This removes those from getting started and from the toml file. 