### PR TITLE
SolaraViz: move hooks before early return in ComponentsView

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -365,9 +365,6 @@ def ComponentsView(
     current_tab_index, set_current_tab_index = solara.use_state(0)
     layouts, set_layouts = solara.use_state({})
 
-    if not components:
-        return
-
     # Backward's compatibility, page = 0 if not passed.
     for i, comp in enumerate(components):
         if not isinstance(comp, tuple):
@@ -390,6 +387,9 @@ def ComponentsView(
 
     # Keep layouts in sync with pages
     def sync_layouts():
+        if not components:  # Handle empty case inside the effect
+            return
+
         current_keys = set(pages.keys())
         layout_keys = set(layouts.keys())
 
@@ -406,6 +406,10 @@ def ComponentsView(
             set_layouts({**cleaned_layouts, **new_layouts})
 
     solara.use_effect(sync_layouts, list(pages.keys()))
+
+    # Allow early return (which is now safe because all hooks have been called)
+    if not components:
+        return
 
     # Tab Navigation
     with solara.v.Tabs(v_model=current_tab_index, on_v_model=set_current_tab_index):


### PR DESCRIPTION
### Problem
The `ComponentsView` component in `solara_viz.py` was violating Solara's Rules of Hooks (rule SH101: early return). The component had an early return statement when the `components` list was empty, but hook calls (`use_state` and `use_effect`) were placed after this conditional return. This caused the following warning during execution:

```
UserWarning: ComponentsView: `use_effect` found despite early return on line 369
```

This violation occurs because hooks must be called in the same order on every render to maintain proper state management. When `components` is empty, the function returns early and skips all hook calls. When `components` is not empty, the hooks are executed. This inconsistency can lead to state slots becoming misaligned between renders, potentially causing bugs and unexpected behavior.

### Solution
This PR restructures the `ComponentsView` component to ensure all hooks (`use_state` and `use_effect`) are called at the top level before the early return statement. The empty components check has been moved inside the `sync_layouts` effect callback, allowing the hook to be called consistently on every render while still handling the empty case appropriately.

### Testing

Warning is gone.

### References
- [Solara Rules of Hooks](https://solara.dev/documentation/advanced/understanding/rules-of-hooks#early-return-sh101)
