### PR TITLE
Fixed 404 error for Examples Tab in Introductory Tutorial (#2662)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ API Documentation <apis/api_main>
 [matrix chat room]: https://matrix.to/#/#project-mesa:matrix.org
 [mesa]: https://github.com/projectmesa/mesa/
 [mesa overview]: overview
-[mesa examples]: https://github.com/projectmesa/mesa-examples
+[mesa examples]: https://mesa.readthedocs.io/stable/examples.html
 [mesa introductory tutorial]: tutorials/intro_tutorial
 [mesa visualization tutorial]: tutorials/visualization_tutorial
 [migration guide]: migration_guide

--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -44,7 +44,7 @@
     "If you are looking for other Mesa models or tools here are some additional resources. \n",
     "\n",
     "- Interactive Dashboard: There is a separate [visualization tutorial](https://mesa.readthedocs.io/latest/tutorials/visualization_tutorial.html) that will take users through building a dashboard for this model (aka Boltzmann Wealth Model).\n",
-    "- Classic ABMs: You can also find canonical examples of ABMs written in Mesa in the [Examples Tab](https://mesa.readthedocs.io/latest/tutorials/examples.html)\n",
+    "- Classic ABMs: You can also find canonical examples of ABMs written in Mesa in the [Examples Tab](https://mesa.readthedocs.io/stable/examples.html)\n",
     "- More Examples: Want to integrate Reinforcement Learning or work on the Traveling Salesman Problem checkout  [Mesa Examples](https://github.com/projectmesa/mesa-examples/)\n",
     "- Mesa-Geo: If you need an ABM with Geographic Information Systems (GIS) checkout [Mesa-Geo](https://mesa-geo.readthedocs.io/latest/)\n",
     "- Mesa Frames: Have a large complex model that you need to speed up, check out [Mesa Frames](https://github.com/projectmesa/mesa-frames)"


### PR DESCRIPTION
### Summary
<!-- Provide a brief summary of the bug and its impact. -->
Fixes the issue where the backlink for the "Examples" tab in the Introductory Tutorial results in a 404 error. 

### Bug / Issue
<!-- Link to the related issue(s) and describe the bug. Include details like the context, what was expected, and what actually happened. -->
- A link for[ Examples Tab](https://mesa.readthedocs.io/latest/tutorials/examples.html) in Introductory Tutorial is gives 404 Page Not Found error.
- Issue: Fixes #2662 
### Implementation
<!-- Describe the changes made to resolve the issue. Highlight any important parts of the code that were modified. -->
- Updated the link for the "Examples" tab to point to the correct location.
- Ensured that the link now directs users to a valid page.

### Testing
<!-- Detail the testing performed to verify the fix. Include information on test cases, steps taken, and any relevant results.

If you're fixing the visualisation, add before/after screenshots. -->
![Screenshot from 2025-02-05 01-14-51](https://github.com/user-attachments/assets/b26c5cac-05be-4985-901d-c58b6272c59d)
After fixing it redirects to [ Examples Tab](https://mesa.readthedocs.io/latest/tutorials/examples.html)
![Screenshot from 2025-02-05 01-15-16](https://github.com/user-attachments/assets/32b2bc04-9084-40ff-a6e7-1e64c5086279)
