### PR TITLE
Update overview.md for Mesa 3.5

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -100,7 +100,7 @@ space = mesa.space.ContinuousSpace(x_max, y_max, torus=True)
 space.move_agent(agent, (new_x, new_y))
 ```
 
-> **Note:** The legacy `mesa.space` module (including `MultiGrid`, `SingleGrid`, etc.) is in maintenance-only mode. For new projects, use `mesa.discrete_space` instead.
+> **Note:** The legacy `mesa.space` module (including `MultiGrid`, `SingleGrid`, etc.) is in maintenance-only mode. For new projects, use `mesa.discrete_space` and `mesa.experimental.continuous_space` instead.
 
 ### Time Advancement and Agent Activation
 


### PR DESCRIPTION
### Summary
Updates `overview.md` to reflect Mesa 3.5 APIs and deprecations, ensuring new users start with current best practices.

### Motive
The overview is often the first documentation new users encounter. It still recommended several deprecated patterns (`model.step()` loops, `mesa.space`, `seed` parameter, experimental `Simulator` classes, `iterations` in `batch_run`, dict-based agent portrayal) that will be removed in Mesa 4.0. This PR aligns the overview with 3.5 so new users don't learn patterns they'll immediately need to migrate away from.

### Implementation
Key changes:

- **Time advancement:** Replaced all `model.step()` usage with `model.run_for()` / `model.run_until()`. Replaced experimental `Simulator`-based event scheduling with the new public `Model.schedule_event()` and `Model.schedule_recurring()` API using `mesa.time.Schedule`.
- **Spaces:** Updated from `mesa.space.MultiGrid` to `mesa.discrete_space.OrthogonalMooreGrid` and updated all discrete space examples. Added note that `mesa.space` is maintenance-only.
- **Agent creation:** Updated model skeleton to use `create_agents()` with vectorized `rng.integers()` instead of a manual loop.
- **Batch run:** Replaced deprecated `iterations=5` with explicit `rng` seed values.
- **Visualization:** Updated `agent_portrayal` to return `AgentPortrayalStyle` instead of a plain dict. Removed `seed` from `Model.__init__` examples.
- **General:** Removed "Mesa 3.0 makes..." / "Mesa now uses..." phrasing. Updated toctree to include new agent activation and event scheduling tutorials.

@quaquel can you review the discrete space and RNG usage?