### PR TITLE
feat(data_collection): add strict_alignment mode to DatasetConfig

### DIFF
--- a/mesa/experimental/data_collection/basedatarecorder.py
+++ b/mesa/experimental/data_collection/basedatarecorder.py
@@ -22,7 +22,6 @@ Key Design Principles:
 from __future__ import annotations
 
 import copy
-import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -210,14 +209,20 @@ class BaseDataRecorder(ABC):
                     continue
 
                 while config._next_collection <= new_time:
-                    if config.end_time is None or config._next_collection <= config.end_time:
+                    if (
+                        config.end_time is None
+                        or config._next_collection <= config.end_time
+                    ):
                         self._store_dataset_snapshot(
                             name, config._next_collection, data_snapshot
                         )
                     config._next_collection += config.interval
 
                 # Auto-disable if next boundary exceeds end_time
-                if config.end_time is not None and config._next_collection > config.end_time:
+                if (
+                    config.end_time is not None
+                    and config._next_collection > config.end_time
+                ):
                     config.enabled = False
             else:
                 # Reactive mode: collect at old_time (last stable state before step)

--- a/tests/experimental/test_datarecorder.py
+++ b/tests/experimental/test_datarecorder.py
@@ -172,7 +172,11 @@ def test_strict_alignment_recorder_aligned_timestamps():
     model = MockModel(n=2)
     recorder = DataRecorder(
         model,
-        {"model_data": DatasetConfig(interval=5.0, start_time=0.0, strict_alignment=True)},
+        {
+            "model_data": DatasetConfig(
+                interval=5.0, start_time=0.0, strict_alignment=True
+            )
+        },
     )
     recorder.clear()
 
@@ -193,7 +197,11 @@ def test_strict_alignment_recorder_backfills_missed_boundaries():
     model = MockModel(n=2)
     recorder = DataRecorder(
         model,
-        {"model_data": DatasetConfig(interval=5.0, start_time=0.0, strict_alignment=True)},
+        {
+            "model_data": DatasetConfig(
+                interval=5.0, start_time=0.0, strict_alignment=True
+            )
+        },
     )
     recorder.clear()
 


### PR DESCRIPTION
### Pre-PR Checklist
- [x] I linked an issue/discussion where a maintainer approved this enhancement/feature for implementation.

### Approval Link
https://github.com/mesa/mesa/issues/3405

### Summary
Add optional `strict_alignment: bool = False` to [DatasetConfig](cci:2://file:///c:/D%20FOLDER/GSSOC%2026/mesa/mesa/experimental/data_collection/basedatarecorder.py:38:0-129:32) to support
deterministic interval grids anchored to [start_time](cci:1://file:///c:/D%20FOLDER/GSSOC%2026/mesa/tests/experimental/test_datarecorder.py:1053:0-1072:23).

### Motive
[update_next_collection](cci:1://file:///c:/D%20FOLDER/GSSOC%2026/mesa/mesa/experimental/data_collection/basedatarecorder.py:110:4-129:32) currently drifts when simulation time jumps  
(e.g. `0.3 → 1.7 → 2.6` with `interval=1.0` shifts grid to `2.7` instead of `3.0`).  
Strict mode anchors boundaries to `start_time + k * interval`.

### Changes
- Added `strict_alignment: bool = False` field to [DatasetConfig](cci:2://file:///c:/D%20FOLDER/GSSOC%2026/mesa/mesa/experimental/data_collection/basedatarecorder.py:38:0-129:32)
- Updated [update_next_collection](cci:1://file:///c:/D%20FOLDER/GSSOC%2026/mesa/mesa/experimental/data_collection/basedatarecorder.py:110:4-129:32) with `math.floor` anchoring
- Added 4 unit tests: drift, exact boundaries, float precision, pre-start edge case

### Backward Compatibility
Default is `False` — zero breaking changes to existing behavior.

Closes #3405
