### PR TITLE
Added aliases for terms in viz modules

### DIFF
--- a/mesa/visualization/__init__.py
+++ b/mesa/visualization/__init__.py
@@ -13,10 +13,14 @@ from mesa.visualization.mpl_space_drawing import (
 from .components import make_plot_component, make_space_component
 from .components.altair_components import make_space_altair
 from .solara_viz import JupyterViz, SolaraViz
+from .types import HexGrid, Network, OrthogonalGrid
 from .user_param import Slider
 
 __all__ = [
+    "HexGrid",
     "JupyterViz",
+    "Network",
+    "OrthogonalGrid",
     "Slider",
     "SolaraViz",
     "draw_space",

--- a/mesa/visualization/types.py
+++ b/mesa/visualization/types.py
@@ -1,0 +1,23 @@
+"""This module defines the types used in the visualization modules."""
+
+from mesa.experimental.cell_space import (
+    HexGrid as ExperimentalHexGrid,
+)
+from mesa.experimental.cell_space import (
+    Network as ExperimentalNetwork,
+)
+from mesa.experimental.cell_space import (
+    OrthogonalMooreGrid,
+    OrthogonalVonNeumannGrid,
+)
+from mesa.space import (
+    HexMultiGrid,
+    HexSingleGrid,
+    MultiGrid,
+    NetworkGrid,
+    SingleGrid,
+)
+
+OrthogonalGrid = SingleGrid | MultiGrid | OrthogonalMooreGrid | OrthogonalVonNeumannGrid
+HexGrid = HexSingleGrid | HexMultiGrid | ExperimentalHexGrid
+Network = NetworkGrid | ExperimentalNetwork


### PR DESCRIPTION
In one of the comments present in the code review for this PR #2430 , there was a request to make some of the aliases related to the visualization module centralized, this PR aims to do that. The link can be found [here](https://github.com/projectmesa/mesa/pull/2430/files#r1822075392)
![image](https://github.com/user-attachments/assets/7e8ebed9-e9f2-4196-a762-799f4e396765)
@EwoutH, I am not exactly sure if you meant to make it centralized throughout mesa or just in the visualization module. Since all the aliases were related to the visualization module, I have added it there.