### PR TITLE
Updated Docs

### DIFF
--- a/docs/apis/visualization.md
+++ b/docs/apis/visualization.md
@@ -37,6 +37,12 @@ For a detailed tutorial, please refer to our [Visualization Tutorial](../tutoria
    :show-inheritance:
 ```
 
+```{eval-rst}
+.. automodule:: mesa.visualization.components.__init__
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
 ## Altair-based visualizations
 
 ```{eval-rst}

--- a/docs/apis/visualization.md
+++ b/docs/apis/visualization.md
@@ -11,6 +11,13 @@ For a detailed tutorial, please refer to our [Visualization Tutorial](../tutoria
    :show-inheritance:
 ```
 
+```{eval-rst}
+.. automodule:: mesa.visualization.components.__init__
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
 ## User Parameters
 
 ```{eval-rst}
@@ -37,12 +44,7 @@ For a detailed tutorial, please refer to our [Visualization Tutorial](../tutoria
    :show-inheritance:
 ```
 
-```{eval-rst}
-.. automodule:: mesa.visualization.components.__init__
-   :members:
-   :undoc-members:
-   :show-inheritance:
-```
+
 ## Altair-based visualizations
 
 ```{eval-rst}


### PR DESCRIPTION
### Added 'make_space_component' and 'make_plot_component' to Docs
These 2 functions were left out as they were [internal functions](https://github.com/projectmesa/mesa/blob/main/mesa/visualization/components/__init__.py).
I guess this PR also resolves this issue #2285 

![image](https://github.com/user-attachments/assets/b6c850ef-707b-4711-af18-c3de2251527f)

![image](https://github.com/user-attachments/assets/751d40ad-39d5-42c1-9b18-8594f65bee4a)
