### PR TITLE
added color-bar for spice

### DIFF
--- a/mesa/examples/advanced/sugarscape_g1mt/app.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/app.py
@@ -29,13 +29,14 @@ def SpaceDrawer(model):
         cmap="spring",
         origin="lower",
     )
-    fig.colorbar(im, orientation="vertical")
+    fig.colorbar(im, ax=ax, orientation="vertical", pad=0.1, fraction=0.046)
     # Spice
-    ax.imshow(
+    im_spice = ax.imshow(
         np.ma.masked_where(model.grid.spice.data <= 1, model.grid.spice.data),
         cmap="winter",
         origin="lower",
     )
+    fig.colorbar(im_spice, ax=ax, orientation="vertical", fraction=0.046, pad=0.04)
     # Trader
     ax.scatter(**out["trader"])
     ax.set_axis_off()


### PR DESCRIPTION
### Summary
In the [Sugarscape Model](https://github.com/projectmesa/mesa/tree/main/mesa/examples/advanced/sugarscape_g1mt), I noticed that while running it, the color bar was shown only for sugar and not for spice, so I added a color bar for spice as well.

### Before
![image](https://github.com/user-attachments/assets/a9a7896b-04dc-4667-b2d6-3325de6a216d)

### After
![image](https://github.com/user-attachments/assets/0f7cd998-a963-412e-a83f-dbd37601566c)





