### PR TITLE
Remove version specific docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ can be displayed in browser windows or Jupyter.*
 
 ## Using Mesa
 
-To install our latest stable release (3.0.x), run:
+To install our latest stable release, run:
 
 ``` bash
 pip install -U mesa

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,4 +11,4 @@ dependencies:
     - matplotlib
     - seaborn
     - solara
-    - mesa[rec]==3.0.0b1
+    - mesa[rec]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -177,8 +177,6 @@ The results are returned as a list of dictionaries, which can be easily converte
 ### Visualization
 Mesa now uses a new browser-based visualization system called SolaraViz. This allows for interactive, customizable visualizations of your models.
 
-> **Note:** SolaraViz is experimental and still in active development for Mesa 3.0. While we attempt to minimize them, there might be API breaking changes between Mesa 3.0 and 3.1. There won't be breaking changes between Mesa 3.0.x patch releases.
-
 > **Note:** SolaraViz instantiates new models using `**model_parameters.value`, so all model inputs must be keyword arguments.
 
 Ensure your model's `__init__` method accepts keyword arguments matching the `model_params` keys.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Mesa allows users to quickly create agent-based models using built-in core compo
 
 ## Using Mesa
 ### Installation Options
-To install our latest stable release (3.1.x), run:
+To install our latest stable release, run:
 
 ```bash
 pip install -U mesa

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "**Important:** \n",
     "- If you are just exploring Mesa and want the fastest way to execute the code we recommend executing this tutorial online in a Colab notebook. [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/projectmesa/mesa/blob/main/docs/tutorials/intro_tutorial.ipynb) or if you do not have a Google account you can use [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/projectmesa/mesa/main?labpath=docs%2Ftutorials%2Fintro_tutorial.ipynb) (This can take 30 seconds to 5 minutes to load)\n",
-    "- If you have installed mesa and are running locally, please ensure that your Mesa version is greater than or equal to 3.0.0b1.\n",
+    "- If you are running locally, please ensure you have the latest Mesa version installed.\n",
     "\n",
     "## Tutorial Description\n",
     "\n",

--- a/docs/tutorials/visualization_tutorial.ipynb
+++ b/docs/tutorials/visualization_tutorial.ipynb
@@ -11,9 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This version of the visualisation tutorial is updated for Mesa 3.0, and works with Mesa `3.0.0` and above.*\n",
-    "\n",
-    "> **Note:** SolaraViz is experimental and still in active development for Mesa 3.0. While we attempt to minimize them, there might be API breaking changes between Mesa 3.0 and 3.1. There won't be breaking changes between Mesa 3.0.x patch releases.\n",
+    "*This version of the visualisation tutorial is updated for Mesa 3.1, and works with Mesa `3.1.0` and above.*\n",
     "\n",
     "**Important:** \n",
     "- If you are just exploring Mesa and want the fastest way to the the dashboard and code checkout [![py.cafe](https://img.shields.io/badge/launch-py.cafe-blue)](https://py.cafe/app/tpike3/boltzmann-wealth-model) (click \"Editor\" to see the code)\n",

--- a/mesa/visualization/__init__.py
+++ b/mesa/visualization/__init__.py
@@ -1,10 +1,4 @@
-"""Solara based visualization for Mesa models.
-
-.. note::
-    SolaraViz is experimental and still in active development for Mesa 3.0. While we attempt to minimize them, there might be API breaking changes between Mesa 3.0 and 3.1.
-
-    There won't be breaking changes between Mesa 3.0.x patch releases.
-"""
+"""Solara based visualization for Mesa models."""
 
 from mesa.visualization.mpl_space_drawing import (
     draw_space,


### PR DESCRIPTION
Update version references in docs to be more generic, avoiding the need to update them with each release.

Also, SolaraViz has been stable and well-tested through the Mesa 3.0.x series. Remove the experimental warnings and version-specific notes from documentation, as it is now a stable component of Mesa 3.1.
