### PR TITLE
Fix: keep simulation running when no events exist in DEVSimulator.

### DIFF
--- a/mesa/experimental/devs/simulator.py
+++ b/mesa/experimental/devs/simulator.py
@@ -115,7 +115,9 @@ class Simulator:
                 event = self.event_list.pop_event()
             except IndexError:  # event list is empty
                 self.time = end_time
-                break
+                # Wait briefly instead of stopping
+                time.sleep(0.1)  # Adjust the sleep time if needed
+                continue
 
             if event.time <= end_time:
                 self.time = event.time
@@ -353,7 +355,9 @@ class ABMSimulator(Simulator):
                 event = self.event_list.pop_event()
             except IndexError:
                 self.time = end_time
-                break
+                # Wait briefly instead of stopping
+                time.sleep(0.1)  # Adjust the sleep time if needed
+                continue
 
             # fixme: the alternative would be to wrap model.step with an annotation which
             #  handles this scheduling.


### PR DESCRIPTION
**Summary**
Modified run_until() to allow the simulation to continue running even when the event list is empty, by implementing idle event handling.

**Motive**
The simulation previously stopped when no events were in the queue. This change ensures the simulation remains active, waiting for new events.

**Implementation**
Updated the run_until() method to prevent termination when the event queue is empty. Introduced a waiting mechanism to keep the simulator running, even in the absence of events.

**Usage Examples**
# The simulation continues to run even when there are no events in the queue.
simulator.run_until(1000)

**Additional Notes**
This change improves long-running simulations by ensuring they don’t stop prematurely. The new behavior is helpful in cases where events are dynamically scheduled.