### PR TITLE
Target main branch for Mesa 4 development

### DIFF
--- a/mesa/__init__.py
+++ b/mesa/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 __title__ = "mesa"
-__version__ = "3.5.0.dev"
+__version__ = "4.0.0.dev"
 __license__ = "Apache 2.0"
 _this_year = datetime.datetime.now(tz=datetime.UTC).date().year
 __copyright__ = f"Copyright {_this_year} Mesa Team"


### PR DESCRIPTION
Bump version from `3.5.0.dev` to `4.0.0.dev`.

Before merge, a `3.x` branch will be split of.

Part of #3132.