### PR TITLE
Add support for dynamic discrete spaces

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -89,7 +89,6 @@ class Cell:
         self._neighborhood.cache_clear()
         self.connections[key] = other
 
-
     def disconnect(self, other: Cell) -> None:
         """Disconnects this cell from another cell.
 
@@ -102,7 +101,9 @@ class Cell:
             del self.connections[key]
 
         self.get_neighborhood.cache_clear()
-        self.__dict__.pop("neighborhood", None)  # cached properties are stored in the dic, see functools.cached_property docs
+        self.__dict__.pop(
+            "neighborhood", None
+        )  # cached properties are stored in the dic, see functools.cached_property docs
         self._neighborhood.cache_clear()
 
     def add_agent(self, agent: CellAgent) -> None:

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -85,7 +85,7 @@ class Cell:
         if key is None:
             key = other.coordinate
         self.get_neighborhood.cache_clear()
-        self.__dict__.pop("neighborhood", None)
+        self.__dict__.pop("neighborhood", None)  # cached properties are stored in __dict__, see functools.cached_property docs
         self._neighborhood.cache_clear()
         self.connections[key] = other
 
@@ -103,7 +103,7 @@ class Cell:
         self.get_neighborhood.cache_clear()
         self.__dict__.pop(
             "neighborhood", None
-        )  # cached properties are stored in the dic, see functools.cached_property docs
+        )  # cached properties are stored in __dict__, see functools.cached_property docs
         self._neighborhood.cache_clear()
 
     def add_agent(self, agent: CellAgent) -> None:

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -85,7 +85,9 @@ class Cell:
         if key is None:
             key = other.coordinate
         self.get_neighborhood.cache_clear()
-        self.__dict__.pop("neighborhood", None)  # cached properties are stored in __dict__, see functools.cached_property docs
+        self.__dict__.pop(
+            "neighborhood", None
+        )  # cached properties are stored in __dict__, see functools.cached_property docs
         self._neighborhood.cache_clear()
         self.connections[key] = other
 

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -84,12 +84,10 @@ class Cell:
         """
         if key is None:
             key = other.coordinate
-        self.get_neighborhood.cache_clear()
-        self.__dict__.pop(
-            "neighborhood", None
-        )  # cached properties are stored in __dict__, see functools.cached_property docs
-        self._neighborhood.cache_clear()
+        self._clear_cache()
         self.connections[key] = other
+
+
 
     def disconnect(self, other: Cell) -> None:
         """Disconnects this cell from another cell.
@@ -101,12 +99,7 @@ class Cell:
         keys_to_remove = [k for k, v in self.connections.items() if v == other]
         for key in keys_to_remove:
             del self.connections[key]
-
-        self.get_neighborhood.cache_clear()
-        self.__dict__.pop(
-            "neighborhood", None
-        )  # cached properties are stored in __dict__, see functools.cached_property docs
-        self._neighborhood.cache_clear()
+        self._clear_cache()
 
     def add_agent(self, agent: CellAgent) -> None:
         """Adds an agent to the cell.
@@ -221,3 +214,16 @@ class Cell:
             "connections"
         ] = {}  # replace this with empty connections to avoid infinite recursion error in pickle/deepcopy
         return state
+
+    def _clear_cache(self):
+        "Helper function to clear local cache."
+
+        try:
+            self.__dict__.pop(
+                "neighborhood"
+            ) # cached properties are stored in __dict__, see functools.cached_property docs
+        except KeyError:
+            pass  # cache is not set
+        else:
+            self.get_neighborhood.cache_clear()
+            self._neighborhood.cache_clear()

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -87,8 +87,6 @@ class Cell:
         self._clear_cache()
         self.connections[key] = other
 
