### PR TITLE
docs: fix typo in first model tutorial

### DIFF
--- a/docs/tutorials/0_first_model.ipynb
+++ b/docs/tutorials/0_first_model.ipynb
@@ -183,7 +183,7 @@
    "source": [
     "### Create Model\n",
     "\n",
-    "Next, create the model. This gives us the two basic classes of any Mesa ABM - the agent class (population of agent objects that doing something) and the manager class (a model object that manages the creation, activation, datacollection etc of the agents)\n",
+    "Next, create the model. This gives us the two basic classes of any Mesa ABM - the agent class (population of agent objects that doing something) and the manager class (a model object that manages the creation, activation, data collection etc of the agents)\n",
     "\n",
     "**Background:** The model can be visualized as a list containing all the agents. The model creates, holds and manages all the agent objects, specifically in a dictionary. The model activates agents in discrete time steps.\n",
     "\n",


### PR DESCRIPTION
This PR fixes a minor typographical error in the 0_first_model.ipynb tutorial.

Changed: "datacollection" → "data collection"

I have verified my development environment by running the SolarViz tests (pytest tests/visualization/test_solara_viz.py), which passed successfully.

This is my first contribution to Mesa as part of my GSoC 2026 preparation!