### PR TITLE
fix broken link in example

### DIFF
--- a/mesa/examples/advanced/epstein_civil_violence/Readme.md
+++ b/mesa/examples/advanced/epstein_civil_violence/Readme.md
@@ -25,7 +25,7 @@ To run the model interactively, in this directory, run the following command
 
 This model is based adapted from:
 
-[Epstein, J. “Modeling civil violence: An agent-based computational approach”, Proceedings of the National Academy of Sciences, Vol. 99, Suppl. 3, May 14, 2002](http://www.pnas.org/content/99/suppl.3/7243.short)
+[Epstein, J. “Modeling civil violence: An agent-based computational approach”, Proceedings of the National Academy of Sciences, Vol. 99, Suppl. 3, May 14, 2002](https://doi.org/10.1073/pnas.092080199)
 
 A similar model is also included with NetLogo:
 


### PR DESCRIPTION
### Summary
Problem described by #2846. The broken link may lead to confusion from potential users of Mesa and adds unnecessary hurdles to further learning by interested readers.

Fixes #2846 by changing the academic article reference link in the "Epstein Civil Violence" example to its corresponding doi equivalent.

### Bug / Issue
Reading through the "Epstein Civil Violence" example in the Mesa documentation, users are referred to the original academic article under "Further Reading" ([link](https://mesa.readthedocs.io/latest/examples/advanced/epstein_civil_violence.html#further-reading)). On clicking, however, the user is brought to "404 Page Not Found" on the PNAS website.

### Implementation
Changed link in the `Readme.md` of the "Epstein Civil Violence" example to the correct and stable doi link (specifically https://doi.org/10.1073/pnas.092080199).

### Testing
Performed very much on-the-fly, so docs were not rebuilt locally. Given that only one line was changed and that the new link in the raw code can be quickly manually checked, this was considered fine.

### Additional Notes
N/A
