### PR TITLE
Add Altair plotting functionality

### DIFF
--- a/mesa/visualization/backends/altair_backend.py
+++ b/mesa/visualization/backends/altair_backend.py
@@ -432,9 +432,7 @@ class AltairBackend(AbstractRenderer):
                         y=alt.Y("y:O", axis=None),
                         fill=alt.Fill("color_str:N", scale=None),
                     )
-                    .properties(
-                        width=chart_width, height=chart_height, title=layer_name
-                    )
+                    .properties(width=chart_width, height=chart_height)
                 )
                 base = (
                     alt.layer(current_chart, base)

--- a/mesa/visualization/components/__init__.py
+++ b/mesa/visualization/components/__init__.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from .altair_components import SpaceAltair, make_altair_space
+from .altair_components import (
+    SpaceAltair,
+    make_altair_plot_component,
+    make_altair_space,
+)
 from .matplotlib_components import (
     SpaceMatplotlib,
     make_mpl_plot_component,
@@ -80,16 +84,13 @@ def make_plot_component(
         backend: the backend to use {"matplotlib", "altair"}
         plot_drawing_kwargs: additional keyword arguments to pass onto the backend specific function for making a plotting component
 
-    Notes:
-        altair plotting backend is not yet implemented and planned for mesa 3.1.
-
     Returns:
         function: A function that creates a plot component
     """
     if backend == "matplotlib":
         return make_mpl_plot_component(measure, post_process, **plot_drawing_kwargs)
     elif backend == "altair":
-        raise NotImplementedError("altair line plots are not yet implemented")
+        return make_altair_plot_component(measure, post_process, **plot_drawing_kwargs)
     else:
         raise ValueError(
             f"unknown backend {backend}, must be one of matplotlib, altair"

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -142,7 +142,7 @@ def SolaraViz(
     if renderer is not None:
         if isinstance(renderer, SpaceRenderer):
             renderer = solara.use_reactive(renderer)  # noqa: RUF100  # noqa: SH102
-        display_components.append(create_space_component(renderer.value))
+        display_components.insert(0, create_space_component(renderer.value))
 
     with solara.AppBar():
         solara.AppBarTitle(name if name else model.value.__class__.__name__)

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -297,7 +297,7 @@ def SpaceRendererComponent(
     else:
         structure = renderer.space_mesh if renderer.space_mesh else None
         agents = renderer.agent_mesh if renderer.agent_mesh else None
-        prop_base, prop_cbar = renderer.propertylayer_mesh or (None, None)
+        propertylayer = renderer.propertylayer_mesh or None
 
         if renderer.space_mesh:
             structure = renderer.draw_structure(**renderer.space_kwargs)
@@ -306,33 +306,21 @@ def SpaceRendererComponent(
                 renderer.agent_portrayal, **renderer.agent_kwargs
             )
         if renderer.propertylayer_mesh:
-            prop_base, prop_cbar = renderer.draw_propertylayer(
+            propertylayer = renderer.draw_propertylayer(
                 renderer.propertylayer_portrayal
             )
 
         spatial_charts_list = [
-            chart for chart in [structure, prop_base, agents] if chart
+            chart for chart in [structure, propertylayer, agents] if chart
         ]
 
-        main_spatial = None
+        final_chart = None
         if spatial_charts_list:
-            main_spatial = (
+            final_chart = (
                 spatial_charts_list[0]
                 if len(spatial_charts_list) == 1
                 else alt.layer(*spatial_charts_list)
             )
-
-        # Determine final chart by combining with color bar if present
-        final_chart = None
-        if main_spatial and prop_cbar:
-            final_chart = alt.vconcat(main_spatial, prop_cbar).configure_view(
-                stroke=None
-            )
-        elif main_spatial:  # Only main_spatial, no prop_cbar
-            final_chart = main_spatial
-        elif prop_cbar:  # Only prop_cbar, no main_spatial
-            final_chart = prop_cbar
-            final_chart = final_chart.configure_view(grid=False)
 
         if final_chart is None:
             # If no charts are available, return an empty chart

--- a/mesa/visualization/space_renderer.py
+++ b/mesa/visualization/space_renderer.py
@@ -309,6 +309,7 @@ class SpaceRenderer:
             self.draw_propertylayer(propertylayer_portrayal)
 
         self.post_process_func = post_process
+        return self
 
     @property
     def canvas(self):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -271,8 +271,7 @@ def test_altair_backend_draw_propertylayer():
     result = ab.draw_propertylayer(
         space, space._mesa_property_layers, propertylayer_portrayal_color
     )
-    assert result[0] is not None
-    assert result[1] is None
+    assert result is not None
 
     # Test with colormap
     def propertylayer_portrayal_colormap(layer):
@@ -283,7 +282,7 @@ def test_altair_backend_draw_propertylayer():
     result = ab.draw_propertylayer(
         space, space._mesa_property_layers, propertylayer_portrayal_colormap
     )
-    assert result[0] is not None
+    assert result is not None
 
     # Test with no color or colormap
     def propertylayer_portrayal(layer):


### PR DESCRIPTION
### Summary
Adds the functionality to make plots using altair.

### Motive
Part of my GSoC commitment.

### Implementation
Following the design of matplotlib plotting function, a `make_altair_plot_component` function is made that returns a callable solara component `PlotAltair`.
Additional kwarg is `grid: bool`, used to draw grid on the plot, default is False.

### Usage Examples
```python
plot_component = make_plot_component(
    {"plot1": "green", "plot2": "blue"}, 
    backend="altair", 
    post_process=post_process_line,
    grid=True
)

page = SolaraViz(
    model,
    components=[plot_component],
    ...
)
```

How it looks:

![image](https://github.com/user-attachments/assets/2a466d16-e301-4fbf-a10f-b332ae37c9c3)

