### PR TITLE
Pin Readthedocs build to Python 3.13

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ formats:
 build:
   os: ubuntu-lts-latest
   tools:
-    python: latest
+    python: "3.13"  # 3.14 (latest) is blocked by an upstream Solara issue: https://github.com/widgetti/solara/issues/1107
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Python 3.14 (currently `latest`) breaks the docs build due to an upstream Solara compatibility issue. Python 3.14 has stricter dictionary iteration rules, causing a `RuntimeError: dictionary changed size during iteration` when Solara is imported.

The fix has been merged in Solara (#1123) but not yet included in a release. Pin to 3.13 until a new Solara version ships.

Upstream issue: https://github.com/widgetti/solara/issues/1107'

On a side note, I'm more and more in doubt about if the Solara team is in capacity to maintain its library.