### PR TITLE
Changed broken documentation link in docs/tutorials/1_adding_space.ipynb

### DIFF
--- a/docs/tutorials/1_adding_space.ipynb
+++ b/docs/tutorials/1_adding_space.ipynb
@@ -347,7 +347,7 @@
    "source": [
     "## Next Steps\n",
     "\n",
-    "Check out the [collecting data tutorial](https://mesa.readthedocs.io/latest/tutorials/2_collecting_data_tutorial.html) on how to collect data form your model."
+    "Check out the [collecting data tutorial](https://mesa.readthedocs.io/latest/tutorials/2_collecting_data.html) on how to collect data form your model."
    ]
   },
   {


### PR DESCRIPTION
### Summary
A tutorial link in documentation leads to a 404 page.

### Bug / Issue
A link to "Collecting Data" tutorial in the Jupyter notebook docs/tutorials/1_adding_space.ipynb leads to a 404 page, when accessed through the rendered site.
Broken Link: https://mesa.readthedocs.io/latest/tutorials/2_collecting_data_tutorial.html

### Implementation
Replaced the link with the following:
https://mesa.readthedocs.io/latest/tutorials/2_collecting_data.html
which I think is the correct one.

