### PR TITLE
Clarify deprecation warning for batch_run iterations

### DIFF
--- a/mesa/batchrunner.py
+++ b/mesa/batchrunner.py
@@ -84,7 +84,8 @@ def batch_run(
         )
     if iterations is not None:
         warnings.warn(
-            "The `iterations` keyword argument is deprecated, please use `rng` instead."
+            "The `iterations` keyword argument is deprecated. "
+            "Use `rng` instead (e.g. `iterations=5` is equivalent to `rng=[None] * 5`). "
             "See https://mesa.readthedocs.io/latest/migration_guide.html#batch-run",
             DeprecationWarning,
             stacklevel=2,


### PR DESCRIPTION
A small clarification is made to the deprecation warning for the `iterations` argument in `batch_run`.

Specifically, it documents the existing equivalence between `iterations=n` and `rng=[None] * n`, so the migration path is explicit
for users reading the warning.

No behavior is changed, this is a warning update intended to reduce confusion during the migration to `rng`.