### PR TITLE
fix : prevent breakdown when citizen_density (Initial Agent Density s…

### DIFF
--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -51,7 +51,7 @@ model_params = {
     },
     "height": 40,
     "width": 40,
-    "citizen_density": Slider("Initial Agent Density", 0.7, 0.0, 0.9, 0.1),
+    "citizen_density": Slider("Initial Agent Density", 0.7, 0.1, 0.9, 0.1),
     "cop_density": Slider("Initial Cop Density", 0.04, 0.0, 0.1, 0.01),
     "citizen_vision": Slider("Citizen Vision", 7, 1, 10, 1),
     "cop_vision": Slider("Cop Vision", 7, 1, 10, 1),


### PR DESCRIPTION
# 🐛 Bug fix

Noticed tiny bug on civil violence : the model breaks down when citizen_density (Initial Agent Density slider) is set to 0.
Fix is : model density starts now at 0.1

