### PR TITLE
Fix visualization deprecation warnings and patch Altair component for…

### DIFF
--- a/mesa/visualization/components/altair_components.py
+++ b/mesa/visualization/components/altair_components.py
@@ -1,8 +1,8 @@
 """Altair based solara components for visualization mesa spaces."""
 
+import dataclasses
 import warnings
 from collections.abc import Callable
-import dataclasses
 
 import altair as alt
 import numpy as np
@@ -88,6 +88,7 @@ def SpaceAltair(
 
     solara.FigureAltair(chart)
 
+
 def _get_agent_data_old__discrete_space(space, agent_portrayal):
     """Format agent portrayal data for old-style discrete spaces.
 
@@ -116,6 +117,7 @@ def _get_agent_data_old__discrete_space(space, agent_portrayal):
             all_agent_data.append(agent_data)
     return all_agent_data
 
+
 def _get_agent_data_new_discrete_space(space: DiscreteSpace, agent_portrayal):
     """Format agent portrayal data for new-style discrete spaces.
 
@@ -139,6 +141,7 @@ def _get_agent_data_new_discrete_space(space: DiscreteSpace, agent_portrayal):
             all_agent_data.append(agent_data)
     return all_agent_data
 
+
 def _get_agent_data_continuous_space(space: ContinuousSpace, agent_portrayal):
     """Format agent portrayal data for continuous space.
 
@@ -158,6 +161,7 @@ def _get_agent_data_continuous_space(space: ContinuousSpace, agent_portrayal):
         agent_data["y"] = agent.pos[1]
         all_agent_data.append(agent_data)
     return all_agent_data
+
 
 def _draw_grid(space, agent_portrayal, propertylayer_portrayal):
     match space:
@@ -268,7 +272,7 @@ def chart_property_layers(space, propertylayer_portrayal, chart_width, chart_hei
             # Convert Style object to dict if needed
             if portrayal is not None and not isinstance(portrayal, dict):
                 portrayal = dataclasses.asdict(portrayal)
-        
+
         # If no style is defined for this layer, skip it
         if portrayal is None:
             continue

--- a/tests/test_solara_viz.py
+++ b/tests/test_solara_viz.py
@@ -164,6 +164,7 @@ def test_call_space_drawer(mocker):
                 vmax=10,
             )
         return None
+
     mock_post_process = mocker.MagicMock()
     solara.render(
         SolaraViz(


### PR DESCRIPTION
**Fix visualization deprecation warnings & patch Altair backend (Issue #2904)**

**PR Description -**
This PR resolves multiple deprecation warnings in the visualization test suite, specifically those related to returning dictionaries from agent_portrayal and propertylayer_portrayal. It also fixes a bug in the Altair backend discovered during testing.

**Changes Made**

1. `tests/test_solara_viz.py` -
Refactored agent_portrayal to return an AgentPortrayalStyle object instead of a dictionary.
Refactored propertylayer_portrayal to use a callable returning a PropertyLayerStyle object instead of a nested dictionary.
This eliminates the bulk of the FutureWarning logs during testing.

2. `mesa/visualization/components/altair_components.py` -

Bug Fix: The Altair backend previously crashed when receiving a Style object (it expected a dictionary and tried to assign keys like data["x"] = ...).
Patch: Updated _get_agent_data_* functions to convert Style objects to dictionaries using dataclasses.asdict before processing.
Patch: Updated chart_property_layers to handle both the old dictionary-based portrayal (for backward compatibility) and the new callable/Style object format.

3. `tests/test_components_matplotlib.py` -
Updated the deprecated import mesa.experimental.cell_space to mesa.discrete_space.

**Testing**
Ran pytest tests/test_solara_viz.py - Passed (warnings removed).
Ran pytest tests/test_components_matplotlib.py - Passed.
Ran full visualization suite (tests/test_backends.py included) - All passed.

Related Issue Resolves #2904