### PR TITLE
Speed up CI by installing only Playwright chromium-headless-shell

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Mesa and dependencies
         run: uv pip install --system .[dev]
       - name: Setup Playwright
-        run: playwright install
+        run: playwright install chromium-headless-shell
       - name: Test with pytest
         run: pytest --durations=10 --cov=mesa tests/ --cov-report=xml
       - if: matrix.os == 'ubuntu'


### PR DESCRIPTION
Replace `playwright install` with `playwright install chromium-headless-shell` to download only the minimal headless Chromium (~105 MiB) instead of all browsers (~470 MiB). Since pytest-playwright defaults to Chromium and our tests run headless, we don't need Firefox, WebKit, or the full Chromium browser.

Also speeds up Playwright install time from 12-20 seconds to 3-6.