### PR TITLE
Remove `model.steps` usage from solara_viz

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -1035,4 +1035,4 @@ def copy_renderer(renderer: SpaceRenderer, model: Model):
 def ShowSteps(model):
     """Display the current step of the model."""
     update_counter.get()
-    return solara.Text(f"Step: {model.steps}")
+    return solara.Text(f"Time: {model.time}")


### PR DESCRIPTION
Remove the `steps` usage from `solara_viz` likely left from #3328

Error encountered:
```plaintext
Traceback (most recent call last):
  File "/home/aman/mesa/env/lib/python3.12/site-packages/reacton/core.py", line 1702, in _render
    root_element = el.component.f(*el.args, **el.kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aman/mesa/mesa/visualization/solara_viz.py", line 1038, in ShowSteps
    return solara.Text(f"Time: {model.steps}")
                                ^^^^^^^^^^^
AttributeError: 'VirusOnNetwork' object has no attribute 'steps'. Did you mean: 'step'?
```