### PR TITLE
Improved typing support for Scenario

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -28,10 +28,6 @@ RNGLike = np.random.Generator | np.random.BitGenerator
 _mesa_logger = create_module_logger()
 
 
-<<<<<<< Updated upstream
-# TODO: We can add `= Scenario` default type when Python 3.13+ is required
-=======
->>>>>>> Stashed changes
 class Model[A: Agent, S: Scenario]:
     """Base class for models in the Mesa ABM library.
 


### PR DESCRIPTION
Small follow up for #3168, which ensures that `model.scenario` is properly typed. Also see #3167.