-
-
     def disconnect(self, other: Cell) -> None:
         """Disconnects this cell from another cell.
 
@@ -216,12 +214,11 @@ class Cell:
         return state
 
     def _clear_cache(self):
-        "Helper function to clear local cache."
-
+        """Helper function to clear local cache."""
         try:
             self.__dict__.pop(
                 "neighborhood"
-            ) # cached properties are stored in __dict__, see functools.cached_property docs
+            )  # cached properties are stored in __dict__, see functools.cached_property docs
         except KeyError:
             pass  # cache is not set
         else:

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -84,7 +84,11 @@ class Cell:
         """
         if key is None:
             key = other.coordinate
+        self.get_neighborhood.cache_clear()
+        self.__dict__.pop("neighborhood", None)
+        self._neighborhood.cache_clear()
         self.connections[key] = other
+
 
     def disconnect(self, other: Cell) -> None:
         """Disconnects this cell from another cell.
@@ -96,6 +100,10 @@ class Cell:
         keys_to_remove = [k for k, v in self.connections.items() if v == other]
         for key in keys_to_remove:
             del self.connections[key]
+
+        self.get_neighborhood.cache_clear()
+        self.__dict__.pop("neighborhood", None)  # cached properties are stored in the dic, see functools.cached_property docs
+        self._neighborhood.cache_clear()
 
     def add_agent(self, agent: CellAgent) -> None:
         """Adds an agent to the cell.

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -92,18 +92,19 @@ class DiscreteSpace(Generic[T]):
             cell: cell to add
 
         """
-        self.all_cells.clear_cache()
+        self.__dict__.pop("all_cells", None)
         self._cells[cell.coordinate] = cell
 
     def remove_cell(self, cell: T):
         """Remove a cell from the space."""
         neighbors = cell.neighborhood
         self._cells.pop(cell.coordinate)
-        self.all_cells.clear_cache()
+        self.__dict__.pop("all_cells", None)
 
         # iterate over all neighbors
         for neighbor in neighbors.cells:
             neighbor.disconnect(cell)
+            cell.disconnect(neighbor)
 
     def add_connection(self, cell1: T, cell2: T):
         """Add a connection between the two cells."""

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -85,6 +85,27 @@ class DiscreteSpace(Generic[T]):
     def _connect_cells(self): ...
     def _connect_single_cell(self, cell: T): ...
 
+    def add_cell(self, cell:T):
+        self.all_cells.clear_cache()
+        self._cells[cell.coordinate] = cell
+
+    def remove_cell(self, cell: T):
+        neighbors = cell.neighborhood
+        self._cells.pop(cell.coordinate, None)
+        self.all_cells.clear_cache()
+
+        # iterate over all neighbors
+        for neighbor in neighbors.cells:
+            neighbor.disconnect(cell)
+
+    def add_connection(self, cell1:T, cell2:T):
+        cell1.connect(cell2)
+        cell2.connect(cell1)
+
+    def remove_connection(self, cell1:T, cell2:T):
+        cell1.connect(cell2)
+        cell2.connect(cell1)
+
     @cached_property
     def all_cells(self):
         """Return all cells in space."""

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -91,12 +91,27 @@ class DiscreteSpace(Generic[T]):
         Args:
             cell: cell to add
 
+        Note:
+            Discrete spaces rely on caching neighborhood relations for speedups. Adding or removing cells and
+            connections at runtime is possible. However, only the caches of cells directly affected will be cleared. So
+            if you rely on getting neighborhoods of cells with a radius higher than 1, these might not be cleared
+            correctly if you are adding or removing cells and connections at runtime.
+
         """
         self.__dict__.pop("all_cells", None)
         self._cells[cell.coordinate] = cell
 
     def remove_cell(self, cell: T):
-        """Remove a cell from the space."""
+        """Remove a cell from the space.
+
+        Note:
+            Discrete spaces rely on caching neighborhood relations for speedups. Adding or removing cells and
+            connections at runtime is possible. However, only the caches of cells directly affected will be cleared. So
+            if you rely on getting neighborhoods of cells with a radius higher than 1, these might not be cleared
+            correctly if you are adding or removing cells and connections at runtime.
+
+
+        """
         neighbors = cell.neighborhood
         self._cells.pop(cell.coordinate)
         self.__dict__.pop("all_cells", None)
