### PR TITLE
Cell.remove_agent shift to swap-remove

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -131,7 +131,12 @@ class Cell:
             agent (CellAgent): agent to remove from this cell
 
         """
-        self._agents.remove(agent)
+        # super nerdy swap remove trick to make removal faster
+        _agents = self._agents
+        index = _agents.index(agent)
+        _agents[index] = _agents[-1]
+        _agents.pop()
+
         self.empty = self.is_empty
 
     @property


### PR DESCRIPTION
Cell._agents is a list. Removing agents from lists can be slow. So this is quick check to see if a swap remove is faster. In short, you look up the index of the agent to remove (O(n)), swap this agent with the last agent in the list, and pop off the last agent (O(1)), instead of shifting all agents after index up. Local testing suggests a modest speed-up in some cases. 