### PR TITLE
Update `from __future__ import annotations` comment

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -3,8 +3,7 @@
 Core Objects: Agent and AgentSet.
 """
 
-# Mypy; for the `|` operator purpose
-# Remove this __future__ import once the oldest supported Python is 3.10
+# Postpone annotation evaluation to avoid NameError from forward references (PEP 563). Remove once Python 3.14+ is required.
 from __future__ import annotations
 
 import contextlib

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -3,8 +3,7 @@
 Core Objects: Model
 """
 
-# Mypy; for the `|` operator purpose
-# Remove this __future__ import once the oldest supported Python is 3.10
+# Postpone annotation evaluation to avoid NameError from forward references (PEP 563). Remove once Python 3.14+ is required.
 from __future__ import annotations
 
 import random

--- a/mesa/space.py
+++ b/mesa/space.py
@@ -21,8 +21,7 @@ Classes
 * NetworkGrid: a network where each node contains zero or more agents.
 """
 
-# Mypy; for the `|` operator purpose
-# Remove this __future__ import once the oldest supported Python is 3.10
+# Postpone annotation evaluation to avoid NameError from forward references (PEP 563). Remove once Python 3.14+ is required.
 from __future__ import annotations
 
 import collections


### PR DESCRIPTION
The `from __future__ import annotations` statements were originally added to enable the `|` union operator for type hints in Python 3.9. Now that Python 3.10 is the minimum supported version (where [PEP 604](https://peps.python.org/pep-0604/) union syntax is natively available), these imports are no longer necessary and can be safely removed from agent.py, model.py, and space.py.
