### PR TITLE
fix: handle deprecated space_kwargs gracefully in SpaceRenderer.rende…

### DIFF
--- a/mesa/visualization/space_renderer.py
+++ b/mesa/visualization/space_renderer.py
@@ -398,7 +398,6 @@ class SpaceRenderer:
         """Render the complete space with structure, agents, and property layers.
 
         Args:
-            self: The SpaceRenderer instance.
             agent_portrayal: (Deprecated) Function for agent portrayal. Use setup_agents() instead.
             propertylayer_portrayal: (Deprecated) Function for property layer portrayal. Use setup_propertylayer() instead.
             **kwargs: (Deprecated) Additional keyword arguments.
@@ -415,8 +414,6 @@ class SpaceRenderer:
             if propertylayer_portrayal is not None:
                 self.propertylayer_portrayal = propertylayer_portrayal
 
-            # FIX: Handle deprecated kwargs gracefully to prevent crashes.
-            # This loop handles multiple deprecated kwargs in a scalable way.
             deprecated_kwargs_map = {
                 "space_kwargs": self.draw_space_kwargs,
                 "agent_kwargs": self.draw_agent_kwargs,


### PR DESCRIPTION

### Summary
This PR adds a safeguard to `SpaceRenderer.render` to prevent a hard `AttributeError` crash when the deprecated `space_kwargs` argument is passed.

### Bug / Issue
Closes #3216

**Context:**
Currently, if a user (or a legacy script/tutorial) passes `space_kwargs` to `renderer.render()`, the method blindly merges it into `kwargs` and passes it to the backend drawer.
**What happened:** Matplotlib raises `AttributeError: Line2D.set() got an unexpected keyword argument 'space_kwargs'` because the dictionary key wasn't unpacked.
**What was expected:** The renderer should handle the deprecated argument gracefully (by unpacking its contents) or at least not crash the entire application.

### Implementation
Modified `mesa/visualization/space_renderer.py` inside the `render` method:
1. Checked if `space_kwargs` exists in `kwargs`.
2. Extracted the dictionary value and merged it into `self.draw_space_kwargs` (which is the correct destination for these parameters).
3. Removed `space_kwargs` from `kwargs` to prevent it from being passed downstream to the backend (Matplotlib/Altair) where it causes the crash.

### Testing
I created a local reproduction script to verify the fix:

**Reproduction Code:**
```python
renderer.render(space_kwargs={"color": "black", "alpha": 0.1})
```

**Results:**
- **Before:** Crashed with `AttributeError: Line2D.set() got an unexpected keyword argument 'space_kwargs'`.
- **After:** Renders successfully without error.

### Additional Notes
While PR #3223 and #3231 updated the tutorials to use the new API, the underlying library code remained fragile. This fix ensures that users who copy-paste old code or haven't updated their scripts yet will encounter a warning rather than a hard crash, improving the DevEx.


