### PR TITLE
Remove unneeded int cast

### DIFF
--- a/mesa/experimental/continuous_space/continuous_space.py
+++ b/mesa/experimental/continuous_space/continuous_space.py
@@ -117,7 +117,7 @@ class ContinuousSpace:
         if self._agent_positions.shape[0] <= index:
             # we are out of space
             fraction = 0.2  # we add 20%  Fixme
-            n = int(round(fraction * self._n_agents))
+            n = round(fraction * self._n_agents, None)
             self._agent_positions = np.vstack(
                 [
                     self._agent_positions,


### PR DESCRIPTION
### Summary
<!-- Provide a brief summary of the bug and its impact. -->

`round()` implicitely returned an int, which was later cast to an int again. This can be avoided.

### Bug / Issue
<!-- Link to the related issue(s) and describe the bug. Include details like the context, what was expected, and what actually happened. -->

### Implementation
<!-- Describe the changes made to resolve the issue. Highlight any important parts of the code that were modified. -->

I've removed the call to `int()` and gave a second argument of `None` to `round()` so it explicitly returns an int.

### Testing
<!-- Detail the testing performed to verify the fix. Include information on test cases, steps taken, and any relevant results. -->

This makes Ruff happy again, as it was failing because of the double int cast.


### Additional Notes
<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work.
