### PR TITLE
Fix: Collect finaFixes #2514  Ensures that BatchRunner collects the last data point after the model stops running.l step data in BatchRunner (Fixes #2514)

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -173,6 +173,10 @@ def _model_run_func(
     model = model_cls(**kwargs)
     while model.running and model.steps <= max_steps:
         model.step()
+        # Fix for Issue #2514: collect final step's data
+if self.collect_data and hasattr(model, "datacollector"):
+    model.datacollector.collect(model)
+
 
     data = []
 


### PR DESCRIPTION
Thanks for opening a PR! Please click the `Preview` tab and select a PR template:

- [🐛 Bug fix](?expand=1&template=bug.md)
- [🛠 Feature/enhancement](?expand=1&template=feature.md)
