### PR TITLE
fix: use weakref in EventGenerator to prevent memory leak

### DIFF
--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -333,7 +333,7 @@ class EventGenerator:
         state = self.__dict__.copy()
         fn = self.function() if self.function is not None else None
         state["_fn_strong"] = fn
-        state["_function"] = None
+        state["function"] = None
         return state
 
     def __setstate__(self, state):

--- a/tests/time/test_events.py
+++ b/tests/time/test_events.py
@@ -616,8 +616,8 @@ class TestEventGeneratorMemoryLeak(unittest.TestCase):
 
         # Verify state contains expected keys
         self.assertIn("_fn_strong", state)
-        self.assertIn("_function", state)
-        self.assertIsNone(state["_function"])
+        self.assertIn("function", state)
+        self.assertIsNone(state["function"])
 
         # Verify _fn_strong is the actual function
         self.assertEqual(state["_fn_strong"](), "hello")
@@ -637,7 +637,7 @@ class TestEventGeneratorMemoryLeak(unittest.TestCase):
         # 3. Test __setstate__ with None function (edge case)
         state_with_none = {
             "_fn_strong": None,
-            "_function": None,
+            "function": None,
             "schedule": schedule,
             "priority": Priority.DEFAULT,
             "_active": False,


### PR DESCRIPTION
### Summary
This PR fixes the memory leak by:
- Using weak references instead of hard references (like Event class)
- Adding error handling for invalid callables
- Implementing silent no-op when references become invalid
- Adding comprehensive tests

### Bug / Issue
 Pr for #3332  
EventGenerator.function is a hard reference rather than a weak ref as used in Event. This can lead to memory leaks if a generator is used in combination with, e.g., an Agent. If the agent is removed from the model but remains part of an EventGenerator, it cannot be garbage-collected.
### Implementation
As per the coversation in #3320   
The behavior of both Event and EventGenerator should be the same
so,
- if the function is not callable -> TypeError
- if the function is not weakrefable -> TypeError
- create weakref, drop local strong ref, then check wr() is None -> ValueError
- so we are failing fast during the initialization but if the weakref resolve to None we are just stoping the     generator(no-op)
- made a `__getstate__`  and `__setstate__` for  the pickling issue
### Testing
-  Error cases (non-callable, non-weakly-referenceable)
    It is work as expected `Event(5, lambda: 5)`  fail, while `a = lambada:10; ` `Event(5, a)` still     works.
- Weak reference behavior and garbage collection
-  Pickling/unpickling support
-  No-op behavior when weakref dies during execution


### Additional Notes
- Matches `Event` class weak reference pattern for consistency
- Maintains backward compatibility
- Comprehensive tests for weakrefs, garbage collection, and pickling
- Proper error handling for invalid callables