### PR TITLE
Add unified time and event scheduling API to Model

### DIFF
--- a/mesa/experimental/devs/__init__.py
+++ b/mesa/experimental/devs/__init__.py
@@ -18,7 +18,14 @@ The implementation supports both pure discrete event simulation and hybrid appro
 combining agent-based modeling with event scheduling.
 """
 
-from .eventlist import Priority, SimulationEvent
+from .eventlist import EventList, Priority, SimulationEvent
 from .simulator import ABMSimulator, DEVSimulator, Simulator
 
-__all__ = ["ABMSimulator", "DEVSimulator", "Priority", "SimulationEvent", "Simulator"]
+__all__ = [
+    "ABMSimulator",
+    "DEVSimulator",
+    "EventList",
+    "Priority",
+    "SimulationEvent",
+    "Simulator",
+]

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import random
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 # mypy
 from typing import Any
@@ -19,6 +19,7 @@ from mesa.agent import Agent, AgentSet
 from mesa.experimental.devs import Simulator
 from mesa.experimental.scenarios import Scenario
 from mesa.mesa_logging import create_module_logger, method_logger
+from mesa.timeflow import Priority, RunControl, Scheduler, SimulationEvent
 
 SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
 RNGLike = np.random.Generator | np.random.BitGenerator
@@ -95,6 +96,10 @@ class Model[A: Agent]:
         # Track if a simulator is controlling time
         self._simulator: Simulator | None = None
 
+        # Add timeflow components
+        self._scheduler = Scheduler(self)
+        self._run_control = RunControl(self, self._scheduler)
+
         # check if `scenario` is provided
         # and if so, whether rng is the same or not
         if scenario is not None:
@@ -151,17 +156,32 @@ class Model[A: Agent]:
 
     def _wrapped_step(self, *args: Any, **kwargs: Any) -> None:
         """Automatically increments time and steps after calling the user's step method."""
-        # Automatically increment time and step counters
+        # Automatically increment step counter
         self.steps += 1
+
+        # Schedule the user's step method to run at the next time unit
         # Only auto-increment time if no simulator is controlling it
         if self._simulator is None:
-            self.time += 1
+            self._scheduler.schedule_at(
+                callback=self._user_step,
+                time=self.time + 1,
+                priority=Priority.HIGH,
+                args=args,
+                kwargs=kwargs,
+            )
 
-        _mesa_logger.info(
-            f"calling model.step for step {self.steps} at time {self.time}"
-        )
-        # Call the original user-defined step method
-        self._user_step(*args, **kwargs)
+            _mesa_logger.info(
+                f"calling model.step for step {self.steps} at time {self.time + 1}"
+            )
+
+            # Run until that scheduled event completes
+            self.run_for(1)
+        else:
+            # Simulator is controlling time, just call the method
+            _mesa_logger.info(
+                f"calling model.step for step {self.steps} at time {self.time}"
+            )
+            self._user_step(*args, **kwargs)
 
     @property
     def agents(self) -> AgentSet[A]:
@@ -281,3 +301,45 @@ class Model[A: Agent]:
         # we need to wrap keys in a list to avoid a RunTimeError: dictionary changed size during iteration
         for agent in list(self._agents.keys()):
             agent.remove()
