### PR TITLE
Clean up duplicate assignment and refine callable typing in Model scheduling methods in model.py

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -375,7 +375,7 @@ class Model[A: Agent, S: Scenario](HasEmitters):
     ### Event scheduling and time progression methods ###
     def schedule_event(
         self,
-        function: Callable,
+        function: Callable[..., None],
         *,
         at: float | None = None,
         after: float | None = None,
@@ -419,7 +419,7 @@ class Model[A: Agent, S: Scenario](HasEmitters):
 
     def schedule_recurring(
         self,
-        function: Callable,
+        function: Callable[..., None],
         schedule: Schedule,
         priority: Priority = Priority.DEFAULT,
     ) -> EventGenerator:


### PR DESCRIPTION
This PR removes a duplicate assignment of `self.time` in `Model.__init__`
and 
refines the `function` type in `schedule_event` and `schedule_recurring`
to `Callable[..., None]`, since the return value of callbacks is ignored.

No functional changes.