### PR TITLE
refactor(examples): migrate visualization apps to new SpaceRenderer A…

### DIFF
--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -80,7 +80,7 @@ renderer = SpaceRenderer(epstein_model, backend="matplotlib").setup_agents(
     citizen_cop_portrayal
 )
 # Specifically, avoid drawing the grid to hide the grid lines.
-renderer.draw_agents()
+renderer.render()
 renderer.post_process = post_process
 
 page = SolaraViz(

--- a/mesa/examples/advanced/sugarscape_g1mt/app.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/app.py
@@ -63,8 +63,7 @@ renderer = (
     .setup_propertylayer(propertylayer_portrayal)
 )
 # Specifically, avoid drawing the grid to hide the grid lines.
-renderer.draw_agents()
-renderer.draw_propertylayer()
+renderer.render()
 
 renderer.post_process = post_process
 

--- a/mesa/examples/advanced/wolf_sheep/app.py
+++ b/mesa/examples/advanced/wolf_sheep/app.py
@@ -84,7 +84,7 @@ renderer = SpaceRenderer(
     backend="matplotlib",
 ).setup_agents(wolf_sheep_portrayal)
 renderer.post_process = post_process_space
-renderer.draw_agents()
+renderer.render()
 
 page = SolaraViz(
     model,

--- a/mesa/examples/basic/conways_game_of_life/app.py
+++ b/mesa/examples/basic/conways_game_of_life/app.py
@@ -58,7 +58,7 @@ model1 = ConwaysGameOfLife()
 renderer = SpaceRenderer(model1, backend="matplotlib").setup_agents(agent_portrayal)
 # In this case the renderer only draws the agents because we just want to observe
 # the state of the agents, not the structure of the grid.
-renderer.draw_agents()
+renderer.render()
 renderer.post_process = post_process
 
 # Create the SolaraViz page. This will automatically create a server and display the


### PR DESCRIPTION
### Summary
This PR migrates the core visualization examples to use the modern `SpaceRenderer.render()` API, removing the deprecated `draw_agents()` and `draw_structure()` calls.

### Bug / Issue
Closes #3282

**Context:**
While the tutorials were updated in #3231, the example models in the codebase were still using the old API. This caused `FutureWarning` and `PendingDeprecationWarning` messages when running the examples (verified locally).

### Implementation
Updated the `app.py` files for the following examples to use `renderer.render()`:
- `advanced/epstein_civil_violence`
- `advanced/sugarscape_g1mt`
- `advanced/wolf_sheep`
- `basic/conways_game_of_life`

This aligns the codebase examples with the current best practices documented in the tutorials.

### Testing
- Verified locally that the examples run without raising the specific `SpaceRenderer` deprecation warnings.
- Visual functionality remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rendering approach in example applications to use a unified render method instead of component-specific rendering calls, improving consistency across examples while maintaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->