### PR TITLE
Fix/boid flockers improvements

### DIFF
--- a/mesa/examples/basic/boid_flockers/agents.py
+++ b/mesa/examples/basic/boid_flockers/agents.py
@@ -94,16 +94,16 @@ class Boid(ContinuousSpaceAgent):
         )
 
         # Build neighbor distances matching self.neighbors exactly
-        neighbor_distances = np.array([
-            d for boid, d in zip(neighbors, distances) if boid is not self
-        ])
+        neighbor_distances = np.array(
+            [d for boid, d in zip(neighbors, distances) if boid is not self]
+        )
         # Clamp to avoid near-zero distances causing weight explosion (decay=2 → 1/d²)
         neighbor_distances = np.clip(neighbor_distances, a_min=1e-2, a_max=None)
 
         # Distance-based weights: closer neighbors have stronger influence
         # decay=2.0 → weight = 1/d² (inverse square law, natural decay)
         # decay=0.0 → weight = 1 for all (falls back to canonical Reynolds)
-        weights = 1.0 / (neighbor_distances ** self.decay + 1e-6)
+        weights = 1.0 / (neighbor_distances**self.decay + 1e-6)
         weights /= weights.sum()  # normalize so weights sum to 1
 
         # Rule 1 — Cohesion: weighted average position of local flockmates

--- a/mesa/examples/basic/boid_flockers/test_boidflockers.py
+++ b/mesa/examples/basic/boid_flockers/test_boidflockers.py
@@ -7,9 +7,7 @@ These tests verify:
 """
 
 import numpy as np
-import pytest
 
-from mesa.examples.basic.boid_flockers.agents import Boid
 from mesa.examples.basic.boid_flockers.model import BoidFlockers, BoidsScenario
 
 
@@ -23,8 +21,7 @@ class TestCanonicalBoids:
         model.step()
         positions_after = [b.position for b in model.agents]
         moved = sum(
-            not np.allclose(a, b)
-            for a, b in zip(positions_before, positions_after)
+            not np.allclose(a, b) for a, b in zip(positions_before, positions_after)
         )
         assert moved > len(model.agents) * 0.8, "Most boids should move each step"
 


### PR DESCRIPTION
## Summary
Improved the Boid flockers implementation with distance-weighted averaging and canonical Reynolds (1986) behavior.

## Changes
- `agents.py` > Added distance-weighted decay (Option 4) for cohesion and alignment.
-  Closer neighbors have stronger influence controlled by decay exponent. 
- Setting decay=0.0 falls back to canonical equal-weight Reynolds (1986) behavior.
- `test_boidflockers.py` > Added comprehensive tests verifying canonical behavior, normalization, and distance-weighted decay.

## Testing
All existing tests pass. New tests added covering:
- Boids move each step
- Direction always normalized
- Cohesion stable with more neighbors
- No neighbors edge case
- Distance-weighted decay behavior