### PR TITLE
ci: restore coverage reporting and adopt best practices

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -74,8 +74,7 @@ jobs:
       - run: uv pip install --system .[dev]
       - run: playwright install chromium-headless-shell
       - run: |
-          coverage run -m pytest tests/
-          coverage xml
+          pytest -p pytest_cov --cov --cov-report=xml --cov-report=markdown-append:"${GITHUB_STEP_SUMMARY}" --cov-context=test tests/
       - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,9 @@ repository = "https://github.com/mesa/mesa"
 ignore-words-list = ["ist", "hart", "nD"]
 
 [tool.coverage.run]
-source = ["mesa"]
+source_pkgs = ["mesa"]
 branch = true
-omit = ["tests/*"]
+relative_files = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["mesa"]


### PR DESCRIPTION
Closes #3004
This PR fixes the 0% coverage reporting issue caused by the test directory reorganization (#2994) and adopts coverage best practices.
The Fix:
relative_files = true: Enabled in pyproject.toml to correctly map coverage paths across subdirectories.
source_pkgs = ["mesa"]: Switched from directory-based to package-based source discovery.
Removed omit = ["tests/*"]: Ensures tests are included in coverage metrics (best practice to detect dead test code).
Standard CI Invocation: Switched CI to use pytest -p pytest_cov, ensuring proper plugin loading and integration.