### PR TITLE
Add `RUN_ENDED` signal and integrate `DataRecorder` terminal snapshot collection

### DIFF
--- a/mesa/experimental/mesa_signals/signal_types.py
+++ b/mesa/experimental/mesa_signals/signal_types.py
@@ -80,3 +80,4 @@ class ModelSignals(SignalType):
 
     AGENT_ADDED = "agent_added"
     AGENT_REMOVED = "agent_removed"
+    RUN_ENDED = "run_ended"

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -444,7 +444,10 @@ class Model[A: Agent, S: Scenario](HasObservables):
         Args:
             duration: Time units to advance
         """
+        start_time = self.time
         self._advance_time(self.time + duration)
+        if self.time > start_time:
+            self._notify_run_ended(start_time=start_time)
 
     def run_until(self, end_time: float | int) -> None:
         """Run the model until the specified time.
@@ -463,4 +466,11 @@ class Model[A: Agent, S: Scenario](HasObservables):
             )
             return
 
+        start_time = self.time
         self._advance_time(end_time)
+        if self.time > start_time:
+            self._notify_run_ended(start_time=start_time)
+
+    @emit("run", ModelSignals.RUN_ENDED)
+    def _notify_run_ended(self, **kwargs) -> None:
+        """Emit a run-ended lifecycle signal."""


### PR DESCRIPTION
### Summary
Adds a new `ModelSignals.RUN_ENDED` lifecycle signal and wires `BaseDataRecorder` to listen for it, so recorders automatically capture a terminal snapshot when `model.run_for(...)` or `model.run_until(...)` completes.

### Motive
Related Issue: #3341 
`DataRecorder` currently collects on `model.time` changes, which can miss an explicit end-of-run capture unless users call `recorder.finalise()` manually.
This change makes terminal-state collection automatic at run completion, while keeping the existing time-based collection behavior unchanged.

### Implementation
- Added `RUN_ENDED` to `ModelSignals`.
- Added a model emitter method:
  - `@emit("run", ModelSignals.RUN_ENDED)`
  - `_notify_run_ended(...)`
- Updated:
  - `Model.run_for(...)`
  - `Model.run_until(...)`
 to emit `RUN_ENDED` only when time actually advances.
- Updated `BaseDataRecorder`:
  - kept subscription to `("time", ObservableSignals.CHANGED)`
  - added subscription to `("run", ModelSignals.RUN_ENDED)`
  - on run ended, call `finalise()` to collect final snapshots.
- Added tests in `test_datarecorder.py`:
  - terminal snapshot on `run_for`
  - terminal snapshot on `run_until`

### Usage Examples
```python
from mesa.experimental.data_collection import DataRecorder, DatasetConfig

model = MyModel()
model.data_registry.track_model(model, "model_data", fields=["metric"])

recorder = DataRecorder(
    model,
    config={"model_data": DatasetConfig(interval=1)}
)

# No explicit recorder.finalise() needed now
model.run_until(100)

df = recorder.get_table_dataframe("model_data")
# Includes terminal snapshot at time=100
```

### Additional Notes
- Backward compatibility is preserved:
  - time-based collection semantics are unchanged.
  - `finalise()` remains available for explicit/manual use.
