### PR TITLE
Optimize `_Grid.move_to_empty` by removing unnecessary sort

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -566,7 +566,7 @@ class _Grid:
                 if self.is_cell_empty(new_pos):
                     break
         else:
-            new_pos = agent.random.choice(sorted(self.empties))
+            new_pos = agent.random.choice(list(self.empties))
         self.remove_agent(agent)
         self.place_agent(agent, new_pos)
 


### PR DESCRIPTION
### Summary
This change optimizes the `_Grid.move_to_empty` method in `mesa/space.py` by removing an unnecessary sorting operation, improving its performance.

### Motive
The previous implementation involved sorting the `self.empties` set before making a random choice. Since sets are inherently unordered, sorting them on every call is a computationally expensive and unnecessary operation, especially in large grids with many empty cells.

### Implementation
The implementation was modified to convert the `self.empties` set directly to a list instead of sorting it. This avoids the `O(n log n)` complexity of sorting in favor of the `O(n)` complexity of list conversion.

### Usage Examples
<!-- Provide code snippets or examples demonstrating how to use the new feature. Highlight key scenarios where this feature will be beneficial.

If you're modifying the visualisation, add before/after screenshots. -->

### Additional Notes
The selection of an empty cell remains random. The order of elements in a set is arbitrary, so sorting it before making a random choice does not make the choice any more or less random.
