### PR TITLE
CI: Split off separate coverage job

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""init of tests."""


### PR DESCRIPTION
After moving tests into subdirectories in, coverage.py consistently reported 0% coverage due to a conflict between pytest-cov and the new test package structure.

Changes:
- Replace `pytest --cov` with `coverage run -m pytest`
- Split coverage into dedicated CI job (Ubuntu 3.14 only)
- Remove coverage overhead from cross-platform test runs

This is a workaround for https://github.com/mesa/mesa/issues/3004.