### PR TITLE
Enforce monotonic time invariant in event scheduling

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -400,7 +400,7 @@ class Model[A: Agent, S: Scenario](HasObservables):
             raise ValueError("Specify exactly one of 'at' or 'after'")
 
         time = at if at is not None else self.time + after
-        #Enforce monotonic time progression
+        # Enforce monotonic time progression
         if time < self.time:
             raise ValueError(
                 f"Cannot schedule event in the past. "
@@ -425,7 +425,7 @@ class Model[A: Agent, S: Scenario](HasObservables):
 
         Returns:
             The EventGenerator (can be used to stop)
-            
+
         Raises:
             ValueError: If the schedule start time is in the past.
         """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,6 +8,7 @@ from mesa.experimental.devs.simulator import DEVSimulator
 from mesa.model import Model
 from mesa.time import Schedule
 
+
 def test_model_set_up():
     """Test Model initialization."""
     model = Model()
@@ -144,6 +145,7 @@ def test_agent_remove():
     model.remove_all_agents()
     assert len(model.agents) == 0
 
+
 def test_schedule_event_rejects_past_time():
     """Model.schedule_event should not allow scheduling in the past."""
     model = Model()
@@ -152,6 +154,7 @@ def test_schedule_event_rejects_past_time():
     # Scheduling in the past should fail
     with pytest.raises(ValueError):
         model.schedule_event(lambda: None, at=5)
+
 
 def test_schedule_recurring_cannot_start_in_past():
     """Model.schedule_recurring should not allow scheduling in the past."""


### PR DESCRIPTION
### Summary
This PR enforces a monotonic time invariant in the event scheduling system. It prevents one-off and recurring events from being scheduled at times earlier than the model’s current simulation time. This ensures the model clock cannot move backwards during execution.

Fixes #3342 

### Bug / Issue
It was previously possible to run the model forward (e.g., to time 10), schedule a new event at an earlier time (e.g., time 3) and then execute that event, causing the model clock to move backward. There is no rollback mechanism in the execution model, so this behavior violates expected time semantics.

### Implementation
The fix enforces the invariant at the scheduling boundary:
- In `Model.schedule_event`, a `ValueError` is raised if  time < `self.time`
- In `Model.schedule_recurring`, a `ValueError` is raised if `schedule.start` is not None and `schedule.start` < `self.time`

This ensures both one-off and recurring schedules cannot be initialized in the past. This is enforced at the API boundary rather than inside `_advance_time`, preventing invalid events from entering the event list in the first place.

### Testing
Added tests in `tests/test_model.py` for verification. Normal forward scheduling behavior remains unchanged All time-related tests pass.

### Additional Notes
This change formalizes time monotonicity as an invariant of the scheduling system. It does not alter normal forward execution behavior. This preserves consistency with the discrete event execution model, which does not support rollback or reversible time progression.