### PR TITLE
paper: Remove experimental note and add missing space

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -84,7 +84,7 @@ The framework is particularly suited for:
 # Core capabilities
 Mesa is a Python-based framework for ABM that provides a comprehensive set of tools for creating, running, and analyzing ABMs. Mesa integrates with the wider scientific Python ecosystem with libraries such as [NumPy](https://numpy.org/), [pandas](https://pandas.pydata.org/), [Matplotlib](https://matplotlib.org/), [NetworkX](https://networkx.org/), and more. The backend of the framework is written in Python, while the front-end end uses a Python implementation of React. The modular architecture is comprised of three main components:
 
-1. Core ABM components (*i.e.,* agents, spaces, agent activation, control over random numbers)to build models
+1. Core ABM components (*i.e.,* agents, spaces, agent activation, control over random numbers) to build models
 2. Data collection and support for model experimentation
 3. Visualization systems
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -168,11 +168,6 @@ For models where agents need to move continuously through space rather than betw
     space = ContinuousSpace(x_max, y_max, torus=True)
     space.move_agent(agent, (new_x, new_y))
 ```
-The space module is stable but under active development. The new cell-based spaces in Mesa 3 are currently being tested and considered feature-complete. The code snippets reflected in this paper are the future expected state of Mesa. Features not yet merged into core are imported from experimental:
-
-```python
-from mesa.experimental.cell_space ...
-```
 
 ### Time advancement
 Mesa supports two primary approaches to advancing time in simulations: incremental-time progression (tick-based) and next-event time progression


### PR DESCRIPTION
Two changes to the paper:
- Remove note that space module is experimental, since it will be stabilized in 3.2 (see https://github.com/projectmesa/mesa/pull/2610)
- Add missing space