### PR TITLE
Optimize model  execution to stop immediately when required

### DIFF
--- a/mesa/experimental/devs/simulator.py
+++ b/mesa/experimental/devs/simulator.py
@@ -110,7 +110,7 @@ class Simulator:
                 "simulator has not been setup, call simulator.setup(model) first"
             )
 
-        while True:
+        while True and self.model.running:
             try:
                 event = self.event_list.pop_event()
             except IndexError:  # event list is empty
@@ -348,7 +348,7 @@ class ABMSimulator(Simulator):
                 "simulator has not been setup, call simulator.setup(model) first"
             )
 
-        while True:
+        while True and self.model.running:
             try:
                 event = self.event_list.pop_event()
             except IndexError:

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -239,9 +239,10 @@ def ModelController(
     def do_step():
         """Advance the model by the number of steps specified by the render_interval slider."""
         for _ in range(render_interval.value):
+            if not running.value:
+                break
             model.value.step()
-
-        running.value = model.value.running
+            running.value = model.value.running
 
         force_update()
 


### PR DESCRIPTION
This PR updates the `do_step` function to exit early when `running.value` is `False`. Previously, it would continue executing `n` steps even after `running` was set to stop. Now, it stops immediately when `running.value` becomes `False`.  

This applies to models running in both `ModelController` and `SimulatorController`.