+
+    def schedule_at(
+        self,
+        callback: Callable,
+        time: int | float,
+        priority: Priority = Priority.DEFAULT,
+        args: list[Any] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> SimulationEvent:
+        """Schedule an event at an absolute time."""
+        return self._scheduler.schedule_at(callback, time, priority, args, kwargs)
+
+    def schedule_after(
+        self,
+        callback: Callable,
+        delay: int | float,
+        priority: Priority = Priority.DEFAULT,
+        args: list[Any] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> SimulationEvent:
+        """Schedule an event after a delay from current time."""
+        return self._scheduler.schedule_after(callback, delay, priority, args, kwargs)
+
+    def cancel_event(self, event: SimulationEvent) -> None:
+        """Cancel a scheduled event."""
+        self._scheduler.cancel(event)
+
+    def run_until(self, end_time: int | float) -> None:
+        """Run the model until the specified time."""
+        self._run_control.run_until(end_time)
+
+    def run_for(self, duration: int | float) -> None:
+        """Run the model for a specific duration."""
+        self._run_control.run_for(duration)
+
+    def run_while(self, condition: Callable[[Model], bool]) -> None:
+        """Run the model while a condition remains true."""
+        self._run_control.run_while(condition)
+
+    def run_next_event(self) -> bool:
+        """Execute the next scheduled event."""
+        return self._run_control.run_next_event()

--- a/mesa/timeflow.py
+++ b/mesa/timeflow.py
@@ -1,0 +1,254 @@
+"""Unified time advancement and event scheduling for Mesa.
+
+This module provides a clean, integrated API for both traditional time-step
+advancement and discrete event scheduling within Mesa models.
+
+Core classes:
+- Scheduler: Manages event scheduling (absolute and relative times)
+- RunControl: Controls time advancement (run_until, run_for, etc.)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from mesa.experimental.devs.eventlist import EventList, Priority, SimulationEvent
+
+if TYPE_CHECKING:
+    from mesa.model import Model
+
+
+class Scheduler:
+    """Handles event scheduling for a model.
+
+    Provides methods to schedule callbacks at absolute or relative times,
+    with optional priority for simultaneous events.
+
+    Attributes:
+        model: The Mesa model instance
+        event_list: Internal priority queue of scheduled events
+    """
+
+    def __init__(self, model: Model) -> None:
+        """Initialize the scheduler.
+
+        Args:
+            model: The Mesa model instance to schedule events for
+        """
+        self.model = model
+        self.event_list = EventList()
+
+    def schedule_at(
+        self,
+        callback: Callable,
+        time: int | float,
+        priority: Priority = Priority.DEFAULT,
+        args: list[Any] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> SimulationEvent:
+        """Schedule an event at an absolute time.
+
+        Args:
+            callback: The function to call when the event fires
+            time: The absolute simulation time to fire the event
+            priority: Priority level for simultaneous events
+            args: Positional arguments to pass to the callback
+            kwargs: Keyword arguments to pass to the callback
+
+        Returns:
+            SimulationEvent: The scheduled event (can be canceled later)
+
+        Raises:
+            ValueError: If time is in the past
+
+        Examples:
+            # Schedule a drought at time 50
+            model.schedule_at(self.drought, time=50)
+
+            # Schedule with priority
+            model.schedule_at(self.critical_update, time=100, priority=Priority.HIGH)
+        """
+        if time < self.model.time:
+            raise ValueError(
+                f"Cannot schedule event in the past (current time: {self.model.time}, "
+                f"requested time: {time})"
+            )
+
+        event = SimulationEvent(
+            time=time,
+            function=callback,
+            priority=priority,
+            function_args=args,
+            function_kwargs=kwargs,
+        )
+        self.event_list.add_event(event)
+        return event
+
+    def schedule_after(
+        self,
+        callback: Callable,
+        delay: int | float,
+        priority: Priority = Priority.DEFAULT,
+        args: list[Any] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> SimulationEvent:
+        """Schedule an event after a delay from the current time.
+
+        Args:
+            callback: The function to call when the event fires
+            delay: Time units to wait before firing the event
+            priority: Priority level for simultaneous events
+            args: Positional arguments to pass to the callback
+            kwargs: Keyword arguments to pass to the callback
+
+        Returns:
+            SimulationEvent: The scheduled event (can be canceled later)
+
+        Examples:
+            # Release prisoner after 5 time units
+            model.schedule_after(self.release_prisoner, delay=5)
+
+            # Agent schedules its own future action
+            self.model.schedule_after(self.wake_up, delay=10)
+        """
+        return self.schedule_at(
+            callback=callback,
+            time=self.model.time + delay,
+            priority=priority,
+            args=args,
+            kwargs=kwargs,
+        )
+
+    def cancel(self, event: SimulationEvent) -> None:
+        """Cancel a scheduled event.
+
+        Args:
+            event: The event to cancel (returned from schedule_at or schedule_after)
+
+        Examples:
+            event = model.schedule_at(callback, time=50)
+            # Changed our mind
+            model.cancel(event)
+        """
+        self.event_list.remove(event)
+
+    def clear(self) -> None:
+        """Clear all scheduled events."""
+        self.event_list.clear()
+
+
+class RunControl:
+    """Controls time advancement for a model.
+
+    Provides methods to run the model for specific durations, until specific
+    times, or while conditions are met.
+
+    Attributes:
+        model: The Mesa model instance
+        scheduler: The scheduler managing events
+    """
+
+    def __init__(self, model: Model, scheduler: Scheduler) -> None:
+        """Initialize run control.
+
+        Args:
+            model: The Mesa model instance
+            scheduler: The scheduler managing events for this model
+        """
+        self.model = model
+        self.scheduler = scheduler
+
+    def run_until(self, end_time: int | float) -> None:
+        """Run the model until the specified time.
+
+        Executes all events scheduled up to and including end_time.
+
+        Args:
+            end_time: The simulation time to run until
+
+        Examples:
+            # Run until time reaches 100
+            model.run_until(100)
+        """
+        while not self.scheduler.event_list.is_empty():
+            try:
+                event = self.scheduler.event_list.pop_event()
+            except IndexError:
+                # No more events
+                self.model.time = end_time
+                break
+
+            if event.time <= end_time:
+                self.model.time = event.time
+                event.execute()
+            else:
+                # Event is beyond end_time, put it back
+                self.scheduler.event_list.add_event(event)
+                self.model.time = end_time
+                break
+
+        # Ensure we advance to end_time even if no events
+        if self.model.time < end_time:
+            self.model.time = end_time
+
+    def run_for(self, duration: int | float) -> None:
+        """Run the model for a specific duration from current time.
+
+        Args:
+            duration: The amount of time to advance
+
+        Examples:
+            # Run for 50 time units
+            model.run_for(50)
+        """
+        end_time = self.model.time + duration
+        self.run_until(end_time)
+
+    def run_while(self, condition: Callable[[Model], bool]) -> None:
+        """Run the model while a condition remains true.
+
+        Args:
+            condition: A function that takes the model and returns bool
+
+        Examples:
+            # Run while the model says it should keep running
+            model.run_while(lambda m: m.running)
+
+            # Run until population drops below threshold
+            model.run_while(lambda m: len(m.agents) > 10)
+        """
+        while condition(self.model):
+            if self.scheduler.event_list.is_empty():
+                break
+
+            try:
+                event = self.scheduler.event_list.pop_event()
+                self.model.time = event.time
+                event.execute()
+            except IndexError:
+                break
+
+    def run_next_event(self) -> bool:
+        """Execute the next scheduled event.
+
+        Useful for debugging or stepping through events one at a time.
+
+        Returns:
+            bool: True if an event was executed, False if event list is empty
+
+        Examples:
+            # Step through events manually
+            while model.run_next_event():
+                print(f"Time: {model.time}")
+        """
+        if self.scheduler.event_list.is_empty():
+            return False
+
+        try:
+            event = self.scheduler.event_list.pop_event()
+            self.model.time = event.time
+            event.execute()
+            return True
+        except IndexError:
+            return False


### PR DESCRIPTION
### Summary
This PR implements the first phase of the unified time and event scheduling API discussed in #2921. It integrates event scheduling directly into the `Model` class, making it simple to use both traditional time-stepping and discrete event simulation without breaking any existing functionality.

Basically, this PR does two things:
1. Introduce a nicer API for DEVS
2. Letting `Model.step()` run the model for 1 timestep

### Motivation
Currently, users who want to use event scheduling must work with the experimental `Simulator` classes (`ABMSimulator`, `DEVSimulator`), which requires managing two separate objects and understanding the distinction between them. This creates unnecessary complexity for a feature that should be a natural part of Mesa models.

This PR makes event scheduling a first-class citizen by integrating it directly into `Model`, while maintaining full backward compatibility with existing step-based models.

### Usage patterns
This API enables classical ABM, pure event-driven, and hybrid stuff in between. I think 

### 1. Pure classical ABM
Everything happens in `step()`, time advances in integer increments:
```python
class WolfSheep(Model):
    def step(self):
        self.agents.shuffle_do("step")

model = WolfSheep()
for _ in range(100):
    model.step()  # t=1, 2, 3, ...
```
This is what most people who don't use a `simulator` do now.

### 2. Hybrid: step + events
Regular stepping with scheduled one-off or agent-triggered events:
```python
class WolfSheep(Model):
    def __init__(self):
        super().__init__()
        self.schedule_at(self.drought, time=50)  # One-off event
    
    def step(self):
        self.agents.shuffle_do("step")
    
    def drought(self):
        self.grass_layer.modify_cells(lambda g: g * 0.5)

model = WolfSheep()
for _ in range(100):
    model.step()  # step() at t=1,2,3... + drought fires at t=50
```
This is functionally equivalent to the ABMScheduler, but you still call model.step(). So instead of a scheduler scheduling the step, this works the other way around, the step run the scheduled events (if any).

### 3. Pure event-driven (no step)
No regular stepping, only scheduled events with continuous time:
```python
class QueueingModel(Model):
    def __init__(self, arrival_rate):
        super().__init__()
        self.arrival_rate = arrival_rate
        self.schedule_at(self.customer_arrival, time=0)
    
    def customer_arrival(self):
        Customer(self)
        next_time = self.time + self.random.expovariate(self.arrival_rate)
        self.schedule_at(self.customer_arrival, time=next_time)

model = QueueingModel(arrival_rate=2.0)
model.run_until(1000.0)  # Time jumps between events: t=0, 0.3, 0.8, 1.2, ...
```
This is functionally equivalent to the DEVScheduler.

<hr>

This PR is fully backward compatible. Users can opt-in to new features without modifying existing code.

Curious what everybody thinks of this approach. Being backwards compatible has a lot going for it, as well as the easy intro into scheduling events.

The only disadvantage might be that users could expect the `run()` methods to also perform the step. But I think we can explain that.

We could optionally add a `run_steps()` utility method:

```Python
def run_steps(self, n_steps):
    """Run n steps using the step() method."""
    for _ in range(n_steps):
        self.step()
```

If we agree on this direction, I will add/update tests, the simulator, example models and the tutorial.

Part of #2921.