### PR TITLE
test: Update simulator.time deprecation test to expect FutureWarning

### DIFF
--- a/tests/test_devs.py
+++ b/tests/test_devs.py
@@ -130,12 +130,12 @@ def test_abm_simulator():
 
 
 def test_simulator_time_deprecation():
-    """Test that simulator.time emits deprecation warning."""
+    """Test that simulator.time emits future warning."""
     simulator = DEVSimulator()
     model = Model()
     simulator.setup(model)
 
-    with pytest.warns(DeprecationWarning, match="simulator.time is deprecated"):
+    with pytest.warns(FutureWarning, match="simulator.time is deprecated"):
         _ = simulator.time
 
 


### PR DESCRIPTION
### Summary
Updates the `test_simulator_time_deprecation` test to expect `FutureWarning` instead of `DeprecationWarning`, aligning with the changes made in PR #2905.

### Bug / Issue
The test was failing after PR #2905 because it expected a `DeprecationWarning`, but the actual warning emitted is now a `FutureWarning`. This change was part of Mesa's new deprecation policy to make warnings visible to users by default.

PRs #2903 and #2905 were in development simultaneously, which resulted in this test not being updated when the deprecation warning policy changed.