### PR TITLE
added dark mode

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Literal
 
 import reacton.core
 import solara
+import solara.lab
 
 import mesa.visualization.components.altair_components as components_altair
 from mesa.experimental.devs.simulator import Simulator
@@ -115,6 +116,7 @@ def SolaraViz(
     reactive_render_interval = solara.use_reactive(render_interval)
     with solara.AppBar():
         solara.AppBarTitle(name if name else model.value.__class__.__name__)
+        solara.lab.ThemeToggle()
 
     with solara.Sidebar(), solara.Column():
         with solara.Card("Controls"):


### PR DESCRIPTION
## This PR adds the Solara Dark theme to Mesa

By default, the theme is set to match the user's system settings, however, it can be controlled by clicking on the toggle at the right end of the app bar once solara is launched

### Dark Mode (Auto for me)
![image](https://github.com/user-attachments/assets/00997f08-acc0-4b73-b921-955beb99e8b6)

### Light Mode
![image](https://github.com/user-attachments/assets/080c2938-3885-4603-a560-fbe8094cdec0)
