### PR TITLE
Docs: Link to online example model demo in a few places

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Repast, or MASON.
 ![A screenshot of the WolfSheep Model in Mesa](https://raw.githubusercontent.com/projectmesa/mesa/main/docs/images/wolf_sheep.png)
 
 *Above: A Mesa implementation of the WolfSheep model, this
-can be displayed in browser windows or Jupyter.*
+can be displayed in browser windows or Jupyter. An online demo is [available here](https://py.cafe/app/EwoutH/mesa-solara-basic-examples).*
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@
 Mesa allows users to quickly create agent-based models using built-in core components (such as spatial grids and agent schedulers) or customized implementations; visualize them using a browser-based interface; and analyze their results using Python's data analysis tools. Mesa's goal is to make simulations accessible to everyone, so humanity can more effectively understand and solve complex problems.
 
 ![A screenshot of the Wolf Sheep model in Mesa|100%](images/wolf_sheep.png)
-*A visualisation of the Wolf Sheep model build with Mesa.*
+*A visualisation of the Wolf Sheep model build with Mesa. An online demo is [available here](https://py.cafe/app/EwoutH/mesa-solara-basic-examples).*
 
 ## Features
 

--- a/mesa/examples/README.md
+++ b/mesa/examples/README.md
@@ -11,6 +11,8 @@ The examples are categorized into two groups:
 ## Basic Examples
 The basic examples are relatively simple and only use stable Mesa features. They are good starting points for learning how to use Mesa.
 
+_An online version of these examples is [available here](https://py.cafe/app/EwoutH/mesa-solara-basic-examples)._
+
 ### [Boltzmann Wealth Model](examples/basic/boltzmann_wealth_model)
 Completed code to go along with the [tutorial](https://mesa.readthedocs.io/latest/tutorials/0_first_model.html) on making a simple model of how a highly-skewed wealth distribution can emerge from simple rules.
 


### PR DESCRIPTION
Link in a few places to the https://py.cafe/app/EwoutH/mesa-solara-basic-examples demo. This allows people unfamiliar with modelling to directly play with interactive models.

Unfortunately, it's pycafe currently doesn't support multiple threads, which we introduced in Python 3.2.0 for the visualisation, so this demo runs on Mesa 3.1.5. See https://github.com/projectmesa/mesa/discussions/2170#discussioncomment-14903887.