### PR TITLE
Fix #2904: Update experimental cell_space import to mesa.discrete_space

### DIFF
--- a/tests/test_components_matplotlib.py
+++ b/tests/test_components_matplotlib.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 
 from mesa import Agent, Model
-from mesa.experimental.cell_space import (
+from mesa.discrete_space import (
     CellAgent,
     HexGrid,
     Network,


### PR DESCRIPTION
This PR addresses a deprecation around the old experimental cell space import used in the matplotlib components tests. The tests were importing grid classes from mesa.experimental.cell_space, which is now deprecated in favor of the new mesa.discrete_space API.

**What does this PR change?**

Updates the import in tests/test_components_matplotlib.py from:

from mesa.experimental.cell_space import (
    CellAgent,
    HexGrid,
    Network,
    OrthogonalMooreGrid,
    VoronoiGrid,
)

to:

from mesa.discrete_space import (
    CellAgent,
    HexGrid,
    Network,
    OrthogonalMooreGrid,
    VoronoiGrid,
)

This resolves item 1.3 from issue   #2904  by pointing the tests at the official, non‑experimental cell space 
implementation.

**How did you test it?**

Ran the targeted test file:

pytest tests/test_components_matplotlib.py

Re-ran the same test with warnings enabled:

pytest -W always tests/test_components_matplotlib.py

All 7 tests passed, and the previous DeprecationWarning about mesa.experimental.cell_space no longer appears (only unrelated existing warnings remain).