### PR TITLE
Minor (bug) fixes to discrete_space

### DIFF
--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -7,6 +7,7 @@ import datetime
 
 import mesa.experimental as experimental
 import mesa.space as space
+import mesa.discrete_space as discrete_space
 from mesa.agent import Agent
 from mesa.batchrunner import batch_run
 from mesa.datacollection import DataCollector
@@ -15,6 +16,7 @@ from mesa.model import Model
 __all__ = [
     "Agent",
     "DataCollector",
+    "discrete_space"
     "Model",
     "batch_run",
     "experimental",

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -16,9 +16,9 @@ from mesa.model import Model
 __all__ = [
     "Agent",
     "DataCollector",
-    "discrete_space",
     "Model",
     "batch_run",
+    "discrete_space",
     "experimental",
     "space",
 ]

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -16,7 +16,8 @@ from mesa.model import Model
 __all__ = [
     "Agent",
     "DataCollector",
-    "discrete_spaceModel",
+    "discrete_space",
+    "Model",
     "batch_run",
     "experimental",
     "space",

--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -5,9 +5,9 @@ Core Objects: Model, and Agent.
 
 import datetime
 
+import mesa.discrete_space as discrete_space
 import mesa.experimental as experimental
 import mesa.space as space
-import mesa.discrete_space as discrete_space
 from mesa.agent import Agent
 from mesa.batchrunner import batch_run
 from mesa.datacollection import DataCollector
@@ -16,8 +16,7 @@ from mesa.model import Model
 __all__ = [
     "Agent",
     "DataCollector",
-    "discrete_space"
-    "Model",
+    "discrete_spaceModel",
     "batch_run",
     "experimental",
     "space",

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -40,7 +40,7 @@ class Cell:
 
     __slots__ = [
         "__dict__",
-        "agents",
+        "_agents",
         "capacity",
         "connections",
         "coordinate",

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -185,12 +185,12 @@ class Cell:
             raise ValueError("radius must be larger than one")
         if radius == 1:
             neighborhood = {
-                neighbor: neighbor.agents for neighbor in self.connections.values()
+                neighbor: neighbor._agents for neighbor in self.connections.values()
             }
             if not include_center:
                 return neighborhood
             else:
-                neighborhood[self] = self.agents
+                neighborhood[self] = self._agents
                 return neighborhood
         else:
             neighborhood: dict[Cell, list[Agent]] = {}

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -65,8 +65,8 @@ class Cell:
         super().__init__()
         self.coordinate = coordinate
         self.connections: dict[Coordinate, Cell] = {}
-        self.agents: list[
-            Agent
+        self._agents: list[
+            CellAgent
         ] = []  # TODO:: change to AgentSet or weakrefs? (neither is very performant, )
         self.capacity: int | None = capacity
         self.properties: dict[
@@ -104,7 +104,7 @@ class Cell:
             agent (CellAgent): agent to add to this Cell
 
         """
-        n = len(self.agents)
+        n = len(self._agents)
         self.empty = False
 
         if self.capacity and n >= self.capacity:
@@ -112,7 +112,7 @@ class Cell:
                 "ERROR: Cell is full"
             )  # FIXME we need MESA errors or a proper error
 
-        self.agents.append(agent)
+        self._agents.append(agent)
 
     def remove_agent(self, agent: CellAgent) -> None:
         """Removes an agent from the cell.
@@ -121,7 +121,7 @@ class Cell:
             agent (CellAgent): agent to remove from this cell
 
         """
-        self.agents.remove(agent)
+        self._agents.remove(agent)
         self.empty = self.is_empty
 
     @property
@@ -133,6 +133,11 @@ class Cell:
     def is_full(self) -> bool:
         """Returns a bool of the contents of a cell."""
         return len(self.agents) == self.capacity
+
+    @property
+    def agents(self) -> list[CellAgent]:
+        """returns a list of the agents occupying the cell."""
+        return self._agents.copy()
 
     def __repr__(self):  # noqa
         return f"Cell({self.coordinate}, {self.agents})"

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -136,7 +136,7 @@ class Cell:
 
     @property
     def agents(self) -> list[CellAgent]:
-        """returns a list of the agents occupying the cell."""
+        """Returns a list of the agents occupying the cell."""
         return self._agents.copy()
 
     def __repr__(self):  # noqa

--- a/mesa/discrete_space/cell_collection.py
+++ b/mesa/discrete_space/cell_collection.py
@@ -59,7 +59,7 @@ class CellCollection(Generic[T]):
         if isinstance(cells, dict):
             self._cells = cells
         else:
-            self._cells = {cell: cell.agents for cell in cells}
+            self._cells = {cell: cell._agents for cell in cells}
 
         # Get capacity from first cell if collection is not empty
         self._capacity: int | None = (

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -89,7 +89,7 @@ class DiscreteSpace(Generic[T]):
     def all_cells(self):
         """Return all cells in space."""
         return CellCollection(
-            {cell: cell.agents for cell in self._cells.values()}, random=self.random
+            {cell: cell._agents for cell in self._cells.values()}, random=self.random
         )
 
     def __iter__(self):  # noqa

--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -1,12 +1,12 @@
 from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealth
-from mesa.mesa_logging import DEBUG, log_to_stderr
+from mesa.mesa_logging import INFO, log_to_stderr
 from mesa.visualization import (
     SolaraViz,
     make_plot_component,
     make_space_component,
 )
 
-log_to_stderr(DEBUG)
+log_to_stderr(INFO)
 
 
 def agent_portrayal(agent):


### PR DESCRIPTION
1. This adds `mesa.discrete_space` to `__init__`. You can now do `from mesa import discrete_space`. This also fixes the failing benchmarks. 
2. This solves #2682. `Cell.agents` now returns a copy of the list of agents in the cell, rather than the actual list. This reduces the potential for nasty side effects. Since `Cell` already has `add_agent` and `remove_agent`, this was a simple fix. 