### PR TITLE
add next_scheduled_time property to EventGenerator

### DIFF
--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -248,7 +248,7 @@ class EventGenerator:
     def execution_count(self) -> int:
         """Return the number of times this generator has executed."""
         return self._execution_count
-    
+
     @property
     def next_scheduled_time(self) -> float | None:
         """Return the time of the next scheduled execution, or None if not scheduled."""

--- a/tests/time/test_events.py
+++ b/tests/time/test_events.py
@@ -584,7 +584,7 @@ class TestEventGenerator:
 
         model.run_for(1.5)
         assert order == ["H", "L"]
-        
+
     def test_introspection_properties(self, setup):
         """Test next_scheduled_time property."""
         model, fn = setup


### PR DESCRIPTION
### Summary
This PR adds a property `next_scheduled_time` to EventGenerator. It exposes the time of the next scheduled execution, or None if no event is currently scheduled.

Part of the event generator improvements in #3420.

### Motive
Currently there is no simple way to inspect when an EventGenerator will execute next without accessing internal attributes such as `_current_event`. For debugging, monitoring, or higher-level scheduling logic it is useful to know when the next execution is scheduled. This change exposes that information through a small explicit public API.

### Implementation
A new read-only property `next_scheduled_time` was added to EventGenerator. It returns the time of the currently scheduled event and None when no event is scheduled. It relies on the existing internal `_current_event` state.

### Usage Examples
````python
gen = EventGenerator(model, fn, Schedule(interval=2.0))
gen.start()
print(gen.next_scheduled_time)  # for example 2.0
gen.stop()
print(gen.next_scheduled_time)  # None
````
