### PR TITLE
Fix: Alpha for colormaps in HexGrid

### DIFF
--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -291,6 +291,7 @@ def draw_property_layers(
                 rgba_colors[:, 3] = normalized_colors * alpha
             else:
                 rgba_colors = cmap(norm(colors))
+                rgba_colors[..., 3] *= alpha
 
             # Draw hexagons
             collection = PolyCollection(hexagons, facecolors=rgba_colors, zorder=-1)


### PR DESCRIPTION
### Summary
There was no applying of alpha value for colormap in hex-grid. This PR fixes that.

### Implementation
Changes made: 
```python
 rgba_colors[..., 3] *= alpha
```

### Before (For alpha 0.1):
![image](https://github.com/user-attachments/assets/a8a1845f-0080-4be5-abcd-907bfcafa925)

### After (For alpha 0.1):
![image](https://github.com/user-attachments/assets/9cc16472-cff8-461e-8d2f-4d05ba1798f3)

