### PR TITLE
Deprecate model.step() and run_model() with FutureWarning

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -202,6 +202,15 @@ class Model[A: Agent, S: Scenario](HasObservables):
 
     def _wrapped_step(self) -> None:
         """Advance time by one unit, processing any scheduled events."""
+        warnings.warn(
+            "model.step() is deprecated and will be removed in Mesa 4.0. Use model.run_for(1) instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        self._step_once()
+
+    def _step_once(self) -> None:
+        """Advance time by one unit without deprecation warnings."""
         self._advance_time(self.time + 1)
 
     def _advance_time(self, until: float) -> None:
@@ -350,8 +359,13 @@ class Model[A: Agent, S: Scenario](HasObservables):
 
         Overload as needed.
         """
+        warnings.warn(
+            "model.run_model() is deprecated and will be removed in Mesa 4.0. Use model.run_for(...) or model.run_until(...) instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         while self.running:
-            self.step()
+            self._step_once()
 
     def step(self) -> None:
         """A single step. Fill in here."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,11 +16,13 @@ def test_model_set_up():
     assert model.time == 0.0
     assert model._simulator is None
 
-    model.step()
+    with pytest.warns(FutureWarning, match=r"model\.step\(\) is deprecated"):
+        model.step()
     assert model.steps == 1
     assert model.time == 1.0
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_model_time_increment():
     """Test that time increments correctly with steps."""
     model = Model()
@@ -57,9 +59,31 @@ def test_running():
                 self.running = False
 
     model = TestModel()
-    model.run_model()
+    with pytest.warns(FutureWarning, match=r"model\.run_model\(\) is deprecated"):
+        model.run_model()
     assert model.steps == 10
     assert model.time == 10.0
+
+
+def test_step_deprecation_warning():
+    """Test that model.step emits deprecation warning."""
+    model = Model()
+
+    with pytest.warns(FutureWarning, match=r"model\.step\(\) is deprecated"):
+        model.step()
+
+
+def test_run_model_deprecation_warning():
+    """Test that model.run_model emits deprecation warning."""
+
+    class TestModel(Model):
+        def step(self):
+            if self.steps == 1:
+                self.running = False
+
+    model = TestModel()
+    with pytest.warns(FutureWarning, match=r"model\.run_model\(\) is deprecated"):
+        model.run_model()
 
 
 def test_rng(rng=23):


### PR DESCRIPTION
### Summary
Adds deprecation warnings for `model.step()` and `model.run_model()` to support the Mesa 4 API transition toward event/time-based execution (`run_for`, `run_until`).

### Motive
Issue #3132: Add deprecation warnings to `model.step()` and `run_model()`
Without warnings, users continue using `step()`/`run_model()` without clear migration guidance, which makes future removal in Mesa 4 more disruptive

### Implementation
- Added `FutureWarning` in `Model._wrapped_step` when `model.step()` is called.
- Added `FutureWarning` in `Model.run_model()` when `model.run_model()` is called.
- Introduced internal helper `Model._step_once()` to advance one tick without emitting deprecation warnings.
  - `model.step()` warns, then calls` _step_once()`.
  - `run_model()` warns once, then loops via `_step_once()` to avoid warning spam each iteration.
- Updated tests in `test_model.py`:
  - Assert warning on `model.step()`.
  - Assert warning on `model.run_model()`.
  - Added dedicated deprecation-warning tests.
  - Added warning filtering for the looped time-increment test to keep intent focused on time behavior.

### Usage Examples
```python
from mesa.model import Model

model = Model()

# Deprecated in Mesa 3.x, will be removed in Mesa 4.0
model.step()        # emits FutureWarning
model.run_model()   # emits FutureWarning
```

Preferred Replacements:
```python
from mesa.model import Model

model = Model()

# Recommended API
model.run_for(1)
model.run_until(10)
```

### Additional Notes
- Warning category used: `FutureWarning` (consistent with other Mesa deprecations).
- Behavior is preserved; this change is additive (warning-only).
- `test_model.py` passes locally after updates.