### PR TITLE
fixing the draw_orthogonal_grid function

### DIFF
--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -350,9 +350,9 @@ def draw_orthogonal_grid(
     if draw_grid:
         # Draw grid lines
         for x in np.arange(-0.5, space.width - 0.5, 1):
-            ax.axvline(x, color="gray", linestyle=":")
+            ax.axvline(x, color="gray", linestyle="-")
         for y in np.arange(-0.5, space.height - 0.5, 1):
-            ax.axhline(y, color="gray", linestyle=":")
+            ax.axhline(y, color="gray", linestyle="-")
 
     return ax
 


### PR DESCRIPTION
## Bug
I noticed that using make_mpl_space_component to create a plot, always created weird patterns in the background when the model used orthogonal grids. The red dots are agents, but the gray patterns were actually the rendition of the orthogonal grid by the draw_orthogonal_grid function. 

### Before
![image](https://github.com/user-attachments/assets/8408c857-c2b3-4a2e-943e-20bf4550fa5a)

The logic seems to be correct, but the grid is being drawn using ":", this makes it easy to confuse between the horizontal and the vertical lines causing visually confusing renditions. To resolve this, I just changed ":" to "-" in the code.

### After
![image](https://github.com/user-attachments/assets/24cdbc32-5db6-458c-92cb-a7fa0127ae92)
 
To replicate an issue of this kind you could change draw_grid to True in [sugarspace](https://github.com/projectmesa/mesa/blob/7c778609e08247829ea86d8310659e32a353b5ef/mesa/examples/advanced/sugarscape_g1mt/app.py#L20C4-L20C21)

