### PR TITLE
Introduce AbstractAgentSet to agent.py and refactor AgentSet to inherit from it

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -232,7 +232,7 @@ class AbstractAgentSet[A: Agent](ABC, MutableSet[A]):
         # Use type(self) to ensure we return the correct subclass (AgentSet vs StrongAgentSet)
         return self._update(agents) if inplace else type(self)(agents, self.random)
 
-        def agg(
+    def agg(
         self, attribute: str, func: Callable | Iterable[Callable]
     ) -> Any | list[Any]:
         """Aggregate an attribute of all agents in the AgentSet using one or more functions.


### PR DESCRIPTION
### Summary
This PR introduces AbstractAgentSet as an abstract base class for all agent collection implementations in Mesa. This establishes a formal interface and sets the foundation for introducing alternative storage mechanisms (strong vs weak references) while maintaining backward compatibility. Further, It refactors `AgentSet` class to inherit from it

### Motive
For complete discussion: see #3128 and #3160 

### Changes
1. New: AbstractAgentSet class: Defines the minimal interface for agent collections via abstract methods.

2. Refactored: AgentSet class
- Now inherits from AbstractAgentSet
- All existing functionality preserved
- Implements all abstract methods with weakref-optimized versions
- Retains performance optimizations:

Fully backward compatible - No breaking changes

Ticks (1) from #3209 