### PR TITLE
Make create_meta_agent deterministic

### DIFF
--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -242,7 +242,9 @@ def create_meta_agent(
 
         else:
             constituting_agent = model.random.choice(constituting_agents)
-            agents = list( (dict.fromkeys(agents) | dict.fromkeys(constituting_agents)).keys() )
+            agents = list(
+                (dict.fromkeys(agents) | dict.fromkeys(constituting_agents)).keys()
+            )
             add_attributes(constituting_agent.meta_agent, agents, meta_attributes)
             add_methods(constituting_agent.meta_agent, agents, meta_methods)
             constituting_agent.meta_agent.add_constituting_agents(agents)


### PR DESCRIPTION
This is a simple bug fix to ensure deterministic behavior of `create_meta_agent`. Instead of a set, we use a dict which is ordered, to ensure we have only unique agents. We do the same inside path_1 to also make this deterministic. Finally, we remove the call to `model.register_agent` in `add_constituting_agents`.

I am not sure about `remove_constituting_agents`, this does a deregister call, but I am fairly sure this should be agent.remove((). @tpike3, can you clarify?

Closes #3182 and #3184 