### PR TITLE
Fix: Property layer visualization for HexGrid

### DIFF
--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -194,7 +194,6 @@ def draw_property_layers(
 
     def get_hexmesh(width: int, height: int) -> list[list[tuple[float, float]]]:
         """Create hexagon vertices for the mesh."""
-
         hexagons = []
         size = 1
         x_spacing = np.sqrt(3) * size
@@ -209,7 +208,7 @@ def draw_property_layers(
                 hexagons.append(vertices)
 
         return hexagons
-    
+
     try:
         # old style spaces
         property_layers = space.properties
@@ -262,13 +261,13 @@ def draw_property_layers(
 
         if is_hex_grid:
             width, height = data.shape
-            
+
             # Generate hexagon mesh
             hexagons = get_hexmesh(width, height)
 
             # Normalize colors
             norm = Normalize(vmin=vmin, vmax=vmax)
-            colors = data.ravel() # flatten data to 1D array
+            colors = data.ravel()  # flatten data to 1D array
 
             if "color" in portrayal:
                 normalized_colors = np.clip(norm(colors), 0, 1)
@@ -279,7 +278,7 @@ def draw_property_layers(
 
             # Draw hexagons
             collection = PolyCollection(hexagons, facecolors=rgba_colors, zorder=-1)
-            im = ax.add_collection(collection)
+            ax.add_collection(collection)
         else:
             # Rectangular grid rendering
             if "color" in portrayal:
@@ -288,9 +287,9 @@ def draw_property_layers(
                 rgba_data = np.full((*data.shape, 4), rgba_color)
                 rgba_data[..., 3] *= normalized_data * alpha
                 rgba_data = np.clip(rgba_data, 0, 1)
-                im = ax.imshow(rgba_data, origin="lower")
+                ax.imshow(rgba_data, origin="lower")
             else:
-                im = ax.imshow(
+                ax.imshow(
                     data.T,
                     cmap=cmap,
                     alpha=alpha,

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -160,27 +160,27 @@ def draw_space(
     return ax
 
 
-# Helper function for getting the vertices of a hexagon given the center and size
-def _get_hex_vertices(
-    center_x: float, center_y: float, size: float
-) -> list[tuple[float, float]]:
-    """Get vertices for a hexagon centered at (center_x, center_y)."""
-    vertices = [
-        (center_x, center_y + size),  # top
-        (center_x + size * np.sqrt(3) / 2, center_y + size / 2),  # top right
-        (center_x + size * np.sqrt(3) / 2, center_y - size / 2),  # bottom right
-        (center_x, center_y - size),  # bottom
-        (center_x - size * np.sqrt(3) / 2, center_y - size / 2),  # bottom left
-        (center_x - size * np.sqrt(3) / 2, center_y + size / 2),  # top left
-    ]
-    return vertices
-
-
 @lru_cache(maxsize=1024, typed=True)
 def _get_hexmesh(
-    width: int, height: int, size: float
+    width: int, height: int, size: float = 1.0
 ) -> Iterator[list[tuple[float, float]]]:
     """Generate hexagon vertices for the mesh. Yields list of vertex coordinates for each hexagon."""
+
+    # Helper function for getting the vertices of a hexagon given the center and size
+    def _get_hex_vertices(
+        center_x: float, center_y: float, size: float = 1.0
+    ) -> list[tuple[float, float]]:
+        """Get vertices for a hexagon centered at (center_x, center_y)."""
+        vertices = [
+            (center_x, center_y + size),  # top
+            (center_x + size * np.sqrt(3) / 2, center_y + size / 2),  # top right
+            (center_x + size * np.sqrt(3) / 2, center_y - size / 2),  # bottom right
+            (center_x, center_y - size),  # bottom
+            (center_x - size * np.sqrt(3) / 2, center_y - size / 2),  # bottom left
+            (center_x - size * np.sqrt(3) / 2, center_y + size / 2),  # top left
+        ]
+        return vertices
+
     x_spacing = np.sqrt(3) * size
     y_spacing = 1.5 * size
 
@@ -276,7 +276,7 @@ def draw_property_layers(
             width, height = data.shape
 
             # Generate hexagon mesh
-            hexagons = _get_hexmesh(width, height, size=1)
+            hexagons = _get_hexmesh(width, height)
 
             # Normalize colors
             norm = Normalize(vmin=vmin, vmax=vmax)
@@ -409,13 +409,12 @@ def draw_hex_grid(
     def setup_hexmesh(width, height):
         """Helper function for creating the hexmesh with unique edges."""
         edges = set()
-        size = 1.0
 
         # Generate edges for each hexagon
-        for vertices in _get_hexmesh(width, height, size):
+        for vertices in _get_hexmesh(width, height):
             # Edge logic, connecting each vertex to the next
             for v1, v2 in pairwise([*vertices, vertices[0]]):
-                # Sort vertices to ensure consistent edge representation
+                # Sort vertices to ensure consistent edge representation and avoid duplicates.
                 edge = tuple(sorted([tuple(np.round(v1, 6)), tuple(np.round(v2, 6))]))
                 edges.add(edge)
 

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -9,10 +9,10 @@ for a paper.
 import contextlib
 import itertools
 import warnings
-from collections.abc import Callable
-from itertools import pairwise
-from typing import Any, Iterator
+from collections.abc import Callable, Iterator
 from functools import lru_cache
+from itertools import pairwise
+from typing import Any
 
 import networkx as nx
 import numpy as np
@@ -177,13 +177,13 @@ def _get_hex_vertices(
 
 
 @lru_cache(maxsize=1024, typed=True)
-def _get_hexmesh(width: int, height: int, size: float) -> Iterator[list[tuple[float, float]]]:
-    """
-    Generate hexagon vertices for the mesh. Yields list of vertex coordinates for each hexagon
-    """
+def _get_hexmesh(
+    width: int, height: int, size: float
+) -> Iterator[list[tuple[float, float]]]:
+    """Generate hexagon vertices for the mesh. Yields list of vertex coordinates for each hexagon."""
     x_spacing = np.sqrt(3) * size
     y_spacing = 1.5 * size
-    
+
     for row, col in itertools.product(range(height), range(width)):
         # Calculate center position with offset for even rows
         x = col * x_spacing + (row % 2 == 0) * (x_spacing / 2)
@@ -207,7 +207,6 @@ def draw_property_layers(
         so you can do `{"some_layer":{"colormap":'viridis', 'alpha':.25, "colorbar":False}}`
 
     """
-
     try:
         # old style spaces
         property_layers = space.properties
@@ -419,7 +418,7 @@ def draw_hex_grid(
                 # Sort vertices to ensure consistent edge representation
                 edge = tuple(sorted([tuple(np.round(v1, 6)), tuple(np.round(v2, 6))]))
                 edges.add(edge)
-        
+
         return LineCollection(edges, linestyle=":", color="black", linewidth=1, alpha=1)
 
     if draw_grid:


### PR DESCRIPTION
### Summary
Property layers were not properly visualized for HexGrids, and this PR aims to resolve that issue. It utilizes the same coordinate system as the `draw_hex_grid` function and generates a `PolyCollection` that overlays color values on the grid.

### Bug / Issue
fixes #2433 

### Before
![Screenshot 2025-01-26 203400](https://github.com/user-attachments/assets/7356fa67-d570-4675-a742-4a7edad2bc08)

### After
![Screenshot 2025-01-26 203521](https://github.com/user-attachments/assets/41e10566-e7cb-4197-9b8b-67800ac1417c)

### Additional Notes:
I am not entirely sure if this was the best approach to address the issue. If there is a more effective or elegant solution, I would greatly appreciate your recommendations.
