### PR TITLE
first proposal for a memory module in mesa

### DIFF
--- a/mesa/experimental/devs/memory.py
+++ b/mesa/experimental/devs/memory.py
@@ -1,0 +1,107 @@
+"""An entry-recording functionality designed to be used as the memory of an agent.
+
+This module provides the foundational class needed for storing information in the memory of an agent.
+Then objective is to implement a very simple and efficient system that can be used for any agent and
+for any kind of information (an entry). The user defines the capacity of the memory chooses the format
+of the entries, which allows for a greater flexibility. Key features:
+
+- Capacity-based memory, with a FIFO system
+- Efficient storage and retrieval of entries
+- Support for different entry_types of entries
+- Possibility to send entries to other agents
+
+For now, the module contains only one main component:
+- Memory: A class representing the memory of an agent
+
+"""
+
+# from experimental.devs.eventlist import EventList, SimulationEvent
+import copy
+import itertools
+from collections import OrderedDict
+from typing import Any
+
+from mesa.model import Model
+
+
+class Memory:
+    """The memory of an Agent : it can store any kind of information based on a unique id of the form (agent_id, entry_id) to ensure the uniqueness of the entry.
+
+    Attributes:
+        model (Model): The used model
+        agent_id (int): The id of the agent
+        capacity (int): The capacity of the memory
+
+    Structure of one entry (example):
+        "entry_id" : {
+            "external_agent_id" : external_agent_id, # Not mandatory : represents the agent that sent the entry (if memory was received)
+            "entry_step" : 1,
+            "entry_type" : "position",
+            "entry_content" : [1,2]
+        },
+
+    """
+
+    def __init__(self, model: Model, agent_id: int, capacity: int):
+        """Initializes the agent memory."""
+        self.model = model
+        self.capacity = capacity
+        self.agent_id = agent_id
+        self._ids = itertools.count()
+
+        self.memory_storage = OrderedDict()
+
+    def remember(
+        self, entry_content: Any, entry_type: Any, external_agent_id=None
+    ) -> tuple:
+        """Store an entry in the memory."""
+        entry_id = (self.agent_id, next(self._ids))
+
+        # creation of a new entry in the memory
+        if entry_id not in self.memory_storage:
+            self.memory_storage[entry_id] = OrderedDict()
+
+        self.memory_storage[entry_id]["entry_content"] = entry_content
+        self.memory_storage[entry_id]["entry_type"] = entry_type
+        self.memory_storage[entry_id]["entry_step"] = self.model.steps
+
+        if external_agent_id is not None:
+            self.memory_storage[entry_id]["external_agent_id"] = external_agent_id
+
+        # if the memory is longer than the capacity, we remove the oldest entry
+        if len(self.memory_storage) > self.capacity:
+            self.memory_storage.popitem(last=False)
+
+        return entry_id
+
+    def recall(self, entry_id):
+        """Recall a specific entry."""
+        # Verification of the existence of the entry
+        if entry_id not in self.memory_storage:
+            return None
+        return self.memory_storage[entry_id]
+
+    def get_by_type(self, entry_type: str) -> list:
+        """Returns all the ids of the entries of a specific entry_type."""
+        entry_list = [
+            entry_id
+            for entry_id, entry in self.memory_storage.items()
+            if entry["entry_type"] == entry_type
+        ]
+        return entry_list
+
+    def forget(self, entry_id):
+        """Forget a specific entry."""
+        if entry_id in self.memory_storage:
+            self.memory_storage.pop(entry_id)
+
+    def tell_to(self, entry_id, external_agent):
+        """Send a precise memory to another agent by making a deep copy of the entry."""
+        entry_copy = copy.deepcopy(self.memory_storage[entry_id])
+        new_entry_id = external_agent.memory.remember(
+            entry_copy["entry_content"],
+            entry_copy["entry_type"],
+            external_agent_id=self.agent_id,
+        )
+
+        return new_entry_id


### PR DESCRIPTION
# Add agent memory module for storing and retrieving information

## Summary
This PR introduces a new Memory module that enables agents to store, recall, and share information during simulations. The mesa user may need memory for a wide range of different usages. Taking this in consideration, I made the memory very flexible and able to store different types of information (cf. [memory structure](#Memory-structure)).

Overall, this memory system provides a simple but useful way to add memory capabilities to any Mesa agent with minimal implementation overhead.

## Key features

**Basic features**
- Capacity-limited FIFO memory storage with automatic management
- Flexible entry types for any kind of information 
- Timestamped entries tied to simulation steps
- Selective memory removal
- Entry selecting by type


**Extra features - the value of this memory module is here**
- Inter-agent memory sharing capabilities
- Efficient retrieval by entry type

## Memory structure

After studying different data structures (plain dict, building my own structure, etc.) I chose to use an `OrderedDict` that have roughly the same complexity as a plain dict, but with features relative to its ordering (pop and related).

Example of a structure for my_agent.memory.memory_structure : 

```json
{
    "entry_id1" : {
        "entry_step" : 7,
        "entry_type" : "position",
        "entry_content" : [1,2]
    },
    "entry_id2" : {
        "entry_step" : 12,
        "entry_type" : "infection",
        "entry_content" : true
    },
    "entry_id3" : {
        "entry_step" : 32,
        "entry_type" : "health",
        "entry_content" : 12
    },
    "entry_id4" : {
        "external_agent_id" : "external_agent_id",
        "entry_step" : 34,
        "entry_type" : "dialog",
        "entry_content" : "Hello, I feel sick like a sheep"
    }
}
```
> Note : the external_agent_id component in the last entry indicates that this entry was transmitted to my_agent by another agent.


## Example usage

I created a whole working model ([the foraging ants model](https://github.com/colinfrisch/ABM_mesa_models/tree/main/foraging_ants)) using this memory feature, feel free to explore it (and don't hesitate to give me feedbacks)

```python
# Creating a memory for an agent
agent.memory = Memory(model=self.model, agent_id=self.unique_id, capacity=10)

# Storing information
position_entry_id = agent.memory.remember(
    entry_content=[10, 20],
    entry_type="position"
)

# Recalling information
position_data = agent.memory.recall(position_entry_id)

# Finding entries by type
all_position_entries = agent.memory.get_by_type("position")

# Sharing memory with another agent
agent.memory.tell_to(position_entry_id, other_agent)

# Removing an entry
agent.memory.forget(position_entry_id)
```

I would love to have your feedbacks on this proposal !

## Update : Next steps

I came across a [paper on LLM based agents](https://arxiv.org/pdf/2401.03428) detailing the possible configuration for memory structures in this case. I am going to experiment around this to see if we can make a general memory structure (not only around LLMs) with these elements.

![MemoryStructure](https://github.com/user-attachments/assets/671272c9-baff-4a6c-887a-338635344487)
