### PR TITLE
Remove token from Codecov action

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -66,7 +66,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes Codecov failures on forked pull requests by removing the explicit upload token from the GitHub Actions workflow. Since Mesa is an open-source project and the organization is configured to allow tokenless uploads, passing an empty secret on forked PRs caused Codecov to reject uploads and report missing head/base commits. Removing the token allows Codecov to correctly perform tokenless uploads on forks while preserving normal coverage reporting on `main` and same-repo PRs.