### PR TITLE
Micro optimization of grid.select_random_empty_cell

### DIFF
--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -120,6 +120,7 @@ class Grid(DiscreteSpace[T], HasPropertyLayers):
             coord: self.cell_klass(coord, capacity, random=self.random)
             for coord in coordinates
         }
+        self._celllist = list(self._cells.values())
         self._connect_cells()
         self.create_property_layer("empty", default_value=True, dtype=bool)
 
@@ -151,10 +152,13 @@ class Grid(DiscreteSpace[T], HasPropertyLayers):
         # https://github.com/mesa/mesa/issues/1052 and
         # https://github.com/mesa/mesa/pull/1565. The cutoff value provided
         # is the break-even comparison with the time taken in the else branching point.
+        random = self.random
+        cells = self._celllist
+
         if self._try_random:
             # Limit attempts to avoid infinite loops on full grids
             for _ in range(50):
-                cell = self.all_cells.select_random_cell()
+                cell = random.choice(cells)
                 if cell.is_empty:
                     return cell
 


### PR DESCRIPTION
This is a micro optimization of `grid.select_random_empty_cell`. Currently, this calls cellcollection.select_random_cell, which in turn does `random.choice(cells)`. This indirection can be avoided by just having a `_celllist` inside `grid` and using `random.choice` directly on it. Then, to top it off, we assign `self.random` and `self._celllist` to local variables in the method to further improve performance. This trick avoids the Python calling overhead of attribute lookup. Since this for loop runs 50 times in the worst case, this micro stuff adds up a lot.