### PR TITLE
Update boid_flockers example include flight direction

### DIFF
--- a/mesa/examples/basic/boid_flockers/agents.py
+++ b/mesa/examples/basic/boid_flockers/agents.py
@@ -58,7 +58,7 @@ class Boid(ContinuousSpaceAgent):
         self.separate_factor = separate
         self.match_factor = match
         self.neighbors = []
-        self.angle = 0.0
+        self.angle = 0.0  # represents the angle at which the boid is moving
 
     def step(self):
         """Get the Boid's neighbors, compute the new vector, and move accordingly."""

--- a/mesa/examples/basic/boid_flockers/agents.py
+++ b/mesa/examples/basic/boid_flockers/agents.py
@@ -58,6 +58,7 @@ class Boid(ContinuousSpaceAgent):
         self.separate_factor = separate
         self.match_factor = match
         self.neighbors = []
+        self.angle = 0.0
 
     def step(self):
         """Get the Boid's neighbors, compute the new vector, and move accordingly."""

--- a/mesa/examples/basic/boid_flockers/app.py
+++ b/mesa/examples/basic/boid_flockers/app.py
@@ -1,6 +1,9 @@
 import os
 import sys
 
+import numpy as np
+from matplotlib.markers import MarkerStyle
+
 sys.path.insert(0, os.path.abspath("../../../.."))
 
 from mesa.examples.basic.boid_flockers.model import BoidFlockers
@@ -13,7 +16,10 @@ def boid_draw(agent):
     if neighbors <= 1:
         return {"color": "red", "size": 20, "marker": "o"}
     elif neighbors >= 2:
-        return {"color": "green", "size": 20, "marker": (3, 0, 60)}
+        deg = np.degrees(np.arctan2(agent.direction[0], agent.direction[1]))
+        marker = MarkerStyle(10)
+        marker._transform = marker.get_transform().rotate_deg(deg)
+        return {"color": "green", "size": 20, "marker": marker}
 
 
 model_params = {

--- a/mesa/examples/basic/boid_flockers/app.py
+++ b/mesa/examples/basic/boid_flockers/app.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-import numpy as np
 from matplotlib.markers import MarkerStyle
 
 sys.path.insert(0, os.path.abspath("../../../.."))
@@ -9,20 +8,26 @@ sys.path.insert(0, os.path.abspath("../../../.."))
 from mesa.examples.basic.boid_flockers.model import BoidFlockers
 from mesa.visualization import Slider, SolaraViz, make_space_component
 
+# Pre-compute markers for different angles (e.g., every 10 degrees)
+MARKER_CACHE = {}
+for angle in range(0, 360, 10):
+    marker = MarkerStyle(10)
+    marker._transform = marker.get_transform().rotate_deg(angle)
+    MARKER_CACHE[angle] = marker
+
 
 def boid_draw(agent):
     neighbors = len(agent.neighbors)
 
+    # Calculate the angle
+    deg = agent.angle
+    # Round to nearest 10 degrees
+    rounded_deg = round(deg / 10) * 10 % 360
+
     if neighbors <= 1:
-        deg = np.degrees(np.arctan2(agent.direction[0], agent.direction[1]))
-        marker = MarkerStyle(10)
-        marker._transform = marker.get_transform().rotate_deg(deg)
-        return {"color": "red", "size": 20, "marker": marker}
+        return {"color": "red", "size": 20, "marker": MARKER_CACHE[rounded_deg]}
     elif neighbors >= 2:
-        deg = np.degrees(np.arctan2(agent.direction[0], agent.direction[1]))
-        marker = MarkerStyle(10)
-        marker._transform = marker.get_transform().rotate_deg(deg)
-        return {"color": "green", "size": 20, "marker": marker}
+        return {"color": "green", "size": 20, "marker": MARKER_CACHE[rounded_deg]}
 
 
 model_params = {

--- a/mesa/examples/basic/boid_flockers/app.py
+++ b/mesa/examples/basic/boid_flockers/app.py
@@ -24,6 +24,7 @@ def boid_draw(agent):
     # Round to nearest 10 degrees
     rounded_deg = round(deg / 10) * 10 % 360
 
+    # using cached markers to speed things up
     if neighbors <= 1:
         return {"color": "red", "size": 20, "marker": MARKER_CACHE[rounded_deg]}
     elif neighbors >= 2:

--- a/mesa/examples/basic/boid_flockers/app.py
+++ b/mesa/examples/basic/boid_flockers/app.py
@@ -14,7 +14,10 @@ def boid_draw(agent):
     neighbors = len(agent.neighbors)
 
     if neighbors <= 1:
-        return {"color": "red", "size": 20, "marker": "o"}
+        deg = np.degrees(np.arctan2(agent.direction[0], agent.direction[1]))
+        marker = MarkerStyle(10)
+        marker._transform = marker.get_transform().rotate_deg(deg)
+        return {"color": "red", "size": 20, "marker": marker}
     elif neighbors >= 2:
         deg = np.degrees(np.arctan2(agent.direction[0], agent.direction[1]))
         marker = MarkerStyle(10)

--- a/mesa/examples/basic/boid_flockers/model.py
+++ b/mesa/examples/basic/boid_flockers/model.py
@@ -49,7 +49,9 @@ class BoidFlockers(Model):
             seed: Random seed for reproducibility (default: None)
         """
         super().__init__(seed=seed)
-        self.agent_angles = np.zeros(population_size)
+        self.agent_angles = np.zeros(
+            population_size
+        )  # holds the angle representing the direction of all agents at a given step
 
         # Set up the space
         self.space = ContinuousSpace(
@@ -80,6 +82,7 @@ class BoidFlockers(Model):
         self.average_heading = None
         self.update_average_heading()
 
+    # vectorizing the calculation of angles for all agents
     def calculate_angles(self):
         d1 = np.array([agent.direction[0] for agent in self.agents])
         d2 = np.array([agent.direction[1] for agent in self.agents])

--- a/mesa/examples/basic/boid_flockers/model.py
+++ b/mesa/examples/basic/boid_flockers/model.py
@@ -49,6 +49,7 @@ class BoidFlockers(Model):
             seed: Random seed for reproducibility (default: None)
         """
         super().__init__(seed=seed)
+        self.agent_angles = np.zeros(population_size)
 
         # Set up the space
         self.space = ContinuousSpace(
@@ -79,6 +80,13 @@ class BoidFlockers(Model):
         self.average_heading = None
         self.update_average_heading()
 
+    def calculate_angles(self):
+        d1 = np.array([agent.direction[0] for agent in self.agents])
+        d2 = np.array([agent.direction[1] for agent in self.agents])
+        self.agent_angles = np.degrees(np.arctan2(d1, d2))
+        for agent, angle in zip(self.agents, self.agent_angles):
+            agent.angle = angle
+
     def update_average_heading(self):
         """Calculate the average heading (direction) of all Boids."""
         if not self.agents:
@@ -96,3 +104,4 @@ class BoidFlockers(Model):
         """
         self.agents.shuffle_do("step")
         self.update_average_heading()
+        self.calculate_angles()


### PR DESCRIPTION
I updated boid_flockers so that the direction of movement of agents is shown in the simulation.
I did this by changing the marker to caret-down (a triangle with a larger base so that the direction of motion is not ambiguous) and then rotating the marker according to the direction of motion of the agent. Here are some images of boid_flockers after this update:
![image](https://github.com/user-attachments/assets/cfcf3030-639c-4fa7-8fac-96efbbcc6eea)


![image](https://github.com/user-attachments/assets/01dfd536-5744-4862-a460-686278ff293a)


