### PR TITLE
Mark whole `mesa.space` module maintenance-only

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -3,13 +3,9 @@
 Objects used to add a spatial component to a model.
 
 .. note::
-    All Grid classes (:class:`_Grid`, :class:`SingleGrid`, :class:`MultiGrid`,
-    :class:`HexGrid`, etc.) are now in maintenance-only mode. While these classes remain
-    fully supported, new development occurs in the experimental cell space module
-    (:mod:`mesa.discrete_space`).
-
-    The :class:`PropertyLayer` and :class:`ContinuousSpace` classes remain fully supported
-    and actively developed.
+    mesa.space now in maintenance-only mode. While these classes remain
+    fully supported, new development occurs in the discrete space module
+    (:mod:`mesa.discrete_space`) and the experimental ContinuousSpace module
 
 Classes
 -------


### PR DESCRIPTION
This PR updates the maintenance statement in `mesa.space` to reflect that `mesa.space` is now maintenance-only.

The `mesa.space` `Grid` classes were already marked maintenance-only last year in https://github.com/mesa/mesa/pull/2420.