### PR TITLE
Model: remove unreleased `step_duration` parameter

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -53,7 +53,6 @@ class Model:
         *args: Any,
         seed: float | None = None,
         rng: RNGLike | SeedLike | None = None,
-        step_duration: float = 1.0,
         **kwargs: Any,
     ) -> None:
         """Create a new model.
@@ -67,7 +66,6 @@ class Model:
             rng : Pseudorandom number generator state. When `rng` is None, a new `numpy.random.Generator` is created
                   using entropy from the operating system. Types other than `numpy.random.Generator` are passed to
                   `numpy.random.default_rng` to instantiate a `Generator`.
-            step_duration: How much time advances each step (default 1.0)
             kwargs: keyword arguments to pass onto super
 
         Notes:
@@ -78,7 +76,6 @@ class Model:
         self.running: bool = True
         self.steps: int = 0
         self.time: float = 0.0
-        self._step_duration: float = step_duration
 
         # Track if a simulator is controlling time
         self._simulator: Simulator | None = None
@@ -127,7 +124,7 @@ class Model:
         self.steps += 1
         # Only auto-increment time if no simulator is controlling it
         if self._simulator is None:
-            self.time += self._step_duration
+            self.time += 1
 
         _mesa_logger.info(
             f"calling model.step for step {self.steps} at time {self.time}"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -13,7 +13,6 @@ def test_model_set_up():
     assert model.running is True
     assert model.steps == 0
     assert model.time == 0.0
-    assert model._step_duration == 1.0
     assert model._simulator is None
 
     model.step()
@@ -29,33 +28,6 @@ def test_model_time_increment():
         model.step()
         assert model.steps == i + 1
         assert model.time == float(i + 1)
-
-
-def test_model_step_duration():
-    """Test custom step_duration."""
-    # Default step_duration
-    model = Model()
-    model.step()
-    assert model.time == 1.0
-
-    # Custom step_duration
-    model = Model(step_duration=0.25)
-    assert model._step_duration == 0.25
-
-    model.step()
-    assert model.steps == 1
-    assert model.time == 0.25
-
-    model.step()
-    assert model.steps == 2
-    assert model.time == 0.5
-
-    # Larger step_duration
-    model = Model(step_duration=10.0)
-    model.step()
-    assert model.time == 10.0
-    model.step()
-    assert model.time == 20.0
 
 
 def test_model_time_with_simulator():


### PR DESCRIPTION
### Summary
Removes the `step_duration` parameter from `Model.__init__()`. Since this was added in #2903 but not yet released, it can be removed without deprecation.

### Motive
The `step_duration` parameter conflicts with Mesa's direction of making `model.time` the universal source of truth and eventually deprecating `steps`. Having configurable step duration confuses the mental model (users must understand how discrete steps map to continuous time), complicates future migration (we'd need to explain what happens to `step_duration` when `steps` is deprecated), and serves limited real-world use cases (non-unit step durations are rarely needed and can be handled via discrete event simulators). Removing it now gives us simple, predictable behavior (each `step()` advances time by 1.0) and a clean path to eventually deprecate `steps` in favor of `model.time`.

If our vision what that `model.steps` is a core feature, it made sense. But the direction is to move to `time`, so a new steps feature doesn't make much sense.

I also violated the principle of atomic PRs by adding it in #2903. It should have been a separate discussion, PR and review process. Sorry.

### Implementation
Remove from `Model.__init__()`:
- `step_duration: float = 1.0` parameter
- `self._step_duration: float = step_duration` attribute
- Update `_wrapped_step()` to use `self.time += 1.0` instead of `self.time += self._step_duration`
- Remove `step_duration` from docstring

### Additional Notes
- Aligns with vision in #2228 and https://github.com/mesa/mesa/discussions/2921
- No migration guide needed (unreleased feature)
- Advanced users can still control time via discrete event simulators