### PR TITLE
Resolve fixme in `discrete_space/cell.py`

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from mesa.discrete_space.cell_agent import CellAgent
 from mesa.discrete_space.cell_collection import CellCollection
+from mesa.errors import CellFullError
 
 if TYPE_CHECKING:
     from mesa.agent import Agent
@@ -110,9 +111,7 @@ class Cell:
         self.empty = False
 
         if self.capacity is not None and n >= self.capacity:
-            raise Exception(
-                "ERROR: Cell is full"
-            )  # FIXME we need MESA errors or a proper error
+            raise CellFullError()
 
         self._agents.append(agent)
 

--- a/mesa/errors.py
+++ b/mesa/errors.py
@@ -1,0 +1,13 @@
+"""Custom exceptions for Mesa."""
+
+
+class MesaError(Exception):
+    """Base class for all Mesa exceptions."""
+
+
+class CellFullError(MesaError):
+    """Raised when a cell is full."""
+
+    def __init__(self):
+        """Initialize the exception."""
+        super().__init__("ERROR: Cell is full")

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -4,6 +4,7 @@ import copy
 import pickle
 import random
 import re
+import unittest
 
 import networkx as nx
 import numpy as np
@@ -23,6 +24,29 @@ from mesa.discrete_space import (
     PropertyLayer,
     VoronoiGrid,
 )
+from mesa.errors import CellFullError
+
+
+class MockCellAgent(CellAgent):
+    """Minimalistic agent for testing purposes."""
+
+    def __init__(self, unique_id):
+        """Create a new agent."""
+        self.unique_id = unique_id
+
+
+class TestCell(unittest.TestCase):
+    """Testing the Cell object."""
+
+    def test_add_agent_to_full_cell(self):
+        """Test that adding an agent to a full cell raises a CellFullError."""
+        cell = Cell(coordinate=(0, 0), capacity=1)
+        agent1 = MockCellAgent(1)
+        cell.add_agent(agent1)
+
+        agent2 = MockCellAgent(2)
+        with self.assertRaises(CellFullError):
+            cell.add_agent(agent2)
 
 
 def test_orthogonal_grid_neumann():


### PR DESCRIPTION
### Summary
A generic `Exception` was raised when an agent was added to a full cell. This has been replaced by a specific `CellFullError` exception to allow for more precise error handling.

### Bug / Issue
Previously, attempting to add an agent to a cell that was at full capacity would raise a generic `Exception`.
The expected behavior is to raise a distinct, custom exception that clearly indicates the nature of the error.

### Implementation
A new `mesa/errors.py` module was created to serve as a central location for custom Mesa exceptions.
A base `MesaError` class was introduced to act as the parent for all custom exceptions in the library.
The `CellFullError` exception, inheriting from `MesaError`, was added to specifically handle cases where a cell's capacity is exceeded.

### Testing
A new unit test, `test_add_agent_to_full_cell`, was added to `tests/discrete_space/test_discrete_space.py`.
This test confirms that a `CellFullError` is raised as expected when an attempt is made to add an agent to a cell that is already full.

### Additional Notes
This change establishes a new pattern for error handling in Mesa by introducing a dedicated module for custom exceptions.
One of my doubts is, whether I have created the module at the right place? with the appropriate naming?
Thanks.