### PR TITLE
bugfix for draw_property_layer

### DIFF
--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -192,8 +192,9 @@ def draw_property_layers(
 
         data = layer.data.astype(float) if layer.data.dtype == bool else layer.data
         width, height = data.shape  # if space is None else (space.width, space.height)
+        data = data.T
 
-        if space and data.shape != (width, height):
+        if space.dimensions != (width, height):
             warnings.warn(
                 f"Layer {layer_name} dimensions ({data.shape}) do not match space dimensions ({width}, {height}).",
                 UserWarning,

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -192,7 +192,7 @@ def draw_property_layers(
 
         data = layer.data.astype(float) if layer.data.dtype == bool else layer.data
 
-        if space.dimensions != data.shape:
+        if (space.width, space.height) != data.shape:
             warnings.warn(
                 f"Layer {layer_name} dimensions ({data.shape}) do not match space dimensions ({width}, {height}).",
                 UserWarning,

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -194,7 +194,7 @@ def draw_property_layers(
 
         if (space.width, space.height) != data.shape:
             warnings.warn(
-                f"Layer {layer_name} dimensions ({data.shape}) do not match space dimensions ({width}, {height}).",
+                f"Layer {layer_name} dimensions ({data.shape}) do not match space dimensions ({space.width}, {space.height}).",
                 UserWarning,
                 stacklevel=2,
             )
@@ -207,6 +207,7 @@ def draw_property_layers(
 
         # Draw the layer
         if "color" in portrayal:
+            data = data.T
             rgba_color = to_rgba(portrayal["color"])
             normalized_data = (data - vmin) / (vmax - vmin)
             rgba_data = np.full((*data.shape, 4), rgba_color)
@@ -216,7 +217,7 @@ def draw_property_layers(
                 layer_name, [(0, 0, 0, 0), (*rgba_color[:3], alpha)]
             )
             im = ax.imshow(
-                rgba_data.T,
+                rgba_data,
                 origin="lower",
             )
             if colorbar:

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -191,10 +191,8 @@ def draw_property_layers(
             continue
 
         data = layer.data.astype(float) if layer.data.dtype == bool else layer.data
-        width, height = data.shape  # if space is None else (space.width, space.height)
-        data = data.T
 
-        if space.dimensions != (width, height):
+        if space.dimensions != data.shape:
             warnings.warn(
                 f"Layer {layer_name} dimensions ({data.shape}) do not match space dimensions ({width}, {height}).",
                 UserWarning,
@@ -218,7 +216,7 @@ def draw_property_layers(
                 layer_name, [(0, 0, 0, 0), (*rgba_color[:3], alpha)]
             )
             im = ax.imshow(
-                rgba_data,
+                rgba_data.T,
                 origin="lower",
             )
             if colorbar:
@@ -232,7 +230,7 @@ def draw_property_layers(
             if isinstance(cmap, list):
                 cmap = LinearSegmentedColormap.from_list(layer_name, cmap)
             im = ax.imshow(
-                data,
+                data.T,
                 cmap=cmap,
                 alpha=alpha,
                 vmin=vmin,


### PR DESCRIPTION
This closes #2635. Axes.imshow uses row, col, while our property layer data is x, y. This solves this by transposing the data in the axes.imshow command.