### PR TITLE
Fix typo in configurations.py

### DIFF
--- a/benchmarks/configurations.py
+++ b/benchmarks/configurations.py
@@ -3,7 +3,7 @@
 from mesa.examples import BoidFlockers, BoltzmannWealth, Schelling, WolfSheep
 
 configurations = {
-    # Schelling Model Configurations
+    # BoltzmannWealth Model Configurations
     BoltzmannWealth: {
         "small": {
             "seeds": 50,


### PR DESCRIPTION
Fix a typo in `benchmarks/configurations.py`

old:
```python
    # Schelling Model Configurations
    BoltzmannWealth: {
```

new:
```python
    # BoltzmannWealth Model Configurations
    BoltzmannWealth: {
```
