### PR TITLE
docs: clarify proposal-first contribution flow and update PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -10,5 +10,8 @@ about: Suggest a new feature for Mesa
 **Describe the solution you'd like**
 <!-- A clear and concise description of what you want to happen. -->
 
+**Are you planning to open a PR for this?**
+<!-- For enhancements/new features, please wait for maintainer approval on this issue/discussion before opening a PR. -->
+
 **Additional context**
 <!-- Add any other context, links, etc. about the feature here. -->

--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,3 +1,9 @@
+> [!NOTE]
+> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.
+
+### Pre-PR Checklist
+- [ ] This PR is a bug fix, not a new feature or enhancement.
+
 ### Summary
 <!-- Provide a brief summary of the bug and its impact. -->
 
@@ -14,3 +20,4 @@ If you're fixing the visualisation, add before/after screenshots. -->
 
 ### Additional Notes
 <!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> For enhancements and new features, include the issue/discussion where a maintainer approved this work before opening a PR. Unapproved feature/enhancement PRs may be closed.
+
+### Pre-PR Checklist
+- [ ] I linked an issue/discussion where a maintainer approved this enhancement/feature for implementation.
+
+### Approval Link
+<!-- Link to the issue/discussion comment where a maintainer confirmed this is ready for a PR. -->
+
 ### Summary
 <!-- Provide a concise summary of the feature and its purpose. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,5 @@ Thanks for opening a PR! Please click the `Preview` tab and select a PR template
 
 - [🐛 Bug fix](?expand=1&template=bug.md)
 - [🛠 Feature/enhancement](?expand=1&template=feature.md)
+
+Feature/enhancement PRs require prior maintainer approval in an issue or discussion before they are accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ discuss via [Matrix] OR via [an issue].
 
 **To submit a contribution**
 
-- Create a ticket for the item that you are working on.
+- For enhancements or new features, open an [issue](https://github.com/mesa/mesa/issues) or [discussion](https://github.com/mesa/mesa/discussions) first and wait for maintainer approval before opening a PR.
+- For clear bug fixes, a direct PR is generally acceptable (opening an issue first is still encouraged for larger or unclear bugs).
 - Fork the Mesa repository.
 - [Clone your repository] from Github to your machine.
 - Create a new branch in your fork: `git checkout -b BRANCH_NAME`
@@ -49,7 +50,7 @@ First step is to install some proper tools, if you haven't already.
 - Dive into Git and GitHub. Watch some videos, this takes some time to click. [GitHub Desktop](https://desktop.github.com/) is great.
 - [`https://github.dev/mesa/mesa`](https://github.dev/mesa/mesa) is great for small changes (to docs).
 
-Learn the tools, talk to us about what you want to change, and open a small PR. Or update an [example model](https://github.com/mesa/mesa-examples) (check open [issues](https://github.com/mesa/mesa-examples/issues))!
+Learn the tools, talk to us about what you want to change, and open a small PR once direction is clear. For enhancements/new features, get maintainer approval in an issue/discussion first. Or update an [example model](https://github.com/mesa/mesa-examples) (check open [issues](https://github.com/mesa/mesa-examples/issues))!
 
 ### I'm a developer (but not a modeller)
 Awesome! You have the basics of open-source software development (if not check above), but not much modelling experience.
@@ -61,13 +62,13 @@ First step is to start thinking like a modeller. To understand the fine details 
   - This MOOC on practical ABM modelling: [Agent-Based Models with Python: An Introduction to Mesa](https://www.complexityexplorer.org/courses/172-agent-based-models-with-python-an-introduction-to-mesa)
 - Go though multiple of our [examples](https://github.com/mesa/mesa-examples). Play with them, modify things and get a feel for Mesa and ABMs.
   - Check our open [issues](https://github.com/mesa/mesa-examples/issues) for the examples.
-  - If you see anything you want to improve, feel free to open a (small) PR!
+  - If you see anything you want to improve, feel free to open a (small) PR for bug fixes/docs. For enhancements/new features, discuss first and wait for maintainer approval.
 - If you have a feel for Mesa, check our [discussions](https://github.com/mesa/mesa/discussions) and [issues](https://github.com/mesa/mesa/issues).
   - Also go through our [release notes](https://github.com/mesa/mesa/releases) to see what we recently have been working on, and see some examples of successful PRs.
 - Once you found or thought of a nice idea, comment on the issue/discussion (or open a new one) and get to work!
 
 ### I'm both
-That's great! You can just start working on things, reach out to us. Skim to the list above if you feel you're missing anything. Start small but don't be afraid to dream big!
+That's great! You can start with bug fixes, docs, or tests right away. For enhancements/new features, align in an issue/discussion and wait for maintainer approval before opening a PR. Reach out to us anytime, start small but don't be afraid to dream big!
 
 ### I'm neither
 Start with creating your own models, for fun. Once you have some experience, move to the topics above.
@@ -76,8 +77,9 @@ Start with creating your own models, for fun. Once you have some experience, mov
 Mesa is a library that aims to provide elegant, scalable, flexible, and powerful building blocks to a wide audience of agent-based modellers. When contributing, it helps to understand our development philosophy and process.
 
 ### When to open what
-- **Small enhancements or bug fixes**: Opening an issue or directly a PR is often great.
-- **Larger features or uncertain scope**: Open a [Discussion](https://github.com/mesa/mesa/discussions) first. This helps align on the problem and approach before investing significant effort.
+- **Bug fixes**: For clear, scoped bugs, opening a PR directly is usually fine. For larger or uncertain bug fixes, open an issue or discussion first.
+- **Enhancements and new features**: Open an issue or discussion first, agree on direction with maintainers, and wait for explicit approval before opening a PR.
+- **No prior approval for feature/enhancement work**: PRs may be closed until there is maintainer alignment and approval to proceed.
 - **When in doubt**: Start with a Discussion. It's always easier to move from discussion to implementation than to rework a large PR.
 
 ### Our development process
@@ -105,7 +107,7 @@ The goal is to wrap our heads around the conceptual approach before diving into 
 Sometimes the answer is that we just need better documentation. Python itself is a powerful tool and there are many existing libraries in the ecosystem to leverage.
 
 #### Stage 3: Implementation
-With alignment on both problem and design, implementation can proceed:
+With alignment on both problem and design, implementation can proceed. For enhancements or new features, this stage starts only after maintainers confirm they are open to a PR:
 
 - Write the code following Mesa's standards
 - Include/update tests and and check test coverage


### PR DESCRIPTION
As discussed among maintainers, feature PRs without prior alignment can create avoidable review burden. This PR is a first attempt to clarify our contribution flow so enhancements/new features follow a proposal-first process:

1. Open an issue or discussion.
2. Align on direction with maintainers.
3. Open a PR only after maintainer approval.

Bug-fix PRs remain flexible: direct PRs are still generally fine for clear, scoped bugs.

To reflect this, this PR updates `CONTRIBUTING.md` and the PR/issue templates, including checkboxes to confirm either:
- the PR is a bug fix, or
- the PR is a feature/enhancement with prior approval.

Further comments and suggestions are very welcome!
