### PR TITLE
replace seed with rng in benchmarking

### DIFF
--- a/benchmarks/global_benchmark.py
+++ b/benchmarks/global_benchmark.py
@@ -32,9 +32,9 @@ def run_model(model_class, seed, parameters):
     start_init = timeit.default_timer()
     if model_class.__name__ in uses_simulator:
         simulator = ABMSimulator()
-        model = model_class(simulator=simulator, seed=seed, **parameters)
+        model = model_class(simulator=simulator, rng=seed, **parameters)
     else:
-        model = model_class(seed=seed, **parameters)
+        model = model_class(rng=seed, **parameters)
 
     end_init_start_run = timeit.default_timer()
 


### PR DESCRIPTION
#3147 deprecated seed and updated Mesa itself, but not the benchmark code. This PR fixes that, so benchmarks work again. 