### PR TITLE
docs: Clarify recommended dependencies in installation guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,9 +43,10 @@ To also install our recommended dependencies:
 pip install -U mesa[rec]
 ```
 
+The `[rec]` option installs additional recommended dependencies needed for visualization (SolaraViz), Matplotlib plotting, and network modeling capabilities.
+
 On a Mac, this command might cause an error stating `zsh: no matches found: mesa[all]`.
 In that case, change the command to `pip install -U "mesa[rec]"`.
-
 
 ### Resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ To also install our recommended dependencies:
 pip install -U mesa[rec]
 ```
 
-The `[rec]` option installs additional recommended dependencies needed for visualization (SolaraViz), Matplotlib plotting, and network modeling capabilities.
+The `[rec]` option installs additional recommended dependencies needed for visualization, plotting, and network modeling capabilities.
 
 On a Mac, this command might cause an error stating `zsh: no matches found: mesa[all]`.
 In that case, change the command to `pip install -U "mesa[rec]"`.


### PR DESCRIPTION
Add explanation of what the [rec] optional dependencies provide, including visualization (SolaraViz), Matplotlib plotting, and network modeling capabilities. This helps users understand when they need to install these additional packages.

Part of #2666 based on the feedback of @jofmi.
