### PR TITLE
fix: snapshot WeakKeyDictionary keys in AgentSet.__iter__ to prevent RuntimeError during GC

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -559,7 +559,7 @@ class AgentSet[A: Agent](AbstractAgentSet[A], Sequence[A]):
 
     def __iter__(self) -> Iterator[A]:
         """Provide an iterator over the agents in the AgentSet."""
-        return self._agents.keys()
+        return iter(list(self._agents.keys()))
 
     def __contains__(self, agent: A) -> bool:
         """Check if an agent is in the AgentSet. Can be used like `agent in agentset`."""


### PR DESCRIPTION
### Summary
`AgentSet.__iter__` returns the raw `WeakKeyDictionary.keys()` iterator, which can raise `RuntimeError: dictionary changed size during iteration` if an agent is garbage collected mid-iteration. This fix snapshots the keys into a list before yielding, making iteration GC-safe

### Bug / Issue
WeakKeyDictionary Iterator Can Break During Garbage Collection      

  - File: mesa/agent.py, line 562
  - Component: AgentSet.__iter__

`AgentSet` stores agents in a` weakref.WeakKeyDictionary`. The `__iter__` method returns `self._agents.keys()` directly — a live view over the weak dictionary. If any agent loses all strong references and gets garbage collected by another thread or a finalizer while iteration is in progress, the dictionary size changes and Python raises a `RuntimeError`.

The sibling class `_HardKeyAgentSet` already avoids this problem by using `iter(self._agents.keys())` on a regular `dict`, but `AgentSet` did not apply any safeguard.

### Implementation

**Changed: mesa/agent.py — AgentSet.__iter__ (line 562)**

`list(self._agents.keys())` creates a point-in-time snapshot of the keys, decoupling the iterator from the live `WeakKeyDictionary`. Subsequent garbage collection no longer affects the iteration. This is the same pattern recommended by the Python documentation for iterating over dictionaries that may change size.


### Additional Notes
- The snapshot adds a minor allocation cost per iteration call (O(n) list copy). This is the same trade-off that _HardKeyAgentSet and Python's own documentation recommend for safe iteration over mutable mappings.
- This does not change the semantics of iteration agents removed during a for loop body will still appear in that loop since the snapshot is taken at iterator creation time. This is consistent with the existing
 shuffle, select, and do methods which already snapshot via list().