@@ -107,12 +122,28 @@ class DiscreteSpace(Generic[T]):
             cell.disconnect(neighbor)
 
     def add_connection(self, cell1: T, cell2: T):
-        """Add a connection between the two cells."""
+        """Add a connection between the two cells.
+
+        Note:
+            Discrete spaces rely on caching neighborhood relations for speedups. Adding or removing cells and
+            connections at runtime is possible. However, only the caches of cells directly affected will be cleared. So
+            if you rely on getting neighborhoods of cells with a radius higher than 1, these might not be cleared
+            correctly if you are adding or removing cells and connections at runtime.
+
+        """
         cell1.connect(cell2)
         cell2.connect(cell1)
 
     def remove_connection(self, cell1: T, cell2: T):
-        """Remove a connection between the two cells."""
+        """Remove a connection between the two cells.
+
+        Note:
+            Discrete spaces rely on caching neighborhood relations for speedups. Adding or removing cells and
+            connections at runtime is possible. However, only the caches of cells directly affected will be cleared. So
+            if you rely on getting neighborhoods of cells with a radius higher than 1, these might not be cleared
+            correctly if you are adding or removing cells and connections at runtime.
+
+        """
         cell1.disconnect(cell2)
         cell2.disconnect(cell1)
 

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -112,8 +112,8 @@ class DiscreteSpace(Generic[T]):
 
     def remove_connection(self, cell1: T, cell2: T):
         """Remove a connection between the two cells."""
-        cell1.connect(cell2)
-        cell2.connect(cell1)
+        cell1.disconnect(cell2)
+        cell2.disconnect(cell1)
 
     @cached_property
     def all_cells(self):

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -97,7 +97,6 @@ class DiscreteSpace(Generic[T]):
 
     def remove_cell(self, cell: T):
         """Remove a cell from the space."""
-
         neighbors = cell.neighborhood
         self._cells.pop(cell.coordinate)
         self.all_cells.clear_cache()
@@ -107,12 +106,12 @@ class DiscreteSpace(Generic[T]):
             neighbor.disconnect(cell)
 
     def add_connection(self, cell1: T, cell2: T):
-        """add a connection between the two cells."""
+        """Add a connection between the two cells."""
         cell1.connect(cell2)
         cell2.connect(cell1)
 
     def remove_connection(self, cell1: T, cell2: T):
-        """remove a connection between the two cells."""
+        """Remove a connection between the two cells."""
         cell1.connect(cell2)
         cell2.connect(cell1)
 

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -86,12 +86,20 @@ class DiscreteSpace(Generic[T]):
     def _connect_single_cell(self, cell: T): ...
 
     def add_cell(self, cell: T):
+        """Add a cell to the space.
+
+        Args:
+            cell: cell to add
+
+        """
         self.all_cells.clear_cache()
         self._cells[cell.coordinate] = cell
 
     def remove_cell(self, cell: T):
+        """Remove a cell from the space."""
+
         neighbors = cell.neighborhood
-        self._cells.pop(cell.coordinate, None)
+        self._cells.pop(cell.coordinate)
         self.all_cells.clear_cache()
 
         # iterate over all neighbors
@@ -99,10 +107,12 @@ class DiscreteSpace(Generic[T]):
             neighbor.disconnect(cell)
 
     def add_connection(self, cell1: T, cell2: T):
+        """add a connection between the two cells."""
         cell1.connect(cell2)
         cell2.connect(cell1)
 
     def remove_connection(self, cell1: T, cell2: T):
+        """remove a connection between the two cells."""
         cell1.connect(cell2)
         cell2.connect(cell1)
 

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -85,7 +85,7 @@ class DiscreteSpace(Generic[T]):
     def _connect_cells(self): ...
     def _connect_single_cell(self, cell: T): ...
 
-    def add_cell(self, cell:T):
+    def add_cell(self, cell: T):
         self.all_cells.clear_cache()
         self._cells[cell.coordinate] = cell
 
