### PR TITLE
Use pandas type checking for numeric dtype detection in Altair backend

### DIFF
--- a/mesa/visualization/backends/altair_backend.py
+++ b/mesa/visualization/backends/altair_backend.py
@@ -276,7 +276,7 @@ class AltairBackend(AbstractRenderer):
         vmin = kwargs.pop("vmin", None)
         vmax = kwargs.pop("vmax", None)
 
-        color_is_numeric = np.issubdtype(df["original_color"].dtype, np.number)
+        color_is_numeric = pd.api.types.is_numeric_dtype(df["original_color"])
         if color_is_numeric:
             color_min = vmin if vmin is not None else df["original_color"].min()
             color_max = vmax if vmax is not None else df["original_color"].max()


### PR DESCRIPTION
Replace `np.issubdtype()` with `pandas.api.types.is_numeric_dtype()` to fix compatibility with pandas 3.0's new `StringDtype`.

NumPy's `np.issubdtype()` cannot handle pandas `ExtensionDtype` objects, particularly the new `StringDtype` introduced as default in pandas 3.0. This caused TypeError when checking if color columns were numeric:
```
"Cannot interpret '<StringDtype(storage='python', na_value=nan)>' as a data type"
```

Using pandas' `is_numeric_dtype()` provides several benefits:
- Correctly handles all pandas dtypes (native NumPy and extension types)
- Works with numeric extension dtypes (Int64, Float64, Decimal, etc.)
- Compatible with both pandas 2.x and 3.x
- More semantically clear - checks if data is numeric rather than checking dtype inheritance hierarchy

