### PR TITLE
Support multiple functions in AgentSet `agg` method

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -382,18 +382,18 @@ class AgentSet(MutableSet, Sequence):
         return res
 
     def agg(
-        self, attribute: str, func: Callable | list[Callable] | tuple[Callable, ...]
+        self, attribute: str, func: Callable | Iterable[Callable]
     ) -> Any | list[Any]:
         """Aggregate an attribute of all agents in the AgentSet using one or more functions.
 
         Args:
             attribute (str): The name of the attribute to aggregate.
-            func (Callable | list[Callable] | tuple[Callable]):
+            func (Callable | Iterable[Callable]):
                 - If Callable: A single function to apply to the attribute values (e.g., min, max, sum, np.mean)
-                - If list or tuple: Multiple functions to apply to the attribute values
+                - If Iterable: Multiple functions to apply to the attribute values
 
         Returns:
-            Any | tuple[Any, ...]: Result of applying the function(s) to the attribute values.
+            Any | [Any, ...]: Result of applying the function(s) to the attribute values.
 
         Examples:
             # Single function
@@ -407,7 +407,7 @@ class AgentSet(MutableSet, Sequence):
         if isinstance(func, Callable):
             return func(values)
         else:
-            return tuple(f(values) for f in func)
+            return [f(values) for f in func]
 
     @overload
     def get(

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -404,10 +404,10 @@ class AgentSet(MutableSet, Sequence):
         """
         values = self.get(attribute)
 
-        if isinstance(func, list | tuple):
-            return tuple(f(values) for f in func)
-        else:
+        if isinstance(func, Callable):
             return func(values)
+        else:
+            return tuple(f(values) for f in func)
 
     @overload
     def get(

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -381,18 +381,33 @@ class AgentSet(MutableSet, Sequence):
 
         return res
 
-    def agg(self, attribute: str, func: Callable) -> Any:
-        """Aggregate an attribute of all agents in the AgentSet using a specified function.
+    def agg(
+        self, attribute: str, func: Callable | list[Callable] | tuple[Callable, ...]
+    ) -> Any | list[Any]:
+        """Aggregate an attribute of all agents in the AgentSet using one or more functions.
 
         Args:
             attribute (str): The name of the attribute to aggregate.
-            func (Callable): The function to apply to the attribute values (e.g., min, max, sum, np.mean).
+            func (Callable | list[Callable] | tuple[Callable]):
+                - If Callable: A single function to apply to the attribute values (e.g., min, max, sum, np.mean)
+                - If list or tuple: Multiple functions to apply to the attribute values
 
         Returns:
-            Any: The result of applying the function to the attribute values. Often a single value.
+            Any | tuple[Any, ...]: Result of applying the function(s) to the attribute values.
+
+        Examples:
+            # Single function
+            avg_energy = model.agents.agg("energy", np.mean)
+
+            # Multiple functions
+            min_wealth, max_wealth, total_wealth = model.agents.agg("wealth", [min, max, sum])
         """
         values = self.get(attribute)
-        return func(values)
+
+        if isinstance(func, list | tuple):
+            return tuple(f(values) for f in func)
+        else:
+            return func(values)
 
     @overload
     def get(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -413,15 +413,15 @@ def test_agentset_agg():
 
     # Test with list of functions
     min_max_energy = agentset.agg("energy", [min, max])
-    assert min_max_energy == (1, 10)
+    assert min_max_energy == [1, 10]
 
     # Test with tuple of functions
     min_energy, max_energy, total_energy = agentset.agg("energy", (min, max, sum))
-    assert (min_energy, max_energy, total_energy) == (1, 10, 55)
+    assert [min_energy, max_energy, total_energy] == [1, 10, 55]
 
     # Test with custom functions in a list
     stats = agentset.agg("wealth", [min, max, np.mean, custom_func])
-    assert stats == (10, 100, 55.0, 55.0)
+    assert stats == [10, 100, 55.0, 55.0]
 
 
 def test_agentset_set_method():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -411,6 +411,18 @@ def test_agentset_agg():
     custom_avg_energy = agentset.agg("energy", custom_func)
     assert custom_avg_energy == 5.5
 
+    # Test with list of functions
+    min_max_energy = agentset.agg("energy", [min, max])
+    assert min_max_energy == (1, 10)
+
+    # Test with tuple of functions
+    min_energy, max_energy, total_energy = agentset.agg("energy", (min, max, sum))
+    assert (min_energy, max_energy, total_energy) == (1, 10, 55)
+
+    # Test with custom functions in a list
+    stats = agentset.agg("wealth", [min, max, np.mean, custom_func])
+    assert stats == (10, 100, 55.0, 55.0)
+
 
 def test_agentset_set_method():
     """Test AgentSet.set."""


### PR DESCRIPTION
### Summary
This PR enhances the `AgentSet.agg` method to accept lists and tuples of aggregation functions, enabling multiple aggregations in a single method call.

### Motive
Currently, when analyzing agent attributes, users need to make separate calls to `agg` for each aggregation function (min, max, sum, etc.). This creates performance overhead since the attribute values must be collected multiple times.

This enhancement improves both performance and code readability by supporting multiple aggregation functions in a single call, allowing the attribute values to be collected just once and reused across all aggregation functions.

### Implementation
- Modified the `agg` method signature to accept a single callable or an iterable of callables
- Updated the return type to handle returning either a single value or a list of results
- Updated docstring with examples to demonstrate the new functionality
- Added comprehensive tests to verify all use cases

### Usage Examples
```python
# Before (multiple calls required)
min_wealth = model.agents.agg("wealth", min)
max_wealth = model.agents.agg("wealth", max)
total_wealth = model.agents.agg("wealth", sum)

# After (single call)
min_wealth, max_wealth, total_wealth = model.agents.agg("wealth", [min, max, sum])

# Also works with custom functions
stats = model.agents.agg("wealth", [min, max, np.mean, custom_aggregation_function])
```

### Additional Notes
This enhancement is completely backward compatible, so existing code will continue to work without changes. The method will now return a tuple when multiple functions are provided, maintaining the same order as the input function list.

It might also reduce future datacollector complexity, because aggregation can be done efficiently outside it.

I also considered allowing multiple `attribute` values, but I decided against it since it adds complexity, its use case is less clear and the performance improvements are negligible.