### PR TITLE
Add deprecation category to release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,9 @@ changelog:
     - title: ⚠️ Breaking changes
       labels:
         - breaking
+    - title: ⏳ Deprecations
+      labels:
+        - deprecation
     - title: 🧪 Experimental features
       labels:
         - experimental


### PR DESCRIPTION
Adds a deprecations section to automatically generated release notes.

This will list [all PRs with the deprecation label](https://github.com/projectmesa/mesa/pulls?q=is%3Apr+label%3Adeprecation) in a new category in the automatically generated release notes.