### PR TITLE
Change Hexgrid._connect_cells_2d to use x,y coordinates

### DIFF
--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -273,19 +273,19 @@ class HexGrid(Grid[T]):
     def _connect_cells_2d(self) -> None:
         # fmt: off
         even_offsets = [
-                        (-1, -1), (-1, 0),
-                    ( 0, -1),        ( 0, 1),
-                        ( 1, -1), ( 1, 0),
+                        (-1, -1), (0, -1),
+                    ( -1, 0),        ( 1, 0),
+                        ( -1, 1), (0, 1),
                 ]
         odd_offsets = [
-                        (-1, 0), (-1, 1),
-                    ( 0, -1),       ( 0, 1),
-                        ( 1, 0), ( 1, 1),
+                        (0, -1), (1, -1),
+                    ( -1, 0),       ( 1, 0),
+                        ( 0, 1), ( 1, 1),
                 ]
         # fmt: on
 
         for cell in self.all_cells:
-            i = cell.coordinate[0]
+            i = cell.coordinate[1]
             offsets = even_offsets if i % 2 == 0 else odd_offsets
             self._connect_single_cell_2d(cell, offsets=offsets)
 

--- a/mesa/experimental/cell_space/grid.py
+++ b/mesa/experimental/cell_space/grid.py
@@ -286,7 +286,7 @@ class HexGrid(Grid[T]):
 
         for cell in self.all_cells:
             i = cell.coordinate[1]
-            offsets = even_offsets if i % 2 == 0 else odd_offsets
+            offsets = even_offsets if i % 2 else odd_offsets
             self._connect_single_cell_2d(cell, offsets=offsets)
 
     def _connect_cells_nd(self) -> None:

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -354,7 +354,7 @@ def test_cell_neighborhood():
     grid = HexGrid(
         (width, height), torus=False, capacity=None, random=random.Random(42)
     )
-    for radius, n in zip(range(1, 4), [2, 6, 11]):
+    for radius, n in zip(range(1, 4), [3, 7, 13]):
         if radius == 1:
             neighborhood = grid._cells[(0, 0)].neighborhood
         else:
@@ -366,7 +366,7 @@ def test_cell_neighborhood():
     grid = HexGrid(
         (width, height), torus=False, capacity=None, random=random.Random(42)
     )
-    for radius, n in zip(range(1, 4), [5, 10, 17]):
+    for radius, n in zip(range(1, 4), [4, 10, 17]):
         if radius == 1:
             neighborhood = grid._cells[(1, 0)].neighborhood
         else:
@@ -385,25 +385,25 @@ def test_hexgrid():
     assert len(grid._cells) == width * height
 
     # first row
-    assert len(grid._cells[(0, 0)].connections.values()) == 2
+    assert len(grid._cells[(0, 0)].connections.values()) == 3
     for connection in grid._cells[(0, 0)].connections.values():
-        assert connection.coordinate in {(0, 1), (1, 0)}
+        assert connection.coordinate in {(0, 1), (1, 0), (1,1)}
 
     # second row
-    assert len(grid._cells[(1, 0)].connections.values()) == 5
+    assert len(grid._cells[(1, 0)].connections.values()) == 4
     for connection in grid._cells[(1, 0)].connections.values():
         # fmt: off
-        assert connection.coordinate in {(0, 0), (0, 1),
-                                         (1, 1),
-                                         (2, 0), (2, 1)}
+        assert connection.coordinate in {   (1, 1), (2, 1),
+                                         (0, 0),    (2, 0),}
+        # fmt: on
 
     # middle odd row
     assert len(grid._cells[(5, 5)].connections.values()) == 6
     for connection in grid._cells[(5, 5)].connections.values():
         # fmt: off
-        assert connection.coordinate in {(4, 5), (4, 6),
-                                         (5, 4), (5, 6),
-                                         (6, 5), (6, 6)}
+        assert connection.coordinate in {  (4, 4), (5, 4),
+                                         (4, 5), (6, 5),
+                                         (4, 6), (5, 6)}
 
         # fmt: on
 
@@ -411,9 +411,9 @@ def test_hexgrid():
     assert len(grid._cells[(4, 4)].connections.values()) == 6
     for connection in grid._cells[(4, 4)].connections.values():
         # fmt: off
-        assert connection.coordinate in {(3, 3), (3, 4),
-                                         (4, 3), (4, 5),
-                                         (5, 3), (5, 4)}
+        assert connection.coordinate in {(4, 3), (5, 3),
+                                         (3, 4), (5, 4),
+                                         (4, 5), (5, 5)}
 
         # fmt: on
 
@@ -424,9 +424,9 @@ def test_hexgrid():
     assert len(grid._cells[(0, 0)].connections.values()) == 6
     for connection in grid._cells[(0, 0)].connections.values():
         # fmt: off
-        assert connection.coordinate in {(9, 9), (9, 0),
-                                         (0, 9), (0, 1),
-                                         (1, 9), (1, 0)}
+        assert connection.coordinate in {(0, 9), (1, 9),
+                                         (9, 0), (1, 0),
+                                         (0, 1), (1, 1)}
 
         # fmt: on
 

--- a/tests/test_cell_space.py
+++ b/tests/test_cell_space.py
@@ -387,7 +387,7 @@ def test_hexgrid():
     # first row
     assert len(grid._cells[(0, 0)].connections.values()) == 3
     for connection in grid._cells[(0, 0)].connections.values():
-        assert connection.coordinate in {(0, 1), (1, 0), (1,1)}
+        assert connection.coordinate in {(0, 1), (1, 0), (1, 1)}
 
     # second row
     assert len(grid._cells[(1, 0)].connections.values()) == 4


### PR DESCRIPTION
This fixes #2631 by changing the coordinates and offsets for connecting the grid to use x,y coordinates instead of row, col coordinates. Below, you see the resulting fixed visual.


![Unknown](https://github.com/user-attachments/assets/225ec2db-1399-43d9-9198-6da3ba04f35f)
