### PR TITLE
Update cell.is_empty 

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -73,6 +73,7 @@ class Cell:
             Coordinate, object
         ] = {}  # fixme still used by voronoi mesh
         self.random = random
+        self.empty = True
 
     def connect(self, other: Cell, key: Coordinate | None = None) -> None:
         """Connects this cell to another cell.
@@ -124,12 +125,12 @@ class Cell:
 
         """
         self._agents.remove(agent)
-        self.empty = self.is_empty
+        self.empty = len(self._agents) == 0
 
     @property
     def is_empty(self) -> bool:
         """Returns a bool of the contents of a cell."""
-        return len(self._agents) == 0
+        return self.empty
 
     @property
     def is_full(self) -> bool:


### PR DESCRIPTION
This PR changes the internal implementation of `Cell.is_empty`. It now always just returns `self.empty`. `self.empty` is maintained via `Cell.add_agent` and `Cell.remove_agent`. 

The reason for this change is performance. As part of my ongoing profiling, I noticed that `Cell.is_empty` tok close 15% of all runtime when running all examples in `mesa.examples` for 100 steps each. This PR should reduce that substantially. 

This PR interacts with #3072, and makes solving that even more important.