### PR TITLE
ADDS ALTAIR PLOT COMPONENT AND SOME OTHER FIXES #2435

### DIFF
--- a/mesa/visualization/__init__.py
+++ b/mesa/visualization/__init__.py
@@ -11,7 +11,7 @@ from mesa.visualization.mpl_space_drawing import (
 )
 
 from .components import make_plot_component, make_space_component
-from .components.altair_components import make_space_altair
+from .components.altair_components import make_space_altair,make_altair_plot_component
 from .solara_viz import JupyterViz, SolaraViz
 from .user_param import Slider
 
@@ -22,5 +22,6 @@ __all__ = [
     "draw_space",
     "make_plot_component",
     "make_space_altair",
+    "make_altair_plot_component",
     "make_space_component",
 ]

--- a/mesa/visualization/components/__init__.py
+++ b/mesa/visualization/components/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from .altair_components import SpaceAltair, make_altair_space
+from .altair_components import SpaceAltair, make_altair_space,make_altair_plot_component
 from .matplotlib_components import (
     SpaceMatplotlib,
     make_mpl_plot_component,
@@ -76,7 +76,7 @@ def make_plot_component(
     if backend == "matplotlib":
         return make_mpl_plot_component(measure, post_process, **plot_drawing_kwargs)
     elif backend == "altair":
-        raise NotImplementedError("altair line plots are not yet implemented")
+        return make_altair_plot_component(measure, post_process, **plot_drawing_kwargs)
     else:
         raise ValueError(
             f"unknown backend {backend}, must be one of matplotlib, altair"

--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -15,12 +15,16 @@ from mesa.visualization.utils import update_counter
 
 def make_space_altair(*args, **kwargs):  # noqa: D103
     warnings.warn(
-        "make_space_altair has been renamed to make_altair_space",
+        "make_space_altair has been renamed to make_altair_space_component",
         DeprecationWarning,
         stacklevel=2,
     )
-    return make_altair_space(*args, **kwargs)
+    return make_altair_space_component(*args, **kwargs)
 
+
+def make_altair_space_component(*args, **kwargs):
+
+    return make_altair_space(*args, **kwargs)
 
 def make_altair_space(
     agent_portrayal, propertylayer_portrayal, post_process, **space_drawing_kwargs


### PR DESCRIPTION
- [x] - rename make_space_altair to something like make_altair_space_component
- [x] - add make_altair_plot_component
- [ ] - Add support for all spaces. This means including the hexgrid and network transformation of the x and y coordinates.
- [ ]  - Have a generic get_agent_data method

@quaquel  @EwoutH  I’ve added a new component, make_altair_plot_component. Could you kindly check if it aligns well with the project?

P.S working on space support.