### PR TITLE
Drop Python 3.11, require Python 3.12+ and update to modern type parameter syntax

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -35,8 +35,6 @@ jobs:
         include:
           - os: ubuntu
             python-version: "3.12"
-          - os: ubuntu
-            python-version: "3.11"
           # Disabled for now. See https://github.com/projectmesa/mesa/issues/1253
           #- os: ubuntu
           #  python-version: 'pypy-3.8'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.20.0
     hooks:
     -   id: pyupgrade
-        args: [--py311-plus]
+        args: [--py312-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0  # Use the ref you want to point at
     hooks:

--- a/docs/tutorials/0_first_model.ipynb
+++ b/docs/tutorials/0_first_model.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "### Tutorial Setup\n",
     "\n",
-    "Create and activate a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/). *Python version 3.11 or higher is required*.\n",
+    "Create and activate a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/). *Python version 3.12 or higher is required*.\n",
     "\n",
     "Install Mesa:\n",
     "\n",

--- a/mesa/discrete_space/cell_collection.py
+++ b/mesa/discrete_space/cell_collection.py
@@ -20,7 +20,7 @@ import warnings
 from collections.abc import Callable, Iterable, Mapping
 from functools import cached_property
 from random import Random
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     from mesa.discrete_space.cell import Cell
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="Cell")
 
 
-class CellCollection(Generic[T]):
+class CellCollection[T: Cell]:
     """An immutable collection of cells.
 
     Attributes:

--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import warnings
 from functools import cached_property
 from random import Random
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 from mesa.agent import AgentSet
 from mesa.discrete_space.cell import Cell
@@ -27,7 +27,7 @@ from mesa.discrete_space.cell_collection import CellCollection
 T = TypeVar("T", bound=Cell)
 
 
-class DiscreteSpace(Generic[T]):
+class DiscreteSpace[T: Cell]:
     """Base class for all discrete spaces.
 
     Attributes:

--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -17,7 +17,7 @@ import copyreg
 from collections.abc import Sequence
 from itertools import product
 from random import Random
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from mesa.discrete_space import Cell, DiscreteSpace
 from mesa.discrete_space.property_layer import (
@@ -56,7 +56,7 @@ def unpickle_gridcell(parent, fields):
     return instance
 
 
-class Grid(DiscreteSpace[T], Generic[T], HasPropertyLayers):
+class Grid(DiscreteSpace[T], HasPropertyLayers):
     """Base class for all grid classes.
 
     Attributes:

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -61,7 +61,7 @@ MultiGridContent = list[Agent]
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def accept_tuple_argument(wrapped_function: F) -> F:
+def accept_tuple_argument[F: Callable[..., Any]](wrapped_function: F) -> F:
     """Decorator to allow grid methods that take a list of (x, y) coord tuples to also handle a single position.
 
     Tuples are wrapped in a single-item list rather than forcing user to do it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "Mesa"
 description = "Agent-based modeling (ABM) in Python"
 license = { text = "Apache 2.0" }
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [
   { name = "Project Mesa Team", email = "maintainers@projectmesa.dev" },
 ]
@@ -25,7 +25,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: Apache Software License",
@@ -98,9 +97,9 @@ path = "mesa/__init__.py"
 
 [tool.ruff]
 # See https://github.com/charliermarsh/ruff#rules for error code definitions.
-# Hardcode to Python 3.11.
+# Hardcode to Python 3.12.
 # Reminder to update mesa-examples if the value below is changed.
-target-version = "py311"
+target-version = "py312"
 extend-exclude = ["build"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
This PR updates Mesa to require Python 3.12 as the minimum version and adopts the new [PEP 695](https://peps.python.org/pep-0695/) type parameter syntax introduced in Python 3.12.

Python 3.11 support is dropped following [SPEC 0](https://scientific-python.org/specs/spec-0000/). The Mesa 3.3.x release series will keep supporting Python 3.11.

**Key changes:**
- Updated minimum Python version from 3.11 to 3.12 across `pyproject.toml`, documentation, and pre-commit configuration
- Replaced legacy `Generic[T]` + `TypeVar` syntax with modern type parameter syntax (`class MyClass[T: Bound]:`)
- Removed redundant `Generic` inheritance where classes already inherit from generic base classes
- Applied the new syntax to `DiscreteSpace`, `CellCollection`, `Grid`, and decorator type hints

Please review. I would like to fast-forward merge this myself.