### PR TITLE
Naming collision in meta-agents `add_atrributes`

### DIFF
--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -227,9 +227,10 @@ def create_meta_agent(
                 meta_attributes = {}
             for agent in agents:
                 for name, value in agent.__dict__.items():
-                    if (not callable(value) and
-                        name not in mesa_primitives and
-                        not name.startswith("_")
+                    if (
+                        not callable(value)
+                        and name not in mesa_primitives
+                        and not name.startswith("_")
                     ):
                         meta_attributes[name] = value
 


### PR DESCRIPTION
### Summary
If users set `assume_consituting_agent_attirbutes=True` in `create_meta_agent` this creates naming collision in mesa `Agent` attributes. 

### Bug / Issue
Naming collisions will occur when new meta-agents are created and the meta-agent will assume critical attributes that mesa uses for bookkeeping For example, users create agent with `agent.unique_id`=1 and then `create_meta_agent` with  `assume_consituting_agent_attributes=True` and agent 1 as a `constituting_agent` a naming collision occurs and no meta_agent  `unique_id` is now 1. 

### Implementation
In the `add_attributes` function added `mesa_primitives = [ "unique_id",  "model", "pos", "name", "random", "rng",  ]` and then excluded these in attribute adoption loop and  as well as `_` to ignore internal use only attributes. 

### Testing
No testing changes

### Additional Notes
With a planned focus on meta-agent, this is just a quick fix to address the immediate bug. `add_methods` has some protections to prevent a similar issue, but I did not give it a more thorough review to ensure they are sufficient. 
