### PR TITLE
feat: Add tooltip to Altair agent portrayal (#2795)

### DIFF
--- a/mesa/examples/basic/boltzmann_wealth_model/app.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app.py
@@ -14,8 +14,9 @@ log_to_stderr(INFO)
 
 def agent_portrayal(agent):
     return AgentPortrayalStyle(
-        color=agent.wealth
-    )  # we are using a colormap to translate wealth to color
+        color=agent.wealth,
+        tooltip={"Agent ID": agent.unique_id, "Wealth": agent.wealth},
+    )
 
 
 model_params = {
@@ -37,23 +38,6 @@ model_params = {
 }
 
 
-def post_process(chart):
-    """Post-process the Altair chart to add a colorbar legend."""
-    chart = chart.encode(
-        color=alt.Color(
-            "color:N",
-            scale=alt.Scale(scheme="viridis", domain=[0, 10]),
-            legend=alt.Legend(
-                title="Wealth",
-                orient="right",
-                type="gradient",
-                gradientLength=200,
-            ),
-        ),
-    )
-    return chart
-
-
 model = BoltzmannWealth(50, 10, 10)
 
 # The SpaceRenderer is responsible for drawing the model's space and agents.
@@ -63,11 +47,13 @@ model = BoltzmannWealth(50, 10, 10)
 renderer = SpaceRenderer(model, backend="altair")
 # Can customize the grid appearance.
 renderer.draw_structure(grid_color="black", grid_dash=[6, 2], grid_opacity=0.3)
-renderer.draw_agents(agent_portrayal=agent_portrayal, cmap="viridis", vmin=0, vmax=10)
-
-# The post_process function is used to modify the Altair chart after it has been created.
-# It can be used to add legends, colorbars, or other visual elements.
-renderer.post_process = post_process
+renderer.draw_agents(
+    agent_portrayal=agent_portrayal,
+    cmap="viridis",
+    vmin=0,
+    vmax=10,
+    legend_title="Wealth",
+)
 
 # Creates a line plot component from the model's "Gini" datacollector.
 GiniPlot = make_plot_component("Gini")

--- a/mesa/visualization/components/portrayal_components.py
+++ b/mesa/visualization/components/portrayal_components.py
@@ -55,6 +55,7 @@ class AgentPortrayalStyle:
     alpha: float | None = 1.0
     edgecolors: str | tuple | None = None
     linewidths: float | int | None = 1.0
+    tooltip: dict | None = None
 
     def update(self, *updates_fields: tuple[str, Any]):
         """Updates attributes from variable (field_name, new_value) tuple arguments.
@@ -91,7 +92,7 @@ class PropertyLayerStyle:
     (vmin, vmax), transparency (alpha) and colorbar visibility.
 
     Note: vmin and vmax are the lower and upper bounds for the colorbar and the data is
-    normalized between these values for color/colormap rendering. If they are not
+    normalized between these values for color/colorbar rendering. If they are not
     declared the values are automatically determined from the data range.
 
     Note: You can specify either a 'colormap' (for varying data) or a single


### PR DESCRIPTION


### Summary
This PR adds a `tooltip` attribute to `AgentPortrayalStyle`, enabling agent-specific information to be displayed on hover in Altair-based visualizations.

### Motive
This feature resolves issue #2795, which requested an easy way to display agent information (like health, status, etc.) directly in the visualization. It is highly useful for debugging and for closely following the state of specific agents during a simulation.

### Implementation
The implementation consists of two main changes:
1.  `AgentPortrayalStyle` in `portrayal_components.py` was extended to include a `tooltip: dict | None = None` attribute.
2.  The `collect_agent_data` and `draw_agents` methods in `altair_backend.py` were updated to process this new `tooltip` data. The backend now correctly creates a Pandas DataFrame with the tooltip columns and adds them to the Altair chart's `tooltip` encoding channel.

### Usage Examples
Users can now pass a dictionary to the `tooltip` attribute within their `agent_portrayal` function.

```python
def agent_portrayal(agent):
    return AgentPortrayalStyle(
        color=agent.wealth,
        tooltip={"Agent ID": agent.unique_id, "Wealth": agent.wealth},
    )
```

This provides a much richer user experience for inspecting agents.

#### Before:
Hovering over an agent only displayed basic coordinate information.
<img width="1919" height="853" alt="Screenshot 2025-10-04 165951" src="https://github.com/user-attachments/assets/5e422df4-acce-402d-9faa-7a992d1a0283" />


#### After:
Hovering over an agent now displays the custom information defined in the `tooltip` dictionary.
<img width="1919" height="877" alt="Screenshot 2025-10-04 165212" src="https://github.com/user-attachments/assets/ae4577b2-958c-4002-9846-5fd984d86fe4" />



### Additional Notes
As discussed in the original issue, this implementation is specific to the Altair backend. A similar feature for the Matplotlib backend is not feasible in an elegant way at this time.
```


