### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,11 +1,11 @@
 StylesPath = .github/styles
 MinAlertLevel = suggestion
 
-Packages = Google
+Packages = Google, https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
 
 [docs/**/*.{md,rst}]
 # Only apply Vale to the docs/ folder
-BasedOnStyles = Google, Mesa
+BasedOnStyles = Google, Mesa, NoAnimalViolence
 Mesa.Branding = error
 
 # --- DISABLE RULES ---
@@ -13,7 +13,7 @@ Vale.Spelling = NO # Disable Spelling (MESA uses codespell)
 
 Google.Acronyms = NO            # Technical docs have many acronyms (MIT, ASCII, SIR, etc.)
 Google.Colons = NO              # Capitalization after colons is flexible in technical docs
-Google.Contractions = NO        # Don't force contractions in technical docs
+Google.Contractions = NO        # Do not force contractions in technical docs
 Google.Ellipses = NO            # Sometimes appropriate in documentation
 Google.EmDash = suggestion      # Style preference
 Google.Exclamation = NO


### PR DESCRIPTION
Adds the [NoAnimalViolence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale setup alongside Google and Mesa styles. This package flags phrases that normalize violence toward animals and suggests clearer professional alternatives.

## Changes

- `.vale.ini`: add `NoAnimalViolence` package URL to `Packages =` and `NoAnimalViolence` to `BasedOnStyles`

## The package

The [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) package detects phrases like:
- "kill two birds with one stone" → "accomplish two things at once"
- "beat a dead horse" → "belabor the point"
- "guinea pig" → "test subject"
- "cattle vs. pets" → "ephemeral vs. persistent"
- "canary deployment" → "progressive rollout"
- "monkey patch" → "runtime patch"

All rules are at `warning` level — informational, not blocking.

Part of the [Open Paws](https://openpaws.ai) no-animal-violence toolchain for inclusive language.