### PR TITLE
Clean up pd_grid example activation logic

### DIFF
--- a/mesa/examples/advanced/pd_grid/agents.py
+++ b/mesa/examples/advanced/pd_grid/agents.py
@@ -35,9 +35,6 @@ class PDAgent(CellAgent):
         best_neighbor = max(neighbors, key=lambda a: a.score)
         self.next_move = best_neighbor.move
 
-        if self.model.activation_order != "Simultaneous":
-            self.advance()
-
     def advance(self):
         self.move = self.next_move
         self.score += self.increment_score()

--- a/mesa/examples/advanced/pd_grid/model.py
+++ b/mesa/examples/advanced/pd_grid/model.py
@@ -62,12 +62,11 @@ class PdGrid(mesa.Model):
         # Activate all agents, based on the activation regime
         match self.activation_order:
             case "Sequential":
-                self.agents.do("step")
+                self.agents.do(lambda a: (a.step(), a.advance()))
             case "Random":
-                self.agents.shuffle_do("step")
+                self.agents.shuffle_do(lambda a: (a.step(), a.advance()))
             case "Simultaneous":
-                self.agents.do("step")
-                self.agents.do("advance")
+                self.agents.do("step").do("advance")
             case _:
                 raise ValueError(f"Unknown activation order: {self.activation_order}")
 


### PR DESCRIPTION
### Summary
Cleans up the pd_grid example by separating agent logic from activation control.

### Motive
`PDAgent.step()` contained a check against `model.activation_order` to decide whether to call `self.advance()`. This couples the agent to the model's activation regime. Agents shouldn't need to know how they're being activated.

### Implementation
- Removed the `if activation_order != "Simultaneous": self.advance()` check from `PDAgent.step()`, so `step()` only computes `next_move`.
- Updated `PdGrid.step()` to use method chaining and lambdas for clear activation semantics:
  - **Sequential:** `do(lambda a: (a.step(), a.advance()))`
  - **Random:** `shuffle_do(lambda a: (a.step(), a.advance()))`
  - **Simultaneous:** `do("step").do("advance")`

### Additional Notes
`increment_score` still checks `activation_order` to decide whether to read `move` or `next_move` from neighbors. This is inherent to the simultaneous game semantics, not an activation concern.

If we find this too ugly:
```Python
do(lambda a: (a.step(), a.advance()))
```
We might update do and shuffle_do to allow taking multiple method names or callables:
```Python
# For each agent, call step, call advance, then the next agent
do("step", "advance")
```