### PR TITLE
benchmarks.yml: Install SciPy and use uv for pip install

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,8 +28,10 @@ jobs:
           python-version: '3.13'
       - name: Add project directory to PYTHONPATH
         run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
+      - name: Install uv
+        run: pip install uv
       - name: Install dependencies
-        run: pip install numpy pandas tqdm tabulate matplotlib solara networkx
+        run: uv pip install --system numpy pandas tqdm tabulate matplotlib solara networkx scipy
       # Benchmarks on the projectmesa main branch
       - name: Checkout main branch
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the broken benchmark workflow.

- Install SciPy, since that's now a dependency
- Use uv for pip install, which is way faster