### PR TITLE
Fix #2996: Prevent infinite loop in Grid.select_random_empty_cell()

### DIFF
--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -150,6 +150,14 @@ class Grid(DiscreteSpace[T], HasPropertyLayers):
         # https://github.com/mesa/mesa/issues/1052 and
         # https://github.com/mesa/mesa/pull/1565. The cutoff value provided
         # is the break-even comparison with the time taken in the else branching point.
+
+        # Check if there are any empty cells to avoid infinite loop
+        if not self.empties:
+            raise ValueError(
+                "Cannot select random empty cell: grid is full. "
+                "Check grid.empties or grid.exists_empty_cells() before calling."
+            )
+
         if self._try_random:
             while True:
                 cell = self.all_cells.select_random_cell()

--- a/tests/test_discrete_space.py
+++ b/tests/test_discrete_space.py
@@ -1046,3 +1046,20 @@ def test_copying_discrete_spaces():  # noqa: D103
     for c1, c2 in zip(grid.all_cells, grid_copy.all_cells):
         for k, v in c1.connections.items():
             assert v.coordinate == c2.connections[k].coordinate
+
+
+def test_select_random_empty_cell_on_full_grid():
+    """Test that select_random_empty_cell raises ValueError when grid is full."""
+    model = Model()
+    grid = OrthogonalMooreGrid(dimensions=(3, 3), capacity=1, random=model.random)
+
+    for cell in grid.all_cells:
+        agent = CellAgent(model)
+        agent.cell = cell
+
+    assert len(grid.empties) == 0
+
+    with pytest.raises(
+        ValueError, match="Cannot select random empty cell: grid is full"
+    ):
+        grid.select_random_empty_cell()


### PR DESCRIPTION
Fixes #2996

## Problem
The `Grid.select_random_empty_cell()` method enters an infinite loop when all cells are occupied, causing the program to hang forever with no error message.

## Solution
- Added check for empty cells before the `while True` loop
- Raises `ValueError` with helpful message when grid is full
- Prevents silent hang and provides clear feedback to users

## Changes
- [mesa/discrete_space/grid.py](cci:7://file:///c:/Users/Nithi/OneDrive/Pictures/Desktop/gsoc/mesa/mesa/discrete_space/grid.py:0:0-0:0): Added empty cell validation
- [tests/test_discrete_space.py](cci:7://file:///c:/Users/Nithi/OneDrive/Pictures/Desktop/gsoc/mesa/tests/test_discrete_space.py:0:0-0:0): Added test case for full grid scenario

