### PR TITLE
Tests: Add test for InputText in UserInputs

### DIFF
--- a/tests/test_solara_viz_updated.py
+++ b/tests/test_solara_viz_updated.py
@@ -93,6 +93,24 @@ class TestMakeUserInput(unittest.TestCase):  # noqa: D101
         assert slider_int.max is None
         assert slider_int.step is None
 
+    def test_input_text_field(self):
+        """Test that "InputText" type creates a vw.TextField."""
+
+        @solara.component
+        def Test(user_params):
+            UserInputs(user_params)
+
+        options = {"type": "InputText", "value": "JohnDoe", "label": "Agent Name"}
+
+        user_params = {"agent_name": options}
+
+        _, rc = solara.render(Test(user_params), handle_error=False)
+
+        textfield = rc.find(vw.TextField).widget
+
+        assert textfield.v_model == options["value"]
+        assert textfield.label == options["label"]
+
 
 def test_call_space_drawer(mocker):
     """Test the call to space drawer."""
@@ -325,24 +343,3 @@ def test_check_model_params_with_args_only():
         ),
     ):
         _check_model_params(ModelWithArgsOnly.__init__, model_params)
-
-
-def test_input_text_field(self):
-    """Test that "InputText" type creates a vw.TextField."""
-
-    @solara.component
-    def Test(user_params):
-        UserInputs(user_params)
-
-    options = {"type": "InputText", "value": "JohnDoe", "label": "Agent Name"}
-    user_params = {"agent_name": options}
-
-    # Action: Render the component
-    _, rc = solara.render(Test(user_params), handle_error=False)
-
-    # Check: Find the widget
-    textfield = rc.find(vw.TextField).widget
-
-    # Assert: Check label and value
-    assert textfield.v_model == options["value"]
-    assert textfield.label == options["label"]


### PR DESCRIPTION
### Description

This PR adds a new test to `test_solara_viz_updated.py` for the `UserInputs` component for the `InputText` type.

This improves the test coverage for this component.

### Related Issue

Addresses part of #1781

### Checklist
- [x] I have read and agree to the [Code of Conduct](https://github.com/projectmesa/mesa/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read the [contributing guidelines](https://github.com/projectmesa/mesa/blob/main/CONTRIBUTING.md).
- [x] I have added tests for my changes.
- [ ] I have updated the documentation if necessary.
- [x] All tests pass.
- [x] My code follows the code style of this project.