### PR TITLE
Feat: Introduce minimal Mesa-specific exception hierarchy in mesa/errors.py

### DIFF
--- a/mesa/errors.py
+++ b/mesa/errors.py
@@ -23,8 +23,7 @@ class MesaError(Exception):
     """
 
     def __init__(self, message: str):
-        """
-        Initialize a MesaError.
+        """Initialize a MesaError.
 
         Args:
             message (str): The error message.


### PR DESCRIPTION
### Summary

This PR introduces a minimal, safe, and non-breaking **Mesa-specific exception hierarchy**.  
It defines a **base exception (`MesaError`)** and three **domain-specific subclasses**:

- `ModelError` – for errors related to model configuration, initialization, or execution
- `AgentError` – for errors related to agent lifecycle or behavior
- `SpaceError` – for errors related to spaces, grids, movement, or spatial constraints

This provides a **foundation for future exception standardization** and migration of existing generic exceptions.

---

### Motivation

- Issue #3132 tracks Mesa 4 development and highlights the need for a **dedicated exception hierarchy**.
- A previous attempt (closed PR #2992) proposed a full hierarchy, but it was too large and unmergeable at the time.
- This PR intentionally takes a **minimal and incremental approach**, allowing the hierarchy to be **adopted gradually**.

---

### Key Features

- Uses `from __future__ import annotations` to avoid circular import issues
- Defines `__all__` for a clean, explicit public API
- Safely stores Mesa version using `importlib.metadata` without importing `mesa`
- Empty domain-specific subclasses include `pass` for linter compliance
- Non-breaking: does not change any existing behavior or messages
- Ready for **future migration** of existing exceptions in Space, Model, or Agent modules

---

### Example Usage

```python
from mesa.errors import MesaError, SpaceError

# Raising a domain-specific exception
if not self.is_cell_empty(pos):
    raise SpaceError(f"Cell {pos} is already occupied")

# Catching all Mesa exceptions safely
try:
    model.step()
except MesaError as e:
    print(f"Mesa error occurred (v{e.mesa_version}): {e}")

```
- [🛠 Feature/enhancement](?expand=1&template=feature.md)
