### PR TITLE
paper: Update to citations 

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -9,3 +9,4 @@ falsy
 assertIn
 nD
 Calle
+Thi

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -72,17 +72,6 @@
 }
 
 # Used Mesa (cited 2015 paper)
-@article{namany2020sustainable,
-  title={Sustainable food security decision-making: an agent-based modelling approach.},
-  author={Namany, Sarah and Govindan, Rajesh and Alfagih, Luluwah and McKay, Gordon and Al-Ansari, Tareq},
-  journal={Journal of Cleaner Production},
-  volume={255},
-  pages={120296},
-  year={2020},
-  publisher={Elsevier},
-  doi = {10.1016/j.jclepro.2020.120296}
-}
-
 @article{sun2020post,
   title={A post-disaster resource allocation framework for improving resilience of interdependent infrastructure networks},
   author={Sun, Jingran and Zhang, Zhanmin},
@@ -94,17 +83,6 @@
   doi = {10.1016/j.trd.2020.102455}
 }
 
-@article{nageli2020towards,
-  title={Towards agent-based building stock modeling: Bottom-up modeling of long-term stock dynamics affecting the energy and climate impact of building stocks},
-  author={N{\"a}geli, Claudio and Jakob, Martin and Catenazzi, Giacomo and Ostermeyer, York},
-  journal={Energy and Buildings},
-  volume={211},
-  pages={109763},
-  year={2020},
-  publisher={Elsevier},
-  doi = {10.1016/j.enbuild.2020.109763}
-}
-
 @article{anatolitis2017putting,
   title={Putting renewable energy auctions into action--An agent-based model of onshore wind power auctions in Germany},
   author={Anatolitis, Vasilios and Welisch, Marijke},
@@ -114,6 +92,18 @@
   year={2017},
   publisher={Elsevier},
   doi = {10.1016/j.enpol.2017.08.024}
+}
+
+@article{pham2021interventions,
+	title = {Interventions to control nosocomial transmission of {SARS}-{CoV}-2: a modelling study},
+	author = {Pham, Thi Mui and Tahir, Hannan and van de Wijgert, Janneke H. H. M. and Van der Roest, Bastiaan R. and Ellerbroek, Pauline and Bonten, Marc J. M. and Bootsma, Martin C. J. and Kretzschmar, Mirjam E.},
+	journal = {BMC Medicine},
+	volume = {19},
+	pages = {211},
+	year = {2021},
+  month = aug,
+  publisher={Springer},
+	doi = {10.1186/s12916-021-02060-y}
 }
 
 # Used Mesa (cited 2020 paper)
@@ -128,6 +118,17 @@
   doi = {10.1016/j.eswa.2022.116604}
 }
 
+@article{taberna2023uncertainty,
+  title={Putting renewable energy auctions into action--An agent-based model of onshore wind power auctions in Germany},
+  author={Anatolitis, Vasilios and Welisch, Marijke},
+  journal={Energy Policy},
+  volume={110},
+  pages={394--402},
+  year={2017},
+  publisher={Elsevier},
+  doi = {10.1016/j.enpol.2017.08.024}
+}
+
 @article{ghanem2022balancing,
   title={Balancing consumer and business value of recommender systems: A simulation-based analysis},
   author={Ghanem, Nada and Leitner, Stephan and Jannach, Dietmar},
@@ -139,14 +140,12 @@
   doi = {10.1016/j.elerap.2022.101195}
 }
 
-@article{taberna2023uncertainty,
-  title={Uncertainty in boundedly rational household adaptation to environmental shocks},
-  author={Taberna, Alessandro and Filatova, Tatiana and Hadjimichael, Antonia and Noll, Brayton},
-  journal={Proceedings of the National Academy of Sciences},
-  volume={120},
-  number={44},
-  pages={e2215675120},
-  year={2023},
-  publisher={National Acad Sciences},
-  doi = {10.1073/pnas.2215675120}
+@article{souza2023edgesimpy,
+  title = {EdgeSimPy: Python-based modeling and simulation of edge computing resource management policies},
+  author = {Paulo S. Souza and Tiago Ferreto and Rodrigo N. Calheiros},
+  journal = {Future Generation Computer Systems},
+  volume = {148},
+  pages = {446-459},
+  year = {2023},
+  doi = {https://doi.org/10.1016/j.future.2023.06.013}
 }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -229,13 +229,13 @@ Mesa supports systematic parameter exploration:
 # Applications
 Mesa has been applied across diverse domains, including:
 
-- Sustainability and food security modeling, including supply chain optimization and resource allocation [@namany2020sustainable]
 - Infrastructure resilience and post-disaster recovery planning [@sun2020post]
-- Building stock modeling for energy demand and emissions analysis [@nageli2020towards]
 - Market modeling, including renewable energy auctions and consumer behavior [@anatolitis2017putting]
 - Transportation optimization, such as combined truck-drone delivery routing [@leon2022multi]
 - Recommender systems analysis examining consumer-business value tradeoffs over time [@ghanem2022balancing]
 - Climate adaptation modeling examining household-level behavioral responses to environmental shocks [@taberna2023uncertainty]
+- SEIR modeling of Sars-CoV-2 (Covid-19) [@pham2021interventions]
+- Management of edge computing resources [@souza2023edgesimpy]
 
 These applications showcase Mesa's versatility in modeling complex systems with autonomous interacting agents, whether representing individual consumers, infrastructure components, buildings, or vehicles.
 


### PR DESCRIPTION
Make updates to do two citations. It is a hard exercise to limit what is selected because of the breadth and depth that Mesa has applied. 

Removed:
- title={Putting renewable energy auctions into action--An agent-based model of onshore wind power auctions in Germany}
- title={Uncertainty in boundedly rational household adaptation to environmental shocks},

The list of citations felt like it was repetitive when it came to themes of climate change, energy, and markets, so I removed the lower-ranking ones to try to create a more unique list. 

Added: 
- Sars cov-2 because there are multiple applications in SIR modeling and biological/medical modeling - we needed to have something in there. 
- EdgeSimPy - because it is 2023 & has seems to have steam. It is also representative of the application from a technological application 

Both of the ones I added also have code online associated with them. 

From my last assessment of Mesa citations, significant areas include Health/Medical, Energy policy everything (because of EU regulatory policy that impacted markets), Climate change/management and disasters, technical-social applications (security, w3 applications), biological, ecological, and evolutionary. 

^^ Noting this, does the current list represent Mesa's various applications? I would like to know if it still skews too heavily on the infrastructure and/or disaster/instability sides. We could add more, but then it feels too long.  Thoughts?

Part of #2559.

Todo: 
- [x] Drop: Sustainable food security decision-making: an agent-based modelling approach
- [x] Drop: Building stock modeling for energy demand and emissions analysis 