### PR TITLE
Fix Cell.add_agent mutating empty flag before capacity check

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -147,11 +147,11 @@ class Cell:
 
         """
         n = len(self._agents)
-        self.empty = False
 
         if self.capacity is not None and n >= self.capacity:
             raise CellFullException(self.coordinate)
 
+        self.empty = False
         self._agents.append(agent)
 
     def remove_agent(self, agent: CellAgent) -> None:


### PR DESCRIPTION
### Summary

Fixes a bug where `Cell.add_agent` mutates the `empty` flag before validating cell capacity.

### Problem

If `Cell.add_agent` raises `CellFullException`, the cell’s `empty` flag is set to `False` even though no agent was added, leaving the cell in an inconsistent state.

### Solution

Move the `empty = False` assignment to occur **after** the capacity check, ensuring state is only mutated when the agent is successfully added.

### Notes

Fixes: #3429 