### PR TITLE
Bugfix ModelCreator for required model parameters and user adjusted model parameters

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -606,9 +606,7 @@ def _check_model_params(init_func, model_params):
             and name != "self"
             and name != "kwargs"
         ):
-            raise ValueError(
-                f"Missing required model parameter: {name} - model_parameter {model_parameters} model_params {model_params}"
-            )
+            raise ValueError(f"Missing required model parameter: {name}")
     for name in model_params:
         if name not in model_parameters and "kwargs" not in model_parameters:
             raise ValueError(f"Invalid model parameter: {name}")

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -553,10 +553,10 @@ def ModelCreator(
     model_parameters = solara.use_reactive(model_parameters)
 
     solara.use_effect(
-        lambda: _check_model_params(model.value.__class__.__init__, fixed_params),
+        lambda: _check_model_params(model.value.__class__.__init__, user_params),
         [model.value],
     )
-    user_params, fixed_params = split_model_params(user_params)
+    user_adjust_params, fixed_params = split_model_params(user_params)
 
     # Use solara.use_effect to run the initialization code only once
     solara.use_effect(
@@ -564,7 +564,7 @@ def ModelCreator(
         lambda: model_parameters.set(
             {
                 **fixed_params,
-                **{k: v.get("value") for k, v in user_params.items()},
+                **{k: v.get("value") for k, v in user_adjust_params.items()},
             }
         ),
         [],
@@ -574,7 +574,7 @@ def ModelCreator(
     def on_change(name, value):
         model_parameters.value = {**model_parameters.value, name: value}
 
-    UserInputs(user_params, on_change=on_change)
+    UserInputs(user_adjust_params, on_change=on_change)
 
 
 def _check_model_params(init_func, model_params):
@@ -606,7 +606,9 @@ def _check_model_params(init_func, model_params):
             and name != "self"
             and name != "kwargs"
         ):
-            raise ValueError(f"Missing required model parameter: {name}")
+            raise ValueError(
+                f"Missing required model parameter: {name} - model_parameter {model_parameters} model_params {model_params}"
+            )
     for name in model_params:
         if name not in model_parameters and "kwargs" not in model_parameters:
             raise ValueError(f"Invalid model parameter: {name}")

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -13,6 +13,7 @@ from mesa.space import MultiGrid, PropertyLayer
 from mesa.visualization.components.altair_components import make_altair_space
 from mesa.visualization.components.matplotlib_components import make_mpl_space_component
 from mesa.visualization.solara_viz import (
+    ModelCreator,
     Slider,
     SolaraViz,
     UserInputs,
@@ -271,6 +272,36 @@ def test_model_param_checks():
     # Test empty params dict raises ValueError if required params
     with pytest.raises(ValueError, match="Missing required model parameter"):
         _check_model_params(ModelWithOnlyRequired.__init__, {})
+
+
+def test_model_creator():  # noqa: D103
+    class ModelWithRequiredParam:
+        def __init__(self, param1):
+            pass
+
+    solara.render(
+        ModelCreator(
+            solara.reactive(ModelWithRequiredParam(param1="mock")),
+            user_params={"param1": 1},
+        ),
+        handle_error=False,
+    )
+
+    solara.render(
+        ModelCreator(
+            solara.reactive(ModelWithRequiredParam(param1="mock")),
+            user_params={"param1": Slider("Param1", 10, 10, 100, 1)},
+        ),
+        handle_error=False,
+    )
+
+    with pytest.raises(ValueError, match="Missing required model parameter"):
+        solara.render(
+            ModelCreator(
+                solara.reactive(ModelWithRequiredParam(param1="mock")), user_params={}
+            ),
+            handle_error=False,
+        )
 
 
 # test that _check_model_params raises ValueError when *args are present


### PR DESCRIPTION
### Summary
For models with required parameters, providing a user input in `model_params` (passed to `SolarViz()`) still raises a `ValueError: Missing required model parameter`. Passing `user_params` instead of `fixed_params` to `_check_model_params` resolves the issue.

### Bug / Issue
Because model params are only checked for `fixed_params`, user adjusted parameters are not considered and mistakenly considered as missing.

### Implementation
* pass `user_params` instead of `fixed_params` to `_check_model_params`
* rename `user_params` as return from `split_model_params` to `user_adjust_params`

### Testing
see tests/test_solara_viz.py::test_model_creator()