### PR TITLE
Fix unbounded growth of `Model._event_generators`

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -129,7 +129,7 @@ class Model[A: Agent, S: Scenario](HasObservables):
         # Event list for event-based execution
         self._event_list: EventList = EventList()
         # Strong references to active EventGenerators (prevent GC)
-        self._event_generators: list[EventGenerator] = []
+        self._event_generators: set[EventGenerator] = set()
 
         # check if `scenario` is provided
         # and if so, whether rng is the same or not
@@ -450,7 +450,6 @@ class Model[A: Agent, S: Scenario](HasObservables):
         """
         generator = EventGenerator(self, function, schedule, priority)
         generator.start()
-        self._event_generators.append(generator)
         return generator
 
     def run_for(self, duration: float | int) -> None:

--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -252,6 +252,7 @@ class EventGenerator:
         else:
             self._active = False
             self._current_event = None
+            self.model._event_generators.discard(self)
 
     def _schedule_next(self, time: float) -> None:
         """Schedule the next event at the given time."""
@@ -278,6 +279,7 @@ class EventGenerator:
             start_time = self.model.time + self._get_interval()
 
         self._active = True
+        self.model._event_generators.add(self)
         self._schedule_next(start_time)
         return self
 
@@ -291,6 +293,7 @@ class EventGenerator:
         if self._current_event is not None:
             self._current_event.cancel()
             self._current_event = None
+        self.model._event_generators.discard(self)
         return self
 
 


### PR DESCRIPTION
### Summary
`Model._event_generators` grows unbounded because exhausted and stopped `EventGenerator`s are never removed.

### Bug / Issue
`_event_generators` exists solely to hold strong references to active generators, preventing garbage collection. However, generators were never removed when they finished or were stopped, causing the list to grow indefinitely. Since generators hold hard references to their callables (which may be bound agent methods), this could also prevent agents from being garbage collected.

Closes #3313.

### Implementation
- Changed `_event_generators` from `list` to `set` (ordering is irrelevant for a GC-prevention container).
- Moved registration responsibility into `EventGenerator`: `start()` adds itself to the set, `stop()` and exhaustion remove it via `discard()`.
- Removed the `_event_generators.append()` call from `Model.schedule_recurring`, since `start()` now handles it.

### Testing
Existing tests pass. Could add a test verifying that a generator with `count=n` is removed from `_event_generators` after completing its executions.

### Additional Notes
No public API changes, `_event_generators` is a private attribute.