### PR TITLE
fix-spawn-generator

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -114,7 +114,12 @@ class Model[A: Agent, S: Scenario]:
         if (seed is not None) and (rng is not None):
             raise ValueError("you have to pass either rng or seed, not both")
         elif seed is None:
-            self.rng: np.random.Generator = np.random.default_rng(rng)
+            # If rng is already a Generator, spawn a child generator for isolation
+            # This ensures operations on model.rng don't affect the original generator's state
+            if isinstance(rng, np.random.Generator):
+                self.rng: np.random.Generator = rng.spawn(1)[0]
+            else:
+                self.rng: np.random.Generator = np.random.default_rng(rng)
             self._rng = (
                 self.rng.bit_generator.state
             )  # this allows for reproducing the rng

--- a/tests/experimental/test_scenarios.py
+++ b/tests/experimental/test_scenarios.py
@@ -56,9 +56,9 @@ def test_scenario():
     model = Model(scenario=scenario)
     # Should work without error
     assert model.rng is not None
-    assert (
-        model.rng is gen
-    )  # fixme we might want to spawn a generator (in essence a copy)
+    # This ensures isolation and that operations on model.rng don't affect the original generator
+    assert model.rng is not gen
+    assert isinstance(model.rng, np.random.Generator)
 
 
 def test_scenario_serialization():


### PR DESCRIPTION
this PR resolves the `# fixme we might want to spawn a generator (in essence a copy)`

Changes:
 - Modified initialization to spawn a child generator when a Generator instance is passed
 - Updated tests to check the assertions 