@@ -98,11 +98,11 @@ class DiscreteSpace(Generic[T]):
         for neighbor in neighbors.cells:
             neighbor.disconnect(cell)
 
-    def add_connection(self, cell1:T, cell2:T):
+    def add_connection(self, cell1: T, cell2: T):
         cell1.connect(cell2)
         cell2.connect(cell1)
 
-    def remove_connection(self, cell1:T, cell2:T):
+    def remove_connection(self, cell1: T, cell2: T):
         cell1.connect(cell2)
         cell2.connect(cell1)
 

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -56,8 +56,7 @@ class Network(DiscreteSpace[Cell]):
         for node_id in self.G.neighbors(cell.coordinate):
             cell.connect(self._cells[node_id], node_id)
 
-
-    def add_cell(self, cell:Cell):
+    def add_cell(self, cell: Cell):
         super().add_cell(cell)
         self.G.add_node(cell.coordinate)
 
@@ -65,10 +64,10 @@ class Network(DiscreteSpace[Cell]):
         super().remove_cell(cell)
         self.G.remove_node(cell.coordinate)
 
-    def add_connection(self, cell1:Cell, cell2:Cell):
+    def add_connection(self, cell1: Cell, cell2: Cell):
         super().add_connection(cell1, cell2)
         self.G.add_edge(cell1.coordinate, cell2.coordinate)
 
-    def remove_connection(self, cell1:Cell, cell2:Cell):
+    def remove_connection(self, cell1: Cell, cell2: Cell):
         super().remove_connection(cell1, cell2)
         self.G.remove_edge(cell1.coordinate, cell2.coordinate)

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -56,26 +56,22 @@ class Network(DiscreteSpace[Cell]):
         for node_id in self.G.neighbors(cell.coordinate):
             cell.connect(self._cells[node_id], node_id)
 
-
-    def add_cell(self, cell:Cell):
+    def add_cell(self, cell: Cell):
         """Add a cell to the space."""
         super().add_cell(cell)
         self.G.add_node(cell.coordinate)
-
 
     def remove_cell(self, cell: Cell):
         """Remove a cell from the space."""
         super().remove_cell(cell)
         self.G.remove_node(cell.coordinate)
 
-
-    def add_connection(self, cell1:Cell, cell2:Cell):
-        """add a connection between the two cells."""
+    def add_connection(self, cell1: Cell, cell2: Cell):
+        """Add a connection between the two cells."""
         super().add_connection(cell1, cell2)
         self.G.add_edge(cell1.coordinate, cell2.coordinate)
 
-
-    def remove_connection(self, cell1:Cell, cell2:Cell):
-        """remove a connection between the two cells."""
+    def remove_connection(self, cell1: Cell, cell2: Cell):
+        """Remove a connection between the two cells."""
         super().remove_connection(cell1, cell2)
         self.G.remove_edge(cell1.coordinate, cell2.coordinate)

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -55,3 +55,20 @@ class Network(DiscreteSpace[Cell]):
     def _connect_single_cell(self, cell: Cell):
         for node_id in self.G.neighbors(cell.coordinate):
             cell.connect(self._cells[node_id], node_id)
+
+
+    def add_cell(self, cell:Cell):
+        super().add_cell(cell)
+        self.G.add_node(cell.coordinate)
+
+    def remove_cell(self, cell: Cell):
+        super().remove_cell(cell)
+        self.G.remove_node(cell.coordinate)
+
+    def add_connection(self, cell1:Cell, cell2:Cell):
+        super().add_connection(cell1, cell2)
+        self.G.add_edge(cell1.coordinate, cell2.coordinate)
+
+    def remove_connection(self, cell1:Cell, cell2:Cell):
+        super().remove_connection(cell1, cell2)
+        self.G.remove_edge(cell1.coordinate, cell2.coordinate)

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -56,18 +56,26 @@ class Network(DiscreteSpace[Cell]):
         for node_id in self.G.neighbors(cell.coordinate):
             cell.connect(self._cells[node_id], node_id)
 
