### PR TITLE
[JOSS] docs: Improve batch_run documentation for parallel processing

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -240,6 +240,7 @@ results = mesa.batch_run(
     iterations=5,
     max_steps=100,
     data_collection_period=1,
+    number_processes=1  # Change to use multiple CPU cores for parallel execution
 )
 ```
 

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -3,7 +3,12 @@
 To take advantage of parallel execution of experiments, `batch_run` uses
 multiprocessing if ``number_processes`` is larger than 1. It is strongly advised
 to only run in parallel using a normal python file (so don't try to do it in a
-jupyter notebook). Moreover, best practice when using multiprocessing is to
+jupyter notebook). This is because Jupyter notebooks have a different execution
+model that can cause issues with Python's multiprocessing module, especially on
+Windows. The main problems include the lack of a traditional __main__ entry
+point, serialization issues, and potential deadlocks.
+
+Moreover, best practice when using multiprocessing is to
 put the code inside an ``if __name__ == '__main__':`` code black as shown below::
 
     from mesa.batchrunner import batch_run
@@ -20,8 +25,6 @@ put the code inside an ``if __name__ == '__main__':`` code black as shown below:
             data_collection_period=1,
             display_progress=True,
         )
-
-
 
 """
 


### PR DESCRIPTION
This PR enhances the documentation for Mesa's `batch_run` function by:

1. Adding explicit mention of the `number_processes` parameter in the getting started guide
2. Including an explanation of why parallel processing should be avoided in Jupyter notebooks
3. Adding a more detailed explanation in the batchrunner module docstring about multiprocessing limitations

Part of #2666, based on feedback from @martibosch.