### PR TITLE
docs: Add Roles section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,64 @@ ruff .
 
 The license of this project is located in [LICENSE].  By submitting a contribution to this project, you are agreeing that your contribution will be released under the terms of this license.
 
-## Maintainers
+## Roles in Mesa
+Mesa has several roles to help structure our collaboration and recognize great work. They also form a progression path for community members to that want to take on increasing responsibility in the project. Since we're all volunteers, everyone contributes what they can when they can - there are no minimum time commitments. Also, the best ideas and contributions can come from anyone, these roles are just a way to coordinate our efforts.
+
+Feel free to reach out to us anytime to discuss your interests and ambitions in the project. We're always happy to chat about how you can grow your involvement in Mesa!
+
+### Contributor
+Contributors help improve Mesa through:
+- Code contributions 
+- Documentation improvements
+- Bug reports and fixes
+- Example models
+- Tutorial improvements
+- Answering questions
+- Participating in discussions
+- Testing pre-releases
+- Sharing Mesa with others
+
+Everyone can contribute what they can, when they can. No contribution is too small! Contributors who have a PR successfully merged receive the "Contributor" label on GitHub.
+
+### Collaborator
+When contributors consistently demonstrate technical skills and community mindset through their contributions, they may be invited to become collaborators. Collaborators help coordinate by:
+
+- Reviewing pull requests
+- Triaging issues and discussions
+- Coordinating between contributors
+- Leading specific areas of development
+- Helping new contributors
+- Participating in project planning
+- Building community
+
+The collaborator role recognizes people who help Mesa grow through both their technical contributions and community involvement. Collaborators receive GitHub triage permissions and the "Collaborator" label.
+
+### Maintainer 
+Maintainers help guide Mesa's overall development while ensuring the project remains sustainable and welcoming. They focus on:
+- Project vision and roadmap
+- Major architectural decisions  
+- Release management
+- Community governance
+- Mentoring collaborators
+- Final decision-making authority
+- Setting community standards
+- Long-term sustainability
+
+Maintainers are selected based on their technical expertise, project understanding, and community leadership. Maintainers receive full repository permissions and the "Member" label.
+
+### Special Roles
+In some cases, special roles may be created for specific purposes, such as leading particular initiatives or components within Mesa. These roles are created as needed based on project requirements and may come with specific permissions and labels.
+
+All roles are expected to:
+- Follow Mesa's code of conduct
+- Communicate respectfully 
+- Work collaboratively
+- Help maintain a welcoming community
+- Make decisions transparently
+
+Mesa grows through good ideas and contributions. We're all volunteers working together to make Mesa better. Don't hesitate to reach out to any maintainer to discuss your interests and potential growth within the project!
+
+## Maintainers' notes
 Some notes useful for Mesa maintainers.
 
 ### Releases


### PR DESCRIPTION
This PR adds a new "Roles" section to the Contributing Guide to clarify Mesa's community structure and progression path. It outlines the different ways community members can contribute and grow within the project:

- Describes the Contributor, Collaborator, Maintainer and Special roles
- Emphasizes that Mesa welcomes contributions from everyone 
- Explains GitHub permissions and labels for each role
- Encourages reaching out to discuss taking on more responsibility
- Reinforces that we're all volunteers working together

This documentation aims to make Mesa's governance more transparent and welcoming to new contributors while providing clear paths for increased involvement.

@projectmesa/maintainers this is a first draft based on our internal discussions. Let me know what you think of it, happy to make adjustments.
