### PR TITLE
tests: Set batch_run tests to use 100 steps instead of 1000

### DIFF
--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -134,75 +134,79 @@ class MockModel(Model):
 
 
 def test_batch_run():  # noqa: D103
-    result = mesa.batch_run(MockModel, {}, number_processes=2, rng=42)
+    result = mesa.batch_run(MockModel, {}, number_processes=2, max_steps=100, rng=42)
     assert result == [
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 1,
             "agent_id": 1,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 42,
         },
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 2,
             "agent_id": 2,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 42,
         },
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 3,
             "agent_id": 3,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 42,
         },
     ]
 
-    result = mesa.batch_run(MockModel, {}, number_processes=2, iterations=1)
+    result = mesa.batch_run(
+        MockModel, {}, number_processes=2, max_steps=100, iterations=1
+    )
     assert result == [
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 1,
             "agent_id": 1,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": None,
         },
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 2,
             "agent_id": 2,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": None,
         },
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 3,
             "agent_id": 3,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": None,
         },
     ]
 
-    result = mesa.batch_run(MockModel, {}, number_processes=2, rng=[42, 31415])
+    result = mesa.batch_run(
+        MockModel, {}, number_processes=2, max_steps=100, rng=[42, 31415]
+    )
 
     # we use 2 processes, so we are not guaranteed the order of the return
     result = sorted(result, key=lambda x: (x["RunId"], x["AgentID"]))
@@ -211,67 +215,69 @@ def test_batch_run():  # noqa: D103
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 1,
             "agent_id": 1,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 42,
         },
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 2,
             "agent_id": 2,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 42,
         },
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 3,
             "agent_id": 3,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 42,
         },
         {
             "RunId": 1,
             "iteration": 1,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 1,
             "agent_id": 1,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 31415,
         },
         {
             "RunId": 1,
             "iteration": 1,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 2,
             "agent_id": 2,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 31415,
         },
         {
             "RunId": 1,
             "iteration": 1,
-            "Step": 1000,
+            "Step": 100,
             "reported_model_param": 42,
             "AgentID": 3,
             "agent_id": 3,
-            "agent_local": 250.0,
+            "agent_local": 25.0,
             "seed": 31415,
         },
     ]
 
     with pytest.raises(ValueError):
-        mesa.batch_run(MockModel, {}, number_processes=2, rng=42, iterations=1)
+        mesa.batch_run(
+            MockModel, {}, number_processes=2, max_steps=100, rng=42, iterations=1
+        )
 
 
 def test_batch_run_with_params():  # noqa: D103
@@ -282,19 +288,20 @@ def test_batch_run_with_params():  # noqa: D103
             "variable_agent_param": range(3),
         },
         number_processes=2,
+        max_steps=100,
     )
 
 
 def test_batch_run_no_agent_reporters():  # noqa: D103
     result = mesa.batch_run(
-        MockModel, {"enable_agent_reporters": False}, number_processes=2
+        MockModel, {"enable_agent_reporters": False}, number_processes=2, max_steps=100
     )
     print(result)
     assert result == [
         {
             "RunId": 0,
             "iteration": 0,
-            "Step": 1000,
+            "Step": 100,
             "enable_agent_reporters": False,
             "reported_model_param": 42,
             "seed": None,
@@ -303,7 +310,7 @@ def test_batch_run_no_agent_reporters():  # noqa: D103
 
 
 def test_batch_run_single_core():  # noqa: D103
-    mesa.batch_run(MockModel, {}, number_processes=1, iterations=6)
+    mesa.batch_run(MockModel, {}, number_processes=1, max_steps=100, iterations=6)
 
 
 def test_batch_run_unhashable_param():  # noqa: D103
@@ -313,12 +320,13 @@ def test_batch_run_unhashable_param():  # noqa: D103
             "n_agents": 2,
             "variable_model_param": [{"key": "value"}],
         },
+        max_steps=100,
         iterations=2,
     )
     template = {
-        "Step": 1000,
+        "Step": 100,
         "reported_model_param": 42,
-        "agent_local": 250.0,
+        "agent_local": 25.0,
         "n_agents": 2,
         "variable_model_param": {"key": "value"},
         "seed": None,


### PR DESCRIPTION
Update all `mesa.batch_run()` calls to use `max_steps=100` and adjust expected test results accordingly (`Step: 100, agent_local: 25.0`).