### PR TITLE
Fix: Improve sidebar navigation 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,10 @@ html_theme = "pydata_sphinx_theme"
 # documentation.
 html_theme_options = {
     "navbar_start": ["navbar-logo"],
+    "navigation_depth": 4,
+    "show_nav_level": 2,
+    "collapse_navigation": True,
+    "show_toc_level": 2,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,8 +95,22 @@ Our [CITATION.cff](https://github.com/projectmesa/mesa/blob/main/CITATION.cff) c
 The original Mesa conference paper from 2015 is [available here](http://conference.scipy.org.s3-website-us-east-1.amazonaws.com/proceedings/scipy2015/jacqueline_kazil.html).
 
 ```{toctree}
-:hidden: true
-:maxdepth: 7
+:maxdepth: 2
+:caption: Contents
+
+getting_started
+overview
+mesa
+examples
+best-practices
+mesa_extension
+migration_guide
+apis/api_main
+GSoC
+```
+   overview
+   tutorials/index
+
 
 Getting started <getting_started>
 Overview <overview>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -298,21 +298,9 @@ This will create an interactive visualization of your model, including:
 - A plot of a model metric over time
 - A slider to adjust the number of agents
 
-```{toctree}
-:hidden: true
-:maxdepth: 7
-
-Overview <overview>
-Creating Your First Model <tutorials/0_first_model>
-Adding Space <tutorials/1_adding_space>
-Collecting Data <tutorials/2_collecting_data>
-AgentSet <tutorials/3_agentset>
-Basic Visualization <tutorials/4_visualization_basic>
-Dynamic Agent Visualization <tutorials/5_visualization_dynamic_agents>
-Custom Visualization Components <tutorials/6_visualization_custom>
-Parameter Sweeps <tutorials/7_batch_run>
-Comparing Scenarios <tutorials/8_comparing_scenarios>
-Best Practices <best-practices>
 
 
-```
+
+
+
+


### PR DESCRIPTION
fixed the bug. 🐛
Refference: doc📃 section navigation:
The changes which will now navigates to the correct ✅documentation .
index.md : Now ensures the main toctree, separates overview and tutorials .
overview.md : Updated its heading , and removed the toctree section as it was keeping hidden links .
conf.py: Added the max depth of headings similar to those of index.md.
This will now help user to find and jump to the part of documentation user wanted to read.
