### PR TITLE
Refactor PropertyLayer to implement NumPy interface

### DIFF
--- a/mesa/discrete_space/property_layer.py
+++ b/mesa/discrete_space/property_layer.py
@@ -26,6 +26,7 @@ from mesa.discrete_space import Cell
 Coordinate = Sequence[int]
 T = TypeVar("T", bound=Cell)
 
+
 class PropertyLayer:
     """A class representing a layer of properties in a two-dimensional grid.
 
@@ -131,12 +132,10 @@ class PropertyLayer:
             mask = condition(self.data)
             target_data = self.data[mask]
 
-        if(isinstance(operation,np.ufunc)):
-            if(ufunc_requires_additional_input(operation)):
+        if isinstance(operation, np.ufunc):
+            if ufunc_requires_additional_input(operation):
                 if value is None:
-                    raise ValueError(
-                        "This ufunc requires an additional input value."
-                    )
+                    raise ValueError("This ufunc requires an additional input value.")
                 self.data[mask] = operation(target_data, value)
             else:
                 self.data[mask] = operation(target_data)


### PR DESCRIPTION
### Summary

Refactors `PropertyLayer` to serve as a direct wrapper around the underlying NumPy array, enabling standard NumPy syntax (slicing, broadcasting and methods)

### Motive

The current `PropertyLayer` class acts as an overly complex wrapper that duplicates native NumPy functionality with custom methods like `set_cells` and `modify_cells`. This design:

* **Violates Pythonic principles:** It hides standard operations behind a slower, restrictive API ("explicit is better than implicit").
* **Hinders Performance:** Methods like `modify_cells` rely on `np.vectorize` for lambdas, which is significantly slower than native ufuncs and broadcasting.
* **Blocks Future Architecture:** As discussed regarding the [`model.world`](https://github.com/mesa/mesa/discussions/2585) vision, layers should ideally be flexible views on data. The current design tightly couples data to legacy access patterns, acting as an obstacle to the "Single Source of Truth" concept.

### Implementation

1. **Direct exposure of NumPy data**

* Replaced the internal attribute `_mesa_data` with a public attribute `data`
* `data` is now a **public NumPy array**, enabling slicing, masking, and aggregation without wrappers
* Eliminates unnecessary `np.copyto` overhead.

2. **More efficient in-place updates**

* `set_cells` and `modify_cells` now operate directly on `self.data`.
* Conditional updates use boolean masks instead of rebuilding arrays.

3. **Improved `modify_cells` semantics**
