### PR TITLE
Debug option for errors in visualisation

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -273,10 +273,8 @@ def ModelController(
                 do_step()
                 if use_threads.value:
                     visualization_pause_event.set()
-        except Exception as e:
-            debug = input(f"Error in step: {e}. Press 'e' for full traceback ")
-            if debug == "e":
-                traceback.print_exc()
+        except Exception as _:
+            traceback.print_exc()
             return
 
     def visualization_task():
@@ -286,12 +284,8 @@ def ModelController(
                     visualization_pause_event.wait()
                     visualization_pause_event.clear()
                     force_update()
-            except Exception as e:
-                debug = input(
-                    f"Error in visualization_task: {e}. Press 'e' for full traceback "
-                )
-                if debug == "e":
-                    traceback.print_exc()
+            except Exception as _:
+                traceback.print_exc()
 
     solara.lab.use_task(
         step, dependencies=[playing.value, running.value], prefer_threaded=True

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -27,6 +27,7 @@ import asyncio
 import inspect
 import threading
 import time
+import traceback
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
@@ -273,7 +274,9 @@ def ModelController(
                 if use_threads.value:
                     visualization_pause_event.set()
         except Exception as e:
-            print(f"Error in step: {e}")
+            debug = input(f"Error in step: {e}. Press 'e' for full traceback ")
+            if debug == "e":
+                traceback.print_exc()
             return
 
     def visualization_task():
@@ -284,7 +287,11 @@ def ModelController(
                     visualization_pause_event.clear()
                     force_update()
             except Exception as e:
-                print(f"Error in visualization_task: {e}")
+                debug = print(
+                    f"Error in visualization_task: {e}. Press 'e' for full traceback "
+                )
+                if debug == "e":
+                    traceback.print_exc()
 
     solara.lab.use_task(
         step, dependencies=[playing.value, running.value], prefer_threaded=True

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -287,7 +287,7 @@ def ModelController(
                     visualization_pause_event.clear()
                     force_update()
             except Exception as e:
-                debug = print(
+                debug = input(
                     f"Error in visualization_task: {e}. Press 'e' for full traceback "
                 )
                 if debug == "e":


### PR DESCRIPTION
Resolves #2745

### What the problem was

I noticed that when there is an error while visualising a mesa model with solara, it only displays the error type, not the classic debugging error (document, line, etc.).
For example, I got an error AttributeError: 'my_object' object has no attribute 'len', but I didn't know what part it was referring to, as I was using dependencies to different files that I created. It would be useful to have a possibility to see the full error for debugging.

### How it fixes it

I only added an option to display the error if needed.
Now, instead of displaying  `Error in step : [YOUR ERROR]`, it displays `Error in step: [YOUR ERROR]. Press 'e' for full traceback `, if you press any other key, it doesn't show anything. It also does not prevent you from refreshing your visualisation or resetting it.
