### PR TITLE
Fix missing variable g in the tutorial

### DIFF
--- a/docs/tutorials/3_agentset.ipynb
+++ b/docs/tutorials/3_agentset.ipynb
@@ -277,7 +277,7 @@
     "data = model.datacollector.get_agent_vars_dataframe()\n",
     "# assign histogram colors\n",
     "palette = {\"Green\": \"green\", \"Blue\": \"blue\", \"Mixed\": \"purple\"}\n",
-    "sns.histplot(data=data, x=\"Wealth\", hue=\"Ethnicity\", discrete=True, palette=palette)\n",
+    "g = sns.histplot(data=data, x=\"Wealth\", hue=\"Ethnicity\", discrete=True, palette=palette)\n",
     "g.set(title=\"Wealth distribution\", xlabel=\"Wealth\", ylabel=\"number of agents\");"
    ]
   },


### PR DESCRIPTION
A minor fix of an undefined variable, g, under the AgentSet tutorial in the documentation.

### Summary
An undefined variable, g, which I encountered when learning from the tutorial. A simple bug.

### Bug / Issue
The histplot variable, g, was not defined but was called in the next line.

### Implementation
Defined the variable

### Testing
All tests were passed
