### PR TITLE
Update alliance formation mode

### DIFF
--- a/mesa/examples/advanced/alliance_formation/model.py
+++ b/mesa/examples/advanced/alliance_formation/model.py
@@ -62,7 +62,7 @@ class MultiLevelAllianceModel(mesa.Model):
         Returns:
             tuple: Potential utility, new position, and level.
         """
-        (agent_0,) = agents[0]
+        agent_0 = agents[0]
         agent_1 = agents[1]
 
         positions = agents.get("position")


### PR DESCRIPTION
This PR updates the shapley value calculation in the alliance formation model. 

The old implementation heavily relies on indexing on an agent set, which is painfully slow. In a benchmark on all example models, for 100 steps each, this one method was responsible for 15% of the total runtime, simply due to indexing on agentsets (i.e., `model.agents[5]`) being so slow.

This PR avoids the problem by destructing the list into the two agents and using these in all places were indexing was used. 

I'll raise a separate issue about `AgentSet.__getitem__` later. 