### PR TITLE
check whether model reporter is a partial function

### DIFF
--- a/mesa/datacollection.py
+++ b/mesa/datacollection.py
@@ -64,9 +64,10 @@ class DataCollector:
 
         Both model_reporters, agent_reporters, and agenttype_reporters accept a
         dictionary mapping a variable name to either an attribute name, a function,
-        a method of a class/instance, or a function with parameters placed in a list.
+        a method of a class/instance, a partial function, or a function with
+        parameters placed in a list.
 
-        Model reporters can take four types of arguments:
+        Model reporters can take five types of arguments:
         1. Lambda function:
            {"agent_count": lambda m: len(m.agents)}
         2. Method of a class/instance:
@@ -74,7 +75,9 @@ class DataCollector:
            {"agent_count": Model.get_agent_count} # Model here is a class
         3. Class attributes of a model:
            {"model_attribute": "model_attribute"}
-        4. Functions with parameters that have been placed in a list:
+        4. Partial function:
+           {"agent_count": functools.partial(count_agents, multiplier=2)}
+        5. Functions with parameters that have been placed in a list:
            {"Model_Function": [function, [param_1, param_2]]}
 
         Agent reporters can similarly take:
@@ -85,7 +88,9 @@ class DataCollector:
         3. Method of an agent class/instance:
            {"agent_action": self.do_action} # self here is an agent class instance
            {"agent_action": Agent.do_action} # Agent here is a class
-        4. Functions with parameters placed in a list:
+        4. Partial function:
+           {"energy": functools.partial(get_energy, scale=2)}
+        5. Functions with parameters placed in a list:
            {"Agent_Function": [function, [param_1, param_2]]}
 
         Agenttype reporters take a dictionary mapping agent types to dictionaries
@@ -156,8 +161,8 @@ class DataCollector:
         """
         self._validated = True  # put the change of signal firstly avoid losing efficacy
 
-        # Type 1: Lambda function
-        if isinstance(reporter, types.LambdaType):
+        # Type 1: Lambda function or partial
+        if isinstance(reporter, (types.LambdaType, partial)):
             try:
                 reporter(model)
             except Exception as e:
@@ -167,7 +172,7 @@ class DataCollector:
                 ) from e
 
         # Type 2: Method of class/instance (bound methods are callable)
-        if callable(reporter) and not isinstance(reporter, types.LambdaType):
+        if callable(reporter) and not isinstance(reporter, (types.LambdaType, partial)):
             try:
                 reporter()  # Call without args for bound methods
             except Exception as e:

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -1,6 +1,7 @@
 """Test the DataCollector."""
 
 import unittest
+from functools import partial
 
 import pandas as pd
 
@@ -671,6 +672,28 @@ class TestMethodReporterValidation(unittest.TestCase):
 
         # Validation call + actual collect call = at least 1
         self.assertGreaterEqual(model.call_count, 1)
+
+
+class TestPartialReporterValidation(unittest.TestCase):
+    """Tests for partial function model reporters."""
+
+    def test_partial_model_reporter(self):
+        """Test that partial model reporters receive the model argument."""
+
+        def count_agents(model, multiplier):
+            return len(model.agents) * multiplier
+
+        model = Model()
+        for _ in range(3):
+            Agent(model)
+
+        dc = DataCollector(
+            model_reporters={"AgentsTimesTwo": partial(count_agents, multiplier=2)}
+        )
+        dc.collect(model)
+
+        data = dc.get_model_vars_dataframe()
+        self.assertEqual(data["AgentsTimesTwo"][0], 6)
 
 
 def test_mutable_data_independence():


### PR DESCRIPTION
fixes https://github.com/mesa/mesa/issues/1871

If we use a partial function as a data collector, for example

```python
from functools import partial


def count_agents(model, multiplier):
    return len(model.agents) * multiplier

dc = DataCollector(
    model_reporters={"AgentsTimesTwo": partial(count_agents, multiplier=2)}
)
dc.collect(model)
```

then we will get a RuntimeError:

```bash
# Type 2: Method of class/instance (bound methods are callable)
if callable(reporter) and not isinstance(reporter, types.LambdaType):
    try:
>        reporter()  # Call without args for bound methods
          ^^^^^^^^^^
E               TypeError: TestPartialReporterValidation.test_partial_model_reporter.<locals>.count_agents() missing 1 required positional argument: 'model'

mesa/datacollection.py:172: TypeError
```

A similar problem was previously fixed in https://github.com/mesa/mesa/pull/1872 by checking whether the reporter is a partial function:

```python
# Check if lambda or partial function
if isinstance(reporter, (types.LambdaType, partial)):
    self.model_vars[var].append(reporter(model))
```

However in https://github.com/mesa/mesa/pull/2605 where we extracted a separate function to validate reporters, this check was not performed:

```python
# Type 1: Lambda function
if isinstance(reporter, types.LambdaType):
    ...
```

This PR essentially added this check into the model reporter validation function:

```python
# Type 1: Lambda function or partial
if isinstance(reporter, (types.LambdaType, partial)):
    ...
```

and added a test case for when a model reporter is a partial function.