### PR TITLE
Fix: Grid not showing in altair if both draw_structure and draw_agnets are called.

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -319,7 +319,9 @@ def SpaceRendererComponent(
             final_chart = (
                 spatial_charts_list[0]
                 if len(spatial_charts_list) == 1
-                else alt.layer(*spatial_charts_list)
+                else alt.layer(*spatial_charts_list).resolve_axis(
+                    x="independent", y="independent"
+                )
             )
 
         if final_chart is None:


### PR DESCRIPTION
### Summary
If both `draw_structure` and `draw_agnets` are called in altair backend, the grid won't show because the axis are overridden when layering the two charts.

### Implementation
Resolved the axis for both x and y to independent to prevent overriding of axis because of charts.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the display of layered spatial charts by setting their axes to be independent, enhancing clarity when viewing multiple chart layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->