### PR TITLE
Revert "Deprecate `model.steps` in favor of `model.time`"

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -3,29 +3,7 @@ This guide contains breaking changes between major Mesa versions and how to reso
 
 Non-breaking changes aren't included, for those see our [Release history](https://github.com/mesa/mesa/releases).
 
-## Mesa 3.5
-### model steps deprecated
-`model.steps` is deprecated and will be removed in Mesa 4.0. Use `model.time` instead.
-
-Previously, time in Mesa was fragmented: simple models used `model.steps` as a proxy for time, while discrete event simulations stored time separately in `simulator.time`.
-`model.time` is now the single, canonical source of simulation time in Mesa.
-
-For most use cases, simply replace `model.steps` with `model.time`. Since `model.time` is a float that increments by 1.0 per step by default, the numerical values will be equivalent.
-
-```python
-# Old
-current = model.steps
-
-# New
-current = model.time
-
-# If you need an integer step count, cast to int
-current = int(model.time)
-```
-
-- Ref: [PR #3136](https://github.com/projectmesa/mesa/pull/3136), [PR #2903](https://github.com/projectmesa/mesa/pull/2903)
-
-## Mesa 3.4
+## Mesa 3.4.0
 
 ### batch run
 `batch_run` has been updated to offer explicit control over the random seeds that are used to run multiple replications of a given experiment. For this a new keyword argument, `rng` has been added and `iterations` will issue a `DeprecationWarning`. The new `rng` keyword argument takes a valid value for seeding or a list of valid values. If you want to run multiple iterations/replications of a given experiment, you need to pass the required seeds explicitly.
@@ -51,7 +29,7 @@ results = mesa.batch_run(
 )
 ```
 
-## Mesa 3.3
+## Mesa 3.3.0
 
 Mesa 3.3.0 is a visualization upgrade introducing a new and improved API, full support for both `altair` and `matplotlib` backends, and resolving several recurring issues from previous versions.
 For full details on how to visualize your model, refer to the [Mesa Documentation](https://mesa.readthedocs.io/latest/tutorials/4_visualization_basic.html).

--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -202,7 +202,7 @@ def _model_run_func(
     run_id, iteration, kwargs = run
 
     model = model_cls(**kwargs)
-    while model.running and model._steps < max_steps:
+    while model.running and model.steps < max_steps:
         model.step()
 
     data = []
@@ -212,9 +212,9 @@ def _model_run_func(
         recorded_steps = model.datacollector._collection_steps
     except AttributeError:
         # Fallback for legacy models without _collection_steps
-        steps = list(range(0, model._steps, data_collection_period))
-        if not steps or steps[-1] != model._steps - 1:
-            steps.append(model._steps - 1)
+        steps = list(range(0, model.steps, data_collection_period))
+        if not steps or steps[-1] != model.steps - 1:
+            steps.append(model.steps - 1)
     else:
         match data_collection_period:
             case -1:

--- a/mesa/examples/advanced/epstein_civil_violence/model.py
+++ b/mesa/examples/advanced/epstein_civil_violence/model.py
@@ -126,7 +126,7 @@ class EpsteinCivilViolence(mesa.Model):
         self._update_counts()
         self.datacollector.collect(self)
 
-        if self.time > self.max_iters:
+        if self.steps > self.max_iters:
             self.running = False
 
     def _update_counts(self):

--- a/mesa/examples/advanced/sugarscape_g1mt/model.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/model.py
@@ -164,11 +164,11 @@ class SugarscapeG1mt(mesa.Model):
         """
         # Need to remove excess data
         # Create local variable to store trade data
-        agent_trades = self.datacollector._agent_records[self.time]
+        agent_trades = self.datacollector._agent_records[self.steps]
         # Get rid of all None to reduce data storage needs
         agent_trades = [agent for agent in agent_trades if agent[2] is not None]
         # Reassign the dictionary value with lean trade data
-        self.datacollector._agent_records[self.time] = agent_trades
+        self.datacollector._agent_records[self.steps] = agent_trades
 
     def run_model(self, step_count=1000):
         for _ in range(step_count):

--- a/mesa/examples/basic/schelling/analysis.ipynb
+++ b/mesa/examples/basic/schelling/analysis.ipynb
@@ -60,9 +60,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while schelling_model.running and schelling_model.time < 100:\n",
+    "while schelling_model.running and schelling_model.steps < 100:\n",
     "    schelling_model.step()\n",
-    "print(schelling_model.time)  # Show how many steps have actually run"
+    "print(schelling_model.steps)  # Show how many steps have actually run"
    ]
   },
   {

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import random
 import sys
-import warnings
 from collections.abc import Sequence
 
 # mypy
@@ -37,8 +36,7 @@ class Model[A: Agent]:
 
     Attributes:
         running: A boolean indicating if the model should continue running.
-        steps: (Deprecated) the number of times `model.step()` has been called.
-               Use `model.time` instead.
+        steps: the number of times `model.step()` has been called.
         time: the current simulation time. Automatically increments by 1.0
               with each step unless controlled by a discrete event simulator.
         random: a seeded python.random number generator.
@@ -91,7 +89,7 @@ class Model[A: Agent]:
         """
         super().__init__(*args, **kwargs)
         self.running: bool = True
-        self._steps: int = 0
+        self.steps: int = 0
         self.time: float = 0.0
 
         # Track if a simulator is controlling time
@@ -151,48 +149,16 @@ class Model[A: Agent]:
             [], random=self.random
         )  # an agenset with all agents
 
-    @property
-    def steps(self) -> int:
-        """Return the number of steps the model has taken.
-
-        Deprecated: Use `model.time` instead.
-        """
-        warnings.warn(
-            "model.steps is deprecated and will be removed in a future Mesa release. "
-            "Use model.time instead, which provides the same functionality for "
-            "discrete-time models and also supports continuous time with DEVS. "
-            "See: https://mesa.readthedocs.io/latest/migration_guide.html#model-steps-deprecated",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self._steps
-
-    @steps.setter
-    def steps(self, value: int) -> None:
-        """Set the number of steps.
-
-        Deprecated: Use `model.time` instead.
-        """
-        warnings.warn(
-            "model.steps is deprecated and will be removed in a future Mesa release. "
-            "Use model.time instead, which provides the same functionality for "
-            "discrete-time models and also supports continuous time with DEVS. "
-            "See: https://mesa.readthedocs.io/latest/migration_guide.html#model-steps-deprecated",
-            FutureWarning,
-            stacklevel=2,
-        )
-        self._steps = value
-
     def _wrapped_step(self, *args: Any, **kwargs: Any) -> None:
         """Automatically increments time and steps after calling the user's step method."""
         # Automatically increment time and step counters
-        self._steps += 1
+        self.steps += 1
         # Only auto-increment time if no simulator is controlling it
         if self._simulator is None:
             self.time += 1
 
         _mesa_logger.info(
-            f"calling model.step for step {self._steps} at time {self.time}"
+            f"calling model.step for step {self.steps} at time {self.time}"
         )
         # Call the original user-defined step method
         self._user_step(*args, **kwargs)

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -948,4 +948,4 @@ def copy_renderer(renderer: SpaceRenderer, model: Model):
 def ShowSteps(model):
     """Display the current step of the model."""
     update_counter.get()
-    return solara.Text(f"Time: {model.time}")
+    return solara.Text(f"Step: {model.steps}")

--- a/tests/experimental/test_devs.py
+++ b/tests/experimental/test_devs.py
@@ -129,7 +129,7 @@ def test_abm_simulator():
     assert len(simulator.event_list) == 2
 
     simulator.run_for(3)
-    assert model._steps == 3
+    assert model.steps == 3
     assert model.time == 3.0
 
     # run_until without setup

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -370,7 +370,7 @@ def test_batch_run_legacy():
             self.schedule = None
             super().__init__()
             self.datacollector = DataCollector(
-                model_reporters={"Step": lambda m: m._steps},
+                model_reporters={"Step": lambda m: m.steps},
                 agent_reporters={"Dummy": lambda a: 1},
             )
             # FORCE LEGACY: Delete _collection_steps attribute manually
@@ -388,7 +388,7 @@ def test_batch_run_legacy():
     # Period = 2
     # range(0, 6, 2) generates -> [0, 2, 4]
     # The last model step is 5.
-    # steps[-1] (4) != model._steps-1 (5).
+    # steps[-1] (4) != model.steps-1 (5).
     # This forces the code to execute: steps.append(5)
     results = mesa.batch_run(
         LegacyModel,
@@ -504,12 +504,12 @@ class SparseCollectionModel(Model):
 
     def step(self):
         """Execute one model step, collecting data at specified intervals."""
-        if self._steps % self.collect_interval == 0:
+        if self.steps % self.collect_interval == 0:
             self.datacollector.collect(self)
 
         self.agent.step()
 
-        if self._steps >= 20:
+        if self.steps >= 20:
             self.running = False
 
 
@@ -761,11 +761,11 @@ def test_batch_run_agenttype_and_agent_reporters():
         def __init__(self, model, wealth):
             super().__init__(model)
             self.wealth = wealth
-            self._steps = 0
+            self.steps = 0
 
         def step(self):
             self.wealth += 1
-            self._steps += 1
+            self.steps += 1
 
     class MixedReportersModel(Model):
         """Model with both agent_reporters and agenttype_reporters."""
@@ -776,7 +776,7 @@ def test_batch_run_agenttype_and_agent_reporters():
             self.datacollector = DataCollector(
                 model_reporters={"agent_count": lambda m: len(m.agents)},
                 agent_reporters={"wealth": "wealth"},
-                agenttype_reporters={MixedAgent: {"type_steps": "_steps"}},
+                agenttype_reporters={MixedAgent: {"type_steps": "steps"}},
             )
             for i in range(n_agents):
                 MixedAgent(self, wealth=i * 10)

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -693,7 +693,7 @@ def test_mutable_data_independence():
 
         def step(self):
             self.datacollector.collect(self)
-            self.agent.data.append(self.time)  # Modify after collection
+            self.agent.data.append(self.steps)  # Modify after collection
 
     model = MutableModel()
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -22,7 +22,7 @@ class LifeTimeModel(Model):
         self.datacollector = DataCollector(
             agent_reporters={
                 "remaining_life": lambda a: a.remaining_life,
-                "time": lambda a: a.time,
+                "steps": lambda a: a.steps,
             }
         )
 
@@ -56,13 +56,13 @@ class FiniteLifeAgent(Agent):
     def __init__(self, lifetime, model):  # noqa: D107
         super().__init__(model)
         self.remaining_life = lifetime
-        self.time = 0
+        self.steps = 0
         self.model = model
 
     def step(self):  # noqa: D102
         deactivated = self.deactivate()
         if not deactivated:
-            self.time += 1  # keep track of how many ticks are seen
+            self.steps += 1  # keep track of how many ticks are seen
             if np.random.binomial(1, 0.1) != 0:  # 10% chance of dying
                 self.remove()
 
@@ -83,7 +83,7 @@ class TestAgentLifespan(unittest.TestCase):  # noqa: D101
 
     def test_ticks_seen(self):
         """Each agent should be activated no more than one time."""
-        assert self.df.time.max() == 1
+        assert self.df.steps.max() == 1
 
     def test_agent_lifetime(self):  # noqa: D102
         lifetimes = self.df.groupby(["AgentID"]).agg({"Step": len})

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -11,12 +11,12 @@ def test_model_set_up():
     """Test Model initialization."""
     model = Model()
     assert model.running is True
-    assert model._steps == 0
+    assert model.steps == 0
     assert model.time == 0.0
     assert model._simulator is None
 
     model.step()
-    assert model._steps == 1
+    assert model.steps == 1
     assert model.time == 1.0
 
 
@@ -26,7 +26,7 @@ def test_model_time_increment():
 
     for i in range(5):
         model.step()
-        assert model._steps == i + 1
+        assert model.steps == i + 1
         assert model.time == float(i + 1)
 
 
@@ -51,12 +51,12 @@ def test_running():
     class TestModel(Model):
         def step(self):
             """Stop at step 10."""
-            if self.time >= 10:
+            if self.steps == 10:
                 self.running = False
 
     model = TestModel()
     model.run_model()
-    assert model._steps == 10
+    assert model.steps == 10
     assert model.time == 10.0
 
 


### PR DESCRIPTION
This reverts commit 7a9299c53ae9fea9859abcd58f8a529250ab16ba and PR (#3136).

I see a role for `steps` after all, and I don't think it should be removed.

Took some black magic, will show in a bit.