### PR TITLE
Replace `Sequence` with `to_list` for `AgentSet`

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -13,7 +13,7 @@ import operator
 import warnings
 import weakref
 from collections import defaultdict
-from collections.abc import Callable, Hashable, Iterable, Iterator, MutableSet, Sequence
+from collections.abc import Callable, Hashable, Iterable, Iterator, MutableSet
 from random import Random
 
 # mypy
@@ -151,11 +151,10 @@ class Agent[M: Model]:
         return self.model.scenario
 
 
-class AgentSet[A: Agent](MutableSet[A], Sequence[A]):
+class AgentSet[A: Agent](MutableSet[A]):
     """A collection class that represents an ordered set of agents within an agent-based model (ABM).
 
-    This class extends both MutableSet and Sequence, providing set-like functionality with order preservation and
-    sequence operations.
+    This class extends MutableSet, providing set-like functionality with order preservation.
 
     Attributes:
         model (Model): The ABM model instance to which this AgentSet belongs.
@@ -208,6 +207,10 @@ class AgentSet[A: Agent](MutableSet[A], Sequence[A]):
     def __iter__(self) -> Iterator[A]:
         """Provide an iterator over the agents in the AgentSet."""
         return self._agents.keys()
+
+    def to_list(self) -> list[A]:
+        """Return the agents in the AgentSet as a list."""
+        return list(self._agents.keys())
 
     def __contains__(self, agent: A) -> bool:
         """Check if an agent is in the AgentSet. Can be used like `agent in agentset`."""
@@ -506,23 +509,6 @@ class AgentSet[A: Agent](MutableSet[A], Sequence[A]):
         for agent in self:
             setattr(agent, attr_name, value)
         return self
-
-    @overload
-    def __getitem__(self, item: int) -> A: ...
-
-    @overload
-    def __getitem__(self, item: slice) -> list[A]: ...
-
-    def __getitem__(self, item):
-        """Retrieve an agent or a slice of agents from the AgentSet.
-
-        Args:
-            item (int | slice): The index or slice for selecting agents.
-
-        Returns:
-            Agent | list[Agent]: The selected agent or list of agents based on the index or slice provided.
-        """
-        return list(self._agents.keys())[item]
 
     def add(self, agent: A):
         """Add an agent to the AgentSet.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -66,10 +66,12 @@ def test_agentset():
 
     assert agents[0] in agentset
     assert len(agentset) == len(agents)
-    assert all(a1 == a2 for a1, a2 in zip(agentset[0:5], agents[0:5]))
+    assert all(a1 == a2 for a1, a2 in zip(agentset.to_list()[:5], agents[:5]))
 
     for a1, a2 in zip(agentset, agents):
         assert a1 == a2
+
+    assert agentset.to_list() == agents
 
     def test_function(agent):
         return agent.unique_id > 5
@@ -85,7 +87,9 @@ def test_agentset():
     assert len(agentset.select(test_function, inplace=True)) == 5
     assert agentset.select(inplace=True) == agentset
     assert all(a1 == a2 for a1, a2 in zip(agentset.select(), agentset))
-    assert all(a1 == a2 for a1, a2 in zip(agentset.select(at_most=5), agentset[:5]))
+    assert all(
+        a1 == a2 for a1, a2 in zip(agentset.select(at_most=5), agentset.to_list()[:5])
+    )
 
     assert len(agentset.shuffle(inplace=False).select(at_most=5)) == 5
 
@@ -94,11 +98,15 @@ def test_agentset():
 
     assert all(
         a1 == a2
-        for a1, a2 in zip(agentset.sort(test_function, ascending=False), agentset[::-1])
+        for a1, a2 in zip(
+            agentset.sort(test_function, ascending=False), agentset.to_list()[::-1]
+        )
     )
     assert all(
         a1 == a2
-        for a1, a2 in zip(agentset.sort("unique_id", ascending=False), agentset[::-1])
+        for a1, a2 in zip(
+            agentset.sort("unique_id", ascending=False), agentset.to_list()[::-1]
+        )
     )
 
     assert all(
@@ -245,12 +253,12 @@ def test_agentset_get_item():
     agents = [AgentTest(model) for _ in range(10)]
     agentset = AgentSet(agents)
 
-    assert agentset[0] == agents[0]
-    assert agentset[-1] == agents[-1]
-    assert agentset[1:3] == agents[1:3]
+    assert agentset.to_list()[0] == agents[0]
+    assert agentset.to_list()[-1] == agents[-1]
+    assert agentset.to_list()[1:3] == agents[1:3]
 
-    with pytest.raises(IndexError):
-        _ = agentset[20]
+    with pytest.raises(TypeError):
+        _ = agentset[0]
 
 
 def test_agentset_do_str():
@@ -554,7 +562,7 @@ def test_agentset_shuffle_do():
             if not self.is_alive:
                 raise Exception
 
-            agent_to_remove = self.random.choice(self.model.agents)
+            agent_to_remove = self.random.choice(self.model.agents.to_list())
 
             if agent_to_remove is not self:
                 agent_to_remove.remove()

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -132,7 +132,7 @@ class TestDataCollector(unittest.TestCase):
         self.model.datacollector.collect(self.model)
         for i in range(7):
             if i == 4:
-                self.model.agents[3].remove()
+                self.model.agents.to_list()[3].remove()
             self.model.step()
 
         # Write to table:


### PR DESCRIPTION
### Summary
Removes `collections.abc.Sequence` inheritance from `AgentSet` and introduces a `to_list()` helper method. `AgentSet` is no longer subscriptable, preventing unintended slow indexing and slicing operations.
Closes #3185

### Motive
`AgentSet` currently subclasses `collections.abc.Sequence` by default. This behavior is often slow.

### Implementation
<!-- Describe how the feature was implemented. Include details on the approach taken, important decisions made, and code changes. -->

### Usage Examples
<!-- Provide code snippets or examples demonstrating how to use the new feature. Highlight key scenarios where this feature will be beneficial.

If you're modifying the visualisation, add before/after screenshots. -->

### Additional Notes
This is a breaking change for users relying on indexing or slicing `AgentSet` directly. It is intended for the Mesa 4 release cycle.