### PR TITLE
Fix issue #2812

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -1571,7 +1571,10 @@ class NetworkGrid:
             )
             if not include_center:
                 del neighbors_with_distance[node_id]
-            neighborhood = sorted(neighbors_with_distance.keys())
+            neighbors_with_distance = sorted(
+                neighbors_with_distance.items(), key=lambda item: item[1]
+            )
+            neighborhood = [node_id for node_id, _ in neighbors_with_distance]
         return neighborhood
 
     def get_neighbors(


### PR DESCRIPTION
### Summary
`get_neighborhood` function in the `NetworkGrid` now returns node ids sorted by the distance from the source node.

### Bug / Issue
Fixes [this](https://github.com/projectmesa/mesa/issues/2812#issuecomment-3117510964). Before this changes mentioned function was returning node_ids sorted by its values, and not the distance.

### Implementation
Dictionary returned by the NetworkX's `single_source_shortest_path_length` is sorted by the value of the items, and then the node_ids are returned. 

### Testing
I have run exsisting tests
