### PR TITLE
tests: Resolved "Missing Random Number Generator" warnings

### DIFF
--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -1,5 +1,6 @@
 """Test Solara visualizations."""
 
+import random
 import re
 import unittest
 
@@ -204,6 +205,7 @@ def test_call_space_drawer(mocker):
     voronoi_model = mesa.Model()
     voronoi_model.grid = mesa.discrete_space.VoronoiGrid(
         centroids_coordinates=[(0, 1), (0, 0), (1, 0)],
+        random=random.Random(42),
     )
     solara.render(
         SolaraViz(voronoi_model, components=[make_mpl_space_component(agent_portrayal)])

--- a/tests/test_space_drawer.py
+++ b/tests/test_space_drawer.py
@@ -1,5 +1,6 @@
 """Test space drawer classes for various grid types."""
 
+import random
 from unittest.mock import MagicMock, patch
 
 import altair as alt
@@ -20,12 +21,12 @@ from mesa.visualization.space_drawers import (
 
 @pytest.fixture
 def orthogonal_grid():  # noqa: D103
-    return OrthogonalMooreGrid([5, 5])
+    return OrthogonalMooreGrid([5, 5], random=random.Random(42))
 
 
 @pytest.fixture
 def hex_grid():  # noqa: D103
-    return HexGrid([5, 5])
+    return HexGrid([5, 5], random=random.Random(42))
 
 
 @pytest.fixture
@@ -38,13 +39,13 @@ def network_grid():  # noqa: D103
     G = nx.Graph()  # noqa: N806
     G.add_nodes_from([0, 1, 2])
     G.add_edges_from([(0, 1), (1, 2)])
-    return Network(G)
+    return Network(G, random=random.Random(42))
 
 
 @pytest.fixture
 def voronoi_space():  # noqa: D103
     points = [(0, 0), (1, 0), (0, 1), (1, 1)]
-    return VoronoiGrid(points)
+    return VoronoiGrid(points, random=random.Random(42))
 
 
 class TestOrthogonalSpaceDrawer:
@@ -288,7 +289,7 @@ class TestVoronoiSpaceDrawer:
 
 class TestEdgeCases:  # noqa: D101
     def test_single_point_voronoi_grid(self):  # noqa: D102
-        single_point_voronoi = VoronoiGrid([(0.5, 0.5)])
+        single_point_voronoi = VoronoiGrid([(0.5, 0.5)], random=random.Random(42))
         drawer = VoronoiSpaceDrawer(single_point_voronoi)
         assert drawer.viz_xmin is not None
         assert drawer.viz_xmax is not None
@@ -300,13 +301,13 @@ class TestEdgeCases:  # noqa: D101
 
     def test_network_empty_graph(self):  # noqa: D102
         empty_graph = nx.Graph()
-        network = Network(empty_graph)
+        network = Network(empty_graph, random=random.Random(42))
         drawer = NetworkSpaceDrawer(network)
         assert len(drawer.pos) == 0
         assert drawer.s_default == 1  # Default when no nodes
 
     def test_hex_grid_single_cell(self):  # noqa: D102
-        grid = HexGrid([1, 1])
+        grid = HexGrid([1, 1], random=random.Random(42))
         drawer = HexSpaceDrawer(grid)
         assert len(drawer.hexagons) == 1
         assert drawer.s_default == (180 / 1) ** 2

--- a/tests/test_space_renderer.py
+++ b/tests/test_space_renderer.py
@@ -1,5 +1,6 @@
 """Test cases for the SpaceRenderer class in Mesa."""
 
+import random
 import re
 from unittest.mock import MagicMock, patch
 
@@ -39,7 +40,9 @@ class CustomModel(mesa.Model):
 
     def __init__(self, seed=None):  # noqa: D107
         super().__init__(seed=seed)
-        self.grid = mesa.discrete_space.OrthogonalMooreGrid([2, 2])
+        self.grid = mesa.discrete_space.OrthogonalMooreGrid(
+            [2, 2], random=random.Random(42)
+        )
         self.layer = PropertyLayer("test", [2, 2], default_value=0)
 
         self.grid.add_property_layer(self.layer)
@@ -59,16 +62,22 @@ def test_backend_selection():
 @pytest.mark.parametrize(
     "grid,expected_drawer",
     [
-        (OrthogonalMooreGrid([2, 2]), OrthogonalSpaceDrawer),
+        (
+            OrthogonalMooreGrid([2, 2], random=random.Random(42)),
+            OrthogonalSpaceDrawer,
+        ),
         (SingleGrid(width=2, height=2, torus=False), OrthogonalSpaceDrawer),
         (MultiGrid(width=2, height=2, torus=False), OrthogonalSpaceDrawer),
-        (HexGrid([2, 2]), HexSpaceDrawer),
+        (HexGrid([2, 2], random=random.Random(42)), HexSpaceDrawer),
         (HexSingleGrid(width=2, height=2, torus=False), HexSpaceDrawer),
         (HexMultiGrid(width=2, height=2, torus=False), HexSpaceDrawer),
-        (Network(G=MagicMock()), NetworkSpaceDrawer),
+        (Network(G=MagicMock(), random=random.Random(42)), NetworkSpaceDrawer),
         (NetworkGrid(g=MagicMock()), NetworkSpaceDrawer),
         (ContinuousSpace(x_max=2, y_max=2, torus=False), ContinuousSpaceDrawer),
-        (VoronoiGrid([[0, 0], [1, 1]]), VoronoiSpaceDrawer),
+        (
+            VoronoiGrid([[0, 0], [1, 1]], random=random.Random(42)),
+            VoronoiSpaceDrawer,
+        ),
     ],
 )
 def test_space_drawer_selection(grid, expected_drawer):
@@ -91,14 +100,16 @@ def test_map_coordinates():
     # same for orthogonal grids
     assert np.array_equal(mapped["loc"], arr)
 
-    with patch.object(model, "grid", new=HexGrid([2, 2])):
+    with patch.object(model, "grid", new=HexGrid([2, 2], random=random.Random(42))):
         sr = SpaceRenderer(model)
         mapped = sr._map_coordinates(args)
 
         assert not np.array_equal(mapped["loc"], arr)
         assert mapped["loc"].shape == arr.shape
 
-    with patch.object(model, "grid", new=Network(G=MagicMock())):
+    with patch.object(
+        model, "grid", new=Network(G=MagicMock(), random=random.Random(42))
+    ):
         sr = SpaceRenderer(model)
         # Patch the space_drawer.pos to provide a mapping for the test
         sr.space_drawer.pos = {0: (0, 0), 1: (1, 1), 2: (2, 2), 3: (3, 3)}


### PR DESCRIPTION
### Summary
Resolved "Missing Random Number Generator" warnings in the test suite by explicitly passing a random number generator to grid instantiations.

### Bug / Issue
[DiscreteSpace](cci:2://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/mesa/discrete_space/discrete_space.py:29:0-174:29) subclasses (such as [OrthogonalMooreGrid](cci:2://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/mesa/discrete_space/grid.py:199:0-227:55), [HexGrid](cci:2://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/mesa/discrete_space/grid.py:269:0-297:71), [Network](cci:2://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/mesa/discrete_space/network.py:21:0-76:62), and [VoronoiGrid](cci:2://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/mesa/discrete_space/voronoi.py:174:0-265:79)) emit a `UserWarning: Random number generator not specified` when instantiated without a [random](cci:1://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/mesa/discrete_space/grid.py:142:4-158:53) parameter. This warning highlights potential non-reproducibility in models. The goal was to resolve these warnings within the project's tests.

### Implementation
Updated the following test files to explicitly pass `random=random.Random(42)` during grid instantiation:
- [tests/test_space_renderer.py](cci:7://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/tests/test_space_renderer.py:0:0-0:0)
- [tests/test_space_drawer.py](cci:7://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/tests/test_space_drawer.py:0:0-0:0)
- [tests/test_solara_viz.py](cci:7://file:///c:/Users/shreyas/Downloads/project-mesa/mesa-os/tests/test_solara_viz.py:0:0-0:0)

This ensures that the tests are reproducible and eliminates the warnings.

### Testing
Verified the fix by running the relevant tests using `pytest`:
`pytest tests/test_discrete_space.py tests/test_space_renderer.py tests/test_space_drawer.py tests/test_solara_viz.py`

All tests passed successfully.

### Additional Notes
No changes were made to the core library logic; only test files were modified to adhere to the requirement of explicit RNG specification.