### PR TITLE
Fix ContinuousSpaceAgent.pos setter to alias position

### DIFF
--- a/mesa/experimental/continuous_space/continuous_space_agents.py
+++ b/mesa/experimental/continuous_space/continuous_space_agents.py
@@ -49,9 +49,9 @@ class ContinuousSpaceAgent(Agent):
         return self.position
 
     @pos.setter
-    def pos(self, value):
+    def pos(self, value: np.ndarray):
         # just here for compatibility solara_viz.
-        pass
+        self.position = value
 
     def __init__(self, space: ContinuousSpace, model):
         """Initialize a continuous space agent.

--- a/tests/experimental/test_continuous_space.py
+++ b/tests/experimental/test_continuous_space.py
@@ -106,11 +106,25 @@ def test_continuous_agent():
     agent.position = [1.1, 1.1]
     assert np.allclose(agent.position, [0.1, 0.1])
 
+    agent = ContinuousSpaceAgent(space, model)
+    agent.pos = [1.1, 1.1]
+    assert np.allclose(agent.position, [0.1, 0.1])
+    assert np.allclose(agent.pos, [0.1, 0.1])
+
     dimensions = np.asarray([[0, 1], [0, 1]])
     space = ContinuousSpace(dimensions, torus=False, random=model.random)
+
+    agent = ContinuousSpaceAgent(space, model)
+    agent.pos = [0.2, 0.3]
+    assert np.allclose(agent.position, [0.2, 0.3])
+    assert np.allclose(agent.pos, [0.2, 0.3])
+
     agent = ContinuousSpaceAgent(space, model)
     with pytest.raises(ValueError):
         agent.position = [1.1, 1.1]
+    agent = ContinuousSpaceAgent(space, model)
+    with pytest.raises(ValueError):
+        agent.pos = [1.1, 1.1]
 
 
 def test_continous_space_calculate_distances():


### PR DESCRIPTION
### Summary
`ContinuousSpaceAgent.pos` is intended as a compatibility alias for position, but its setter was a silent no-op. This made `agent.pos = ...` do nothing without warning, which can lead to confusing behavior and wasted debugging time (especially in interactive/visualization workflows).

### Bug / Issue
Fixes #3399

`ContinuousSpaceAgent.pos` getter returns `self.position`, but the setter previously contained pass, so assignments like `agent.pos = [x, y]` did not update the agent’s position. Expected behavior is for `pos` to behave as a true alias of position, preserving the existing torus correction.


### Implementation
* Updated `ContinuousSpaceAgent.pos` setter to delegate to the existing position setter `(self.position = value)`, ensuring identical behavior (including torus correction and bounds checks).

* Added regression assertions to ensure `pos` matches `position` behavior.

### Testing
```
pytest -q tests/experimental/test_continuous_space.py::test_continuous_agent
pytest -q tests/experimental/test_continuous_space.py
```
Pre-commit hooks ran on commit (ruff format/check, etc.)

If you're fixing the visualisation, add before/after screenshots. -->

### Additional Notes
This is a low-severity behavioral fix with minimal scope. it only makes the compatibility property behave consistently with its getter and does not change position semantics.