### PR TITLE
ci: treat warnings as errors to prevent accumulation

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Playwright
         run: playwright install chromium-headless-shell
       - name: Test with pytest
-        run: pytest --durations=10 --cov=mesa tests/ --cov-report=xml
+        run: pytest --durations=10 --cov=mesa tests/ --cov-report=xml -Werror -Wdefault::PendingDeprecationWarning
       - if: matrix.os == 'ubuntu'
         name: Codecov
         uses: codecov/codecov-action@v5
@@ -90,4 +90,4 @@ jobs:
       - name: Test examples
         run: |
           cd mesa-examples
-          pytest -rA -Werror -Wdefault::FutureWarning -Wi::DeprecationWarning test_examples.py
+          pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py


### PR DESCRIPTION
### Summary
Configure CI to treat all warnings as errors (except `PendingDeprecationWarning`) to prevent warning accumulation and enforce immediate fixes.

### Motive
Mesa recently had 1,514 warnings across 366 tests, creating technical debt and degrading developer experience. While significant cleanup has reduced this to ~22 warnings, we need to prevent regression. 

Without enforcement, warnings slowly accumulate as contributors add code that triggers new warnings. By the time someone notices, hundreds of warnings have built up, making cleanup overwhelming. Treating warnings as errors catches issues immediately at PR time when they're easiest to fix.

### Implementation
Added `-Werror -Wdefault::PendingDeprecationWarning` flags to pytest in both CI jobs:

- **`-Werror`**: Converts all warnings to errors, failing the build
- **`-Wdefault::PendingDeprecationWarning`**: Exempts `PendingDeprecationWarning`, as listed in our [deprecation policy](https://github.com/projectmesa/mesa/blob/main/CONTRIBUTING.md#deprecation-policy).

This means `DeprecationWarning`, `FutureWarning`, `UserWarning`, and `RuntimeWarning` will now fail CI, forcing contributors to fix them before merging.

Simplified the examples job configuration to match the main build job for consistency.