### PR TITLE
tests: Update agent portrayals to use AgentPortrayalStyle

### DIFF
--- a/tests/test_components_matplotlib.py
+++ b/tests/test_components_matplotlib.py
@@ -18,6 +18,7 @@ from mesa.space import (
     PropertyLayer,
     SingleGrid,
 )
+from mesa.visualization.components import AgentPortrayalStyle
 from mesa.visualization.mpl_space_drawing import (
     draw_continuous_space,
     draw_hex_grid,
@@ -36,11 +37,11 @@ def agent_portrayal(agent):
         agent (Agent): The agent to portray
 
     """
-    return {
-        "s": 10,
-        "c": "tab:blue",
-        "marker": "s" if (agent.unique_id % 2) == 0 else "o",
-    }
+    return AgentPortrayalStyle(
+        size=10,
+        color="tab:blue",
+        marker="s" if (agent.unique_id % 2) == 0 else "o",
+    )
 
 
 def test_draw_space():
@@ -53,14 +54,14 @@ def test_draw_space():
             agent (Agent): The agent to portray
 
         """
-        return {
-            "s": 10,
-            "c": "tab:blue",
-            "marker": "s" if (agent.unique_id % 2) == 0 else "o",
-            "alpha": 0.5,
-            "linewidths": 1,
-            "linecolors": "tab:orange",
-        }
+        return AgentPortrayalStyle(
+            size=10,
+            color="tab:blue",
+            marker="s" if (agent.unique_id % 2) == 0 else "o",
+            alpha=0.5,
+            linewidths=1,
+            edgecolors="tab:orange",
+        )
 
     # draw space for hexgrid
     model = Model(seed=42)


### PR DESCRIPTION
<h1 data-start="110" data-end="188">PR: Migrate Test Agent Portrayals to <code data-start="151" data-end="172">AgentPortrayalStyle</code> (Part of #2904)</h1>
<p data-start="190" data-end="432">This PR updates <code data-start="206" data-end="243">tests/test_components_matplotlib.py</code> to use the new <code data-start="259" data-end="280">AgentPortrayalStyle</code> API rather than legacy dict-based portrayals.<br data-start="326" data-end="329">
It reduces deprecation warnings and ensures the test suite reflects the modern visualization interface.</p>
<hr data-start="434" data-end="437">
<h2 data-start="439" data-end="460">🔧 Issue Reference</h2>
<p data-start="461" data-end="569"><strong data-start="461" data-end="472">Linked:</strong> #2904 — Migration away from deprecated dict-based agent portrayals toward <code data-start="547" data-end="568">AgentPortrayalStyle</code>.</p>
<p data-start="571" data-end="654">Previously, several tests defined <code data-start="605" data-end="622">agent_portrayal</code> functions returning dicts like:</p>
<pre class="overflow-visible!" data-start="656" data-end="701"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-python"><span><span>{</span><span><span class="hljs-string">"s"</span></span><span>: </span><span><span class="hljs-number">10</span></span><span>, </span><span><span class="hljs-string">"c"</span></span><span>: </span><span><span class="hljs-string">"tab:blue"</span></span><span>, ...}
</span></span></code></div></div></pre>
<p data-start="703" data-end="867">These have been deprecated. The visualization system now expects an <code data-start="771" data-end="792">AgentPortrayalStyle</code> instance, leading to noisy warnings and inconsistencies in the test suite.</p>
<hr data-start="869" data-end="872">
<h2 data-start="874" data-end="903">🛠️ Implementation Details</h2>
<h3 data-start="905" data-end="926">✔ Updated Imports</h3>
<pre class="overflow-visible!" data-start="927" data-end="1002"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-python"><span><span><span class="hljs-keyword">from</span></span><span> mesa.visualization.components </span><span><span class="hljs-keyword">import</span></span><span> AgentPortrayalStyle
</span></span></code></div></div></pre>
<h3 data-start="1004" data-end="1045">✔ Refactored Test Portrayal Functions</h3>
<p data-start="1046" data-end="1178">All portrayal functions in <code data-start="1073" data-end="1110">tests/test_components_matplotlib.py</code> have been updated to return <code data-start="1139" data-end="1160">AgentPortrayalStyle</code> instead of dicts.</p>
<h3 data-start="1180" data-end="1217">✔ Key Mappings (Legacy → New API)</h3>
<div class="_tableContainer_1rjym_1"><div tabindex="-1" class="group _tableWrapper_1rjym_13 flex w-fit flex-col-reverse">
Old Dict Key | New AgentPortrayalStyle Field
-- | --
s | size
c | color
linewidths | linewidths
linecolors | edgecolors

</div></div>
<p data-start="1521" data-end="1614">These mappings preserve the previous semantics—same markers, colors, sizes, and alpha values.</p>
<hr data-start="1616" data-end="1619">
<h2 data-start="1621" data-end="1634">🧪 Testing</h2>
<p data-start="1636" data-end="1665">Executed focused test suites:</p>
<pre class="overflow-visible!" data-start="1667" data-end="1744"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-bash"><span><span>pytest tests/test_components_matplotlib.py tests/test_backends.py
</span></span></code></div></div></pre>
<h3 data-start="1746" data-end="1760">✅ Result</h3>
<ul data-start="1761" data-end="1902">
<li data-start="1761" data-end="1782">
<p data-start="1763" data-end="1782"><strong data-start="1763" data-end="1782">21 tests passed</strong></p>
</li>
<li data-start="1783" data-end="1818">
<p data-start="1785" data-end="1818">Only pre-existing warnings remain</p>
</li>
<li data-start="1819" data-end="1847">
<p data-start="1821" data-end="1847">No new errors introduced</p>
</li>
<li data-start="1848" data-end="1902">
<p data-start="1850" data-end="1902">Tests now exercise the updated portrayal API cleanly</p>
</li>
</ul>
<hr data-start="1904" data-end="1907">
<h2 data-start="1909" data-end="1920">📌 Notes</h2>
<ul data-start="1922" data-end="2168">
<li data-start="1922" data-end="2043">
<p data-start="1924" data-end="2043">This PR intentionally targets <strong data-start="1954" data-end="1977">only the test layer</strong>, aligning with the incremental migration plan discussed in #2904.</p>
</li>
<li data-start="2044" data-end="2168">
<p data-start="2046" data-end="2168">Core visualization code already supports <code data-start="2087" data-end="2108">AgentPortrayalStyle</code>; these changes ensure tests validate the new API correctly.</p>
</li>
</ul>
