### PR TITLE
Allowing color mapping to integers in AgentPortrayalStyle

### DIFF
--- a/mesa/visualization/backends/matplotlib_backend.py
+++ b/mesa/visualization/backends/matplotlib_backend.py
@@ -142,8 +142,6 @@ class MatplotlibBackend(AbstractRenderer):
             else:
                 aps = portray_input
                 # Set defaults if not provided
-                if aps.edgecolors is None:
-                    aps.edgecolors = aps.color
                 if aps.x is None and aps.y is None:
                     aps.x, aps.y = self._get_agent_pos(agent, space)
 

--- a/mesa/visualization/components/portrayal_components.py
+++ b/mesa/visualization/components/portrayal_components.py
@@ -46,7 +46,7 @@ class AgentPortrayalStyle:
 
     x: float | None = None
     y: float | None = None
-    color: str | tuple | None = "tab:blue"
+    color: str | tuple | int | float | None = "tab:blue"
     marker: str | None = "o"
     size: int | float | None = 50
     zorder: int | None = 1


### PR DESCRIPTION
### Summary
Allowing color mapping to integers in AgentPortrayalStyle

### Motive
This could only be achieved in the `dict` version of `agent_portrayal`, but also now possible in `AgentPortrayalStyle`.

### Implementation
Main problem was the collect_agent_data function in matplotlib used to assume the color of edgecolors as the defined color if edgecolors are not defined, this removes this assumption and allows the mapping of color with a proper colormap.

### Usage Examples
Boltzman wealth model works with this:
```python
def agent_portrayal(agent):
    color = agent.wealth  # we are using a colormap to translate wealth to color
    return AgentPortrayalStyle(color=color)

def post_process(ax):
    ax.get_figure().colorbar(ax.collections[0], label="wealth", ax=ax)

# Create initial model instance
model = BoltzmannWealth(50, 10, 10)
renderer = SpaceRenderer(model, backend="matplotlib")

renderer.draw_structure()
renderer.draw_agents(agent_portrayal=agent_portrayal, cmap="viridis", vmin=0, vmax=10)
renderer.post_process = post_process

page = SolaraViz(
    model,
    renderer,
    components=[GiniPlot],
    model_params=model_params,
    name="Boltzmann Wealth Model",
)
page

```