-    def add_cell(self, cell: Cell):
+
+    def add_cell(self, cell:Cell):
+        """Add a cell to the space."""
         super().add_cell(cell)
         self.G.add_node(cell.coordinate)
 
+
     def remove_cell(self, cell: Cell):
+        """Remove a cell from the space."""
         super().remove_cell(cell)
         self.G.remove_node(cell.coordinate)
 
-    def add_connection(self, cell1: Cell, cell2: Cell):
+
+    def add_connection(self, cell1:Cell, cell2:Cell):
+        """add a connection between the two cells."""
         super().add_connection(cell1, cell2)
         self.G.add_edge(cell1.coordinate, cell2.coordinate)
 
-    def remove_connection(self, cell1: Cell, cell2: Cell):
+
+    def remove_connection(self, cell1:Cell, cell2:Cell):
+        """remove a connection between the two cells."""
         super().remove_connection(cell1, cell2)
         self.G.remove_edge(cell1.coordinate, cell2.coordinate)

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -315,6 +315,38 @@ def test_orthogonal_grid_moore_1d():
         assert connection.coordinate in {(1,), (9,)}
 
 
+def test_dynamic_modifications_to_space():
+    grid = OrthogonalMooreGrid((5,5), torus=False, capacity=1, random=random.Random(42))
+
+    cells = grid._cells
+
+    # test remove_connection
+    cell1 = cells[(2, 0)]
+    cell2 = cells[(3, 0)]
+    grid.remove_connection(cell1, cell2)
+
+    assert cell2 not in cell1.neighborhood
+    assert cell1 not in cell2.neighborhood
+
+    # test add connection
+    grid.add_connection(cell1, cell2)
+    assert cell1 in cell2.neighborhood
+    assert cell2 in cell1.neighborhood
+
+    # test remove cell
+    neigbors = cell1.neighborhood
+    grid.remove_cell(cell1)
+    for neighbor in neigbors:
+        assert cell1 not in neighbor.neighborhood
+
+    # test add_cells
+    grid.add_cell(cell1)
+    for neighbor in neigbors:
+        grid.add_connection(cell1, neighbor)
+
+    for neighbor in neigbors:
+        assert cell1 in neighbor.neighborhood
+
 def test_cell_neighborhood():
     """Test neighborhood method of cell in different GridSpaces."""
     # orthogonal grid
@@ -450,6 +482,17 @@ def test_networkgrid():
     import pickle
 
     pickle.loads(pickle.dumps(grid))  # noqa: S301
+
+
+    cell = Cell(10)  # n = 10, so 10 + 1
+    grid.add_cell(cell)
+    grid.add_connection(cell, grid._cells[0])
+    assert cell in grid._cells[0].neighborhood
+    assert grid._cells[0] in cell.neighborhood
+
+    grid.remove_cell(cell)
+    assert cell not in grid._cells[0].neighborhood
+    assert grid._cells[0] not in cell.neighborhood
 
 
 def test_voronoigrid():

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -316,7 +316,9 @@ def test_orthogonal_grid_moore_1d():
 
 
 def test_dynamic_modifications_to_space():
-    grid = OrthogonalMooreGrid((5,5), torus=False, capacity=1, random=random.Random(42))
+    grid = OrthogonalMooreGrid(
+        (5, 5), torus=False, capacity=1, random=random.Random(42)
+    )
 
     cells = grid._cells
 
@@ -346,6 +348,7 @@ def test_dynamic_modifications_to_space():
 
     for neighbor in neigbors:
         assert cell1 in neighbor.neighborhood
+
 
 def test_cell_neighborhood():
     """Test neighborhood method of cell in different GridSpaces."""
@@ -482,7 +485,6 @@ def test_networkgrid():
     import pickle
 
     pickle.loads(pickle.dumps(grid))  # noqa: S301
-
 
     cell = Cell(10)  # n = 10, so 10 + 1
     grid.add_cell(cell)

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -337,17 +337,17 @@ def test_dynamic_modifications_to_space():
     assert cell2 in cell1.neighborhood
 
     # test remove cell
-    neigbors = cell1.neighborhood
+    neighbors = cell1.neighborhood
     grid.remove_cell(cell1)
-    for neighbor in neigbors:
+    for neighbor in neighbors:
         assert cell1 not in neighbor.neighborhood
 
     # test add_cells
     grid.add_cell(cell1)
-    for neighbor in neigbors:
+    for neighbor in neighbors:
         grid.add_connection(cell1, neighbor)
 
-    for neighbor in neigbors:
+    for neighbor in neighbors:
         assert cell1 in neighbor.neighborhood
 
 

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -316,9 +316,11 @@ def test_orthogonal_grid_moore_1d():
 
 
 def test_dynamic_modifications_to_space():
+    """Test dynamic modifications to DiscreteSpace."""
     grid = OrthogonalMooreGrid(
         (5, 5), torus=False, capacity=1, random=random.Random(42)
     )
+
 
     cells = grid._cells
 

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -497,11 +497,10 @@ def test_networkgrid():
     assert cell not in grid._cells[0].neighborhood
     assert grid._cells[0] not in cell.neighborhood
 
-
     cell = Cell(10)  # n = 10, so 10 + 1
     grid.add_cell(cell)
     grid.add_connection(cell, grid._cells[0])
-    grid.remove_cell(cell) # this also removes all connections
+    grid.remove_cell(cell)  # this also removes all connections
     assert cell not in grid._cells[0].neighborhood
     assert grid._cells[0] not in cell.neighborhood
 

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -321,7 +321,6 @@ def test_dynamic_modifications_to_space():
         (5, 5), torus=False, capacity=1, random=random.Random(42)
     )
 
-
     cells = grid._cells
 
     # test remove_connection

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -493,7 +493,15 @@ def test_networkgrid():
     assert cell in grid._cells[0].neighborhood
     assert grid._cells[0] in cell.neighborhood
 
-    grid.remove_cell(cell)
+    grid.remove_connection(cell, grid._cells[0])
+    assert cell not in grid._cells[0].neighborhood
+    assert grid._cells[0] not in cell.neighborhood
+
+
+    cell = Cell(10)  # n = 10, so 10 + 1
+    grid.add_cell(cell)
+    grid.add_connection(cell, grid._cells[0])
+    grid.remove_cell(cell) # this also removes all connections
     assert cell not in grid._cells[0].neighborhood
     assert grid._cells[0] not in cell.neighborhood
 


### PR DESCRIPTION
Currently, all `DiscreteSpace` subclasses rely on `@cache` and `@cached_property` for neighborhood-related functionality. This is critical for performance. However, if you want to represent a dynamically changing discrete space (e.g., a dynamic network), this is currently not possible. See ##2754 for more details

# API
This PR adds explicit support for changing discrete spaces during the simulation. It adds 4 new methods to `DiscreteSpace` which means these are available to all subclasses. These methods are `add_cell`, `remove_cell`, `add_connection`, `remove_connection`. With these, you can make any modification to a discrete space that you want. For example, it allows you to dynamically change a network or impose a barrier in an orthogonal grid by removing connections between specific cells. 

# Implementation details
This adds support for adding and removing cells and connections to discrete spaces. The critical issue is that discrete spaces relies on caching neighborhoods for substantial performance gains. `Cell` already has a `connect` and `disconnect` method, so clearing the relevant cell caches is placed here. The new methods (`add_cell`, `remove_cell`, `add_connection`, `remove_connection`) are added to `DiscreteSpace`, and the relevant cache (`all_cells`) is cleared here as well. 

The clearing of caches on `connect` and `disconnect` adds some additional overhead when constructing a discrete space. It might be possible to reduce this overhead by checking if the cache is already active (long story short, this can be done by checking if `self.__dict__["name of cached property"]` exists, but this adds code complexity). 
  