### PR TITLE
Update visualization tabs to be compatible with ipyvuetify 3.0

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -423,9 +423,9 @@ def ComponentsView(
         for index in sorted_page_indices:
             solara.v.Tab(children=[f"Page {index}"])
 
-    with solara.v.TabsItems(v_model=current_tab_index):
+    with solara.v.Window(v_model=current_tab_index):
         for _, page_id in enumerate(sorted_page_indices):
-            with solara.v.TabItem():
+            with solara.v.WindowItem():
                 if page_id == current_tab_index:
                     page_components = pages[page_id]
                     page_layout = layouts.get(page_id)


### PR DESCRIPTION
Replace deprecated Vuetify 2 tab components with Vuetify 3 equivalents:
- Replace `solara.v.TabsItems` with `solara.v.Window`
- Replace `solara.v.TabItem` with `solara.v.WindowItem`

This fixes compatibility with ipyvuetify 3.0.0a3, which migrated from Vuetify 2 to Vuetify 3. The TabsItems/TabItem components were removed in Vuetify 3 in favor of the Window/WindowItem component system for managing tab panels.

Resolves: AttributeError: module 'reacton.ipyvuetify' has no attribute 'TabsItems'