### PR TITLE
add general exception handling guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ Across Mesa, prefer clear and predictable exception behavior:
 - For standard validation and input errors, prefer the most appropriate Python built-in exception.
 - Use Mesa-specific exceptions when they add meaningful domain context or hide internal implementation details from callers.
 - Follow the existing Mesa exception hierarchy: use the most specific `MesaException` subclass that fits the failure before introducing a new one.
-- Allways check with the maintainers as part of a PR or issue when you think you need a new exception.
+- Always check with the maintainers as part of a PR or issue when you think you need a new exception.
 - When wrapping internal exceptions, use `raise ... from ...` to preserve the original cause.
 - Write exception messages that are actionable — users should immediately understand what went wrong and how to fix it.
 


### PR DESCRIPTION
This PR adds a short “Exception handling guidance” section to `CONTRIBUTING.md` to make exception usage more consistent across Mesa.

**What this PR changes**

- Adds repo-wide guidance to prefer clear, predictable exception behavior.
- Recommends specific built-in exceptions for standard validation/input failures.
- Clarifies when Mesa-specific exceptions should be used (domain context or API clarity).
- Encourages consistent use of the existing `MesaException` hierarchy.
- Recommends `raise ... from ...` when wrapping internal exceptions.
- Adds guidance to keep exception messages actionable and to update tests when exception behavior changes.

**Why**
Recent exception-related discussions highlighted (https://github.com/mesa/mesa/pull/3380#issuecomment-3966220288) the need for a concise contributor guideline so future changes follow a shared approach and stay consistent.