### PR TITLE
Fix: adding networkx  in core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "pandas",
   "tqdm",
   "scipy",
+  "networkx",
   "pythran>=0.17.0 ; sys_platform == 'darwin'", # required for darwin scipy overrides in nix
 
 ]


### PR DESCRIPTION
### Summary
`import mesa` fails with `ModuleNotFoundError: No module named 'networkx'` after a basic `pip install mesa`, making mesa completely unusable out of the box.

### Bug / Issue
Fixes #3365 
Since there are no conditional guards anywhere in this chain, every user who does a basic `pip install mesa` hits this error immediately on `import mesa`.

### Implementation
Added `networkx` to dependencies in `pyproject.toml`:

### Testing
1. Create a fresh virtual environment
2. Run `pip install mesa`
3. Run `python -c "import mesa"`
It runs without any errors after this.