### PR TITLE
Backlink Fixed for Examples Tab

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: mesa-tutorials
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python
   - numpy
   - pip
   - pip:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,8 +1,8 @@
-name: example-environment
+name: mesa-tutorials
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python=3.9
   - numpy
   - pip
   - pip:

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ API Documentation <apis/api_main>
 [matrix chat room]: https://matrix.to/#/#project-mesa:matrix.org
 [mesa]: https://github.com/projectmesa/mesa/
 [mesa overview]: overview
-[mesa examples]: https://github.com/projectmesa/mesa-examples
+[mesa examples]: https://mesa.readthedocs.io/stable/examples.html
 [mesa introductory tutorial]: tutorials/intro_tutorial
 [mesa visualization tutorial]: tutorials/visualization_tutorial
 [migration guide]: migration_guide


### PR DESCRIPTION
### Summary
<!-- Provide a brief summary of the bug and its impact. -->
A link for[ Examples Tab](https://mesa.readthedocs.io/latest/tutorials/examples.html) in Introductory Tutorial is gives 404 Page Not Found error.

### Implementation
<!-- Describe the changes made to resolve the issue. Highlight any important parts of the code that were modified. -->
- Updated the Examples tab link
- Ensured that the link now directs users to a valid page.
### Testing
<!-- Detail the testing performed to verify the fix. Include information on test cases, steps taken, and any relevant results.

If you're fixing the visualisation, add before/after screenshots. -->
![Screenshot from 2025-02-05 01-14-51](https://github.com/user-attachments/assets/f9cea64f-1f05-4399-bbd3-882070b373e9)
After implementation it redirects to [ Examples Tab](https://mesa.readthedocs.io/latest/tutorials/examples.html)
![Screenshot from 2025-02-05 01-15-16](https://github.com/user-attachments/assets/59340f3e-7e9a-4751-bc4f-7b74c36afc79)

