### PR TITLE
Implemented post_process in Altair based components

### DIFF
--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -46,13 +46,15 @@ def make_altair_space(
             return {"id": a.unique_id}
 
     def MakeSpaceAltair(model):
-        return SpaceAltair(model, agent_portrayal)
+        return SpaceAltair(model, agent_portrayal, post_process=post_process)
 
     return MakeSpaceAltair
 
 
 @solara.component
-def SpaceAltair(model, agent_portrayal, dependencies: list[any] | None = None):
+def SpaceAltair(
+    model, agent_portrayal, dependencies: list[any] | None = None, post_process=None
+):
     """Create an Altair-based space visualization component.
 
     Returns:
@@ -65,6 +67,9 @@ def SpaceAltair(model, agent_portrayal, dependencies: list[any] | None = None):
         space = model.space
 
     chart = _draw_grid(space, agent_portrayal)
+    # Apply post-processing if provided
+    if post_process is not None:
+        chart = post_process(chart)
     solara.FigureAltair(chart)
 
 

--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -29,8 +29,8 @@ def make_altair_space(
 
     Args:
         agent_portrayal: Function to portray agents.
-        propertylayer_portrayal: A user specified callable that will be called with the Chart instance from Altair. Allows for fine tuning plots (e.g., control ticks)
-        post_process :not yet implemented
+        propertylayer_portrayal: not yet implemented
+        post_process :A user specified callable that will be called with the Chart instance from Altair. Allows for fine tuning plots (e.g., control ticks)
         space_drawing_kwargs : not yet implemented
 
     ``agent_portrayal`` is called with an agent and should return a dict. Valid fields in this dict are "color",

--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -1,12 +1,9 @@
 """Altair based solara components for visualization mesa spaces."""
 
-import contextlib
 import warnings
 
+import altair as alt
 import solara
-
-with contextlib.suppress(ImportError):
-    import altair as alt
 
 from mesa.experimental.cell_space import DiscreteSpace, Grid
 from mesa.space import ContinuousSpace, _Grid

--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -29,7 +29,7 @@ def make_altair_space(
 
     Args:
         agent_portrayal: Function to portray agents.
-        propertylayer_portrayal: not yet implemented
+        propertylayer_portrayal: A user specified callable that will be called with the Chart instance from Altair. Allows for fine tuning plots (e.g., control ticks)
         post_process :not yet implemented
         space_drawing_kwargs : not yet implemented
 

--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -164,7 +164,7 @@ def _draw_grid(space, agent_portrayal):
         # no y-axis label
         "y": alt.Y("y", axis=None, type=x_y_type),
         "tooltip": [
-            alt.Tooltip(key, type=alt.utils.infer_vegalite_type([value]))
+            alt.Tooltip(key, type=alt.utils.infer_vegalite_type_for_pandas([value]))
             for key, value in all_agent_data[0].items()
             if key not in invalid_tooltips
         ],

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -97,7 +97,11 @@ def SolaraViz(
           reduce update frequency,resulting in faster execution.
     """
     if components == "default":
-        components = [components_altair.make_altair_space()]
+        components = [
+            components_altair.make_altair_space(
+                agent_portrayal=None, propertylayer_portrayal=None, post_process=None
+            )
+        ]
     if model_params is None:
         model_params = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ network = [
 viz = [
   "matplotlib",
   "solara",
+  "altair",
 ]
 # Dev and CI stuff
 dev = [

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -9,6 +9,7 @@ import solara
 import mesa
 import mesa.visualization.components.altair_components
 import mesa.visualization.components.matplotlib_components
+from mesa.visualization.components.altair_components import make_altair_space
 from mesa.visualization.components.matplotlib_components import make_mpl_space_component
 from mesa.visualization.solara_viz import (
     Slider,
@@ -132,6 +133,34 @@ def test_call_space_drawer(mocker):  # noqa: D103
     # should call default method with class instance and agent portrayal
     assert mock_space_matplotlib.call_count == 0
     assert mock_space_altair.call_count == 0
+
+    # checking if SpaceAltair is working as intended with post_process
+    def mock_post_process(chart):
+        return chart.configure_legend(titleFontSize=14, labelFontSize=12)
+
+    mock_post_process_spy = mocker.spy(mock_post_process)
+    solara.render(
+        SolaraViz(
+            model,
+            components=[
+                make_altair_space(
+                    agent_portrayal,
+                    propertylayer_portrayal,
+                    post_process=mock_post_process,
+                )
+            ],
+        )
+    )
+
+    mock_space_altair.assert_called_with(
+        model, agent_portrayal, propertylayer_portrayal, post_process=mock_post_process
+    )
+    mock_post_process_spy.assert_called_once()
+    assert mock_space_matplotlib.call_count == 0
+
+    mock_space_altair.reset_mock()
+    mock_space_matplotlib.reset_mock()
+    mock_post_process_spy.reset_mock()
 
     # specify a custom space method
     class AltSpace:

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -138,7 +138,7 @@ def test_call_space_drawer(mocker):  # noqa: D103
     def mock_post_process(chart):
         return chart.configure_legend(titleFontSize=14, labelFontSize=12)
 
-    mock_post_process_spy = mocker.spy(mock_post_process)
+    mock_post_process_spy = mocker.spy(mock_post_process, "__call__")
     solara.render(
         SolaraViz(
             model,


### PR DESCRIPTION
## Feature
I implemented post_process for Altair based components. And I just tested it out on the Boltzmann Wealth Model, with the following code:

```python
def post_process(chart: alt.Chart) -> alt.Chart:
    return (
        chart
        .configure_legend(
            titleFontSize=14,  
            labelFontSize=12
        )
        .properties(title="Agent Wealth Distribution")
        .configure_view(
            stroke="black",
            strokeWidth=1
        )
    )
```
### Before
![image](https://github.com/user-attachments/assets/d67282ff-984d-4f43-b939-e17aba6cc274)

### After
![Screenshot 2025-01-25 010414](https://github.com/user-attachments/assets/c0e31e3b-3ad4-478e-afb2-204069549d6f)




