### PR TITLE
Fix hacky RNG access in legacy Space classes and add tests

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -37,7 +37,8 @@ class TestSingleGrid(unittest.TestCase):
         # The height needs to be even to test the edge case described in PR #1517
         height = 6  # height of grid
         width = 3  # width of grid
-        self.grid = SingleGrid(width, height, self.torus)
+        self.rng = random.Random(42)
+        self.grid = SingleGrid(width, height, self.torus, random=self.rng)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -224,7 +225,8 @@ class TestSingleGridEnforcement(unittest.TestCase):
         """Create a test non-toroidal grid and populate it with Mock Agents."""
         width = 3
         height = 5
-        self.grid = SingleGrid(width, height, True)
+        self.rng = random.Random(42)
+        self.grid = SingleGrid(width, height, True, random=self.rng)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -294,7 +296,8 @@ class TestMultiGrid(unittest.TestCase):
         """Create a test non-toroidal grid and populate it with Mock Agents."""
         width = 3
         height = 5
-        self.grid = MultiGrid(width, height, self.torus)
+        self.rng = random.Random(42)
+        self.grid = MultiGrid(width, height, self.torus, random=self.rng)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -343,7 +346,8 @@ class TestHexSingleGrid(unittest.TestCase):
         """Create a test non-toroidal grid and populate it with Mock Agents."""
         width = 3
         height = 5
-        self.grid = HexSingleGrid(width, height, torus=False)
+        self.rng = random.Random(42)
+        self.grid = HexSingleGrid(width, height, torus=False, random=self.rng)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -391,7 +395,8 @@ class TestHexSingleGridTorus(TestSingleGrid):
         """Create a test non-toroidal grid and populate it with Mock Agents."""
         width = 3
         height = 5
-        self.grid = HexSingleGrid(width, height, torus=True)
+        self.rng = random.Random(42)
+        self.grid = HexSingleGrid(width, height, torus=True, random=self.rng)
         self.agents = []
         counter = 0
         for x in range(width):
@@ -428,7 +433,7 @@ class TestHexSingleGridTorus(TestSingleGrid):
 
 class TestIndexing:  # noqa: D101
     # Create a grid where the content of each coordinate is a tuple of its coordinates
-    grid = SingleGrid(3, 5, True)
+    grid = SingleGrid(3, 5, True, random=random.Random(42))
     for _, pos in grid.coord_iter():
         x, y = pos
         grid._grid[x][y] = pos


### PR DESCRIPTION
**Title:** Fix hacky RNG access in legacy Space classes & standardize random parameter

**Description:** This PR resolves the issue where legacy space classes (`_Grid`, `ContinuousSpace`, `NetworkGrid`) relied on a "hacky" pattern to access the Random Number Generator (RNG) by attempting to access `agents[0].random`. This approach was fragile and inconsistent with the newer `DiscreteSpace` architecture.

This update standardizes RNG management across these classes by allowing the RNG to be passed directly during initialization.

**Changes:**

-  **Refactor space.py:**

1. Added a helper function _get_rng_for_agentset() to centralize the logic for extracting the RNG.
2. Updated the constructors for _Grid, ContinuousSpace, and NetworkGrid to accept a random parameter.
3. These classes now store self.random. If random is not provided, a UserWarning is issued to the user.
4. Updated _PropertyGrid to pass the random parameter through to its parent _Grid class.

- **Tests:**
1. Added TestSpaceRandomParameter to tests/test_space.py containing 10 new tests.
2. These tests verify that the random parameter is stored correctly, that warnings are issued when it is missing, and that the agents property correctly utilizes the space's RNG.

**Verification:** Ran the full test suite for space and grid. All 144 tests passed, including the 10 new tests covering this implementation.

**API Changes / Deprecation**: This introduces a soft deprecation for initializing legacy spaces without an RNG.
Before: `grid = SingleGrid(10, 10, torus=False)`  (Now emits UserWarning).
After: `grid = SingleGrid(10, 10, torus=False, random=model.random)` (Recommended).
