### PR TITLE
Fix broken docs link - Fix issue 2792

### DIFF
--- a/docs/apis/visualization.md
+++ b/docs/apis/visualization.md
@@ -1,6 +1,11 @@
 # Visualization
 
-For a detailed tutorial, please refer to our [Visualization Tutorial](../tutorials/visualization_tutorial.ipynb).
+For detailed tutorials, please refer to:
+
+- [Basic Visualization](../tutorials/4_visualization_basic)
+- [Dynamic Agent Visualization](../tutorials/5_visualization_dynamic_agents)
+- [Custom Agent Visualization](../tutorials/6_visualization_custom)
+
 
 ## Jupyter Visualization
 


### PR DESCRIPTION
Replaces broken link with links to 3 visualization tutorials

Closes https://github.com/projectmesa/mesa/issues/2792

### Summary

Broken link from https://mesa.readthedocs.io/latest/apis/visualization.html produces slight confusion 

### Bug / Issue

https://github.com/projectmesa/mesa/issues/2792

Link to ../tutorials/visualization_tutorial.ipynb goes nowhere

### Implementation

Replaced with links to the three visualization tutorial notebooks that currently exist

### Testing

Ran `make html` locally, served docs locally, confirmed that the new links work 

### Additional Notes