### PR TITLE
Fix: Handle capacity=None in Cell.is_full property

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -135,7 +135,7 @@ class Cell:
     def is_full(self) -> bool:
         """Returns a bool of the contents of a cell."""
         if self.capacity is None:
-            return False  
+            return False
         return len(self.agents) >= self.capacity
 
     @property

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -605,28 +605,28 @@ def test_cell():
 def test_cell_is_full_with_none_capacity():
     cell = Cell((0, 0), capacity=None)
     assert cell.is_full is False
-    
+
     model = Model()
     for _ in range(100):
         agent = CellAgent(model)
         agent._mesa_cell = cell
         cell._agents.append(agent)
-    
+
     assert cell.is_full is False
 
 
 def test_cell_is_full_with_finite_capacity():
     cell = Cell((0, 0), capacity=3)
     model = Model()
-    
+
     assert cell.is_full is False
-    
+
     cell.add_agent(CellAgent(model))
     assert cell.is_full is False
-    
+
     cell.add_agent(CellAgent(model))
     assert cell.is_full is False
-    
+
     cell.add_agent(CellAgent(model))
     assert cell.is_full is True
 


### PR DESCRIPTION
Fixes #2980

This PR fixes the type comparison error in `Cell.is_full` when `capacity=None`.

### Changes
- Add explicit `None` check for infinite capacity
- Change `==` to `>=` to handle edge cases where agents exceed capacity
- Add comprehensive tests covering None capacity, finite capacity, and edge cases

### Testing
All new tests pass:
- [test_cell_is_full_with_none_capacity](cci:1://file:///c:/Users/Nithi/OneDrive/Pictures/Desktop/gsoc/mesa/tests/test_cell_is_full_fix.py:9:0-24:32)
- [test_cell_is_full_with_finite_capacity](cci:1://file:///c:/Users/Nithi/OneDrive/Pictures/Desktop/gsoc/mesa/tests/test_cell_is_full_fix.py:27:0-51:31)  
- `test_cell_is_full_with_capacity_exceeded`