### PR TITLE
Document `Agent` hashability requirement

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -36,8 +36,9 @@ class Agent[M: Model]:
         pos (Position): A reference to the position where this agent is located.
 
     Notes:
-        Agents must be hashable to be stored in AgentSets. If you override
-        __eq__(), you must also implement __hash__() to maintain hashability.
+        Agents must be hashable to be used in an AgentSet.
+        In Python 3, defining `__eq__` without `__hash__` makes an object unhashable,
+        which will break AgentSet usage.
         unique_id is unique relative to a model instance and starts from 1
 
     """


### PR DESCRIPTION
### Summary
Clarifies the requirement for Mesa agents to be hashable and adds tests to verify this behavior, particularly when `__eq__` is overridden in subclasses.

### Motive
`AgentSet` requires agents to be hashable because it uses them in a `WeakKeyDictionary`. This requirement was previously implicit. An earlier attempt to enforce this via the type system (`collections.abc.Hashable`) was reverted due to significant performance regressions.

### Implementation

### Usage Examples
<!-- Provide code snippets or examples demonstrating how to use the new feature. Highlight key scenarios where this feature will be beneficial.

If you're modifying the visualisation, add before/after screenshots. -->

### Additional Notes
