### PR TITLE
remove any reference to using --pre

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,16 @@ To install our latest stable release (3.0.x), run:
 pip install -U mesa
 ```
 
-To install our latest pre-release, run:
-
-``` bash
-pip install -U --pre mesa
-```
 Starting with Mesa 3.0, we don't install all our dependencies anymore by default.
 ```bash
 # You can customize the additional dependencies you need, if you want. Available are:
-pip install -U --pre mesa[network,viz]
+pip install -U mesa[network,viz]
 
 # This is equivalent to our recommended dependencies:
-pip install -U --pre mesa[rec]
+pip install -U mesa[rec]
 
 # To install all, including developer, dependencies:
-pip install -U --pre mesa[all]
+pip install -U mesa[all]
 ```
 
 You can also use `pip` to install the latest GitHub version:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Mesa allows users to quickly create agent-based models using built-in core compo
 
 ## Using Mesa
 ### Installation Options
-To install our latest stable release (3.0.x), run:
+To install our latest stable release (3.1.x), run:
 
 ```bash
 pip install -U mesa
@@ -46,12 +46,6 @@ pip install -U mesa[rec]
 On a Mac, this command might cause an error stating `zsh: no matches found: mesa[all]`.
 In that case, change the command to `pip install -U "mesa[rec]"`.
 
-
-To install our latest pre-release:
-
-```bash
-pip install -U --pre mesa[rec]
-```
 
 ### Resources
 

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -85,12 +85,6 @@
     "pip install --upgrade mesa[rec] \n",
     "```\n",
     "\n",
-    "If you want to use our newest features, you can also opt to install our latest pre-release version:\n",
-    "\n",
-    "```bash\n",
-    "pip install --upgrade --pre mesa[rec]\n",
-    "```\n",
-    "\n",
     "Install Jupyter notebook (optional):\n",
     "\n",
     "```bash\n",
@@ -117,9 +111,7 @@
   {
    "cell_type": "raw",
    "metadata": {},
-   "source": [
-    "pip install --quiet --upgrade --pre mesa[rec] #installs Mesa 3.0"
-   ]
+   "source": "pip install --quiet --upgrade mesa[rec] #installs Mesa 3.1.3"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
In preparing for mesa 3, we used pre-releases. With 3.1 and onwards we are not doing this anymore. Moreover, using e.g. `--pre mesa[all]` installs pre-releases not just for mesa but also for any other dependencies. This can e.g., result in solara malfunctioning (i.e., white screens as reported repeatedly). This PR removes all references to using `--pre` when installing mesa. 