### PR TITLE
AgentSet.__getitem__ Creates Full List

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -522,15 +522,12 @@ class AgentSet[A: Agent](MutableSet[A], Sequence[A]):
         Returns:
             Agent | list[Agent]: The selected agent or list of agents based on the index or slice provided.
         """
-        # For slices, we need the full list
         if isinstance(item, slice):
             return list(self._agents.keys())[item]
 
-        # For negative indices, we need the full list
         if item < 0:
             return list(self._agents.keys())[item]
 
-        # For positive indices, use islice to avoid creating full list
         try:
             return next(itertools.islice(self._agents.keys(), item, item + 1))
         except StopIteration:


### PR DESCRIPTION
### Summary
Every single index access (e.g., agents[0]) creates a complete list of all agents just to return one element. For an AgentSet with 10,000 agents, accessing agents[0] allocates and populates a list of 10,000 items.

### Implementation
Before implmentation:
```python
def __getitem__(self, item):
    return list(self._agents.keys())[item]
```

After implementation:
```python
import itertools

def __getitem__(self, item):
    # Handle negative indices and slices
    if isinstance(item, slice):
        return list(self._agents.keys())[item]
    
    # For single index, use islice to avoid creating full list
    if item < 0:
        # Negative index - need full list
        return list(self._agents.keys())[item]
    
    try:
        return next(itertools.islice(self._agents.keys(), item, item + 1))
    except StopIteration:
        raise IndexError("AgentSet index out of range")
```

