### PR TITLE
Improve Schelling example run instructions

### DIFF
--- a/mesa/examples/basic/schelling/Readme.md
+++ b/mesa/examples/basic/schelling/Readme.md
@@ -8,8 +8,17 @@ By default, the number of similar neighbors the agents need to be happy is set t
 
 ## How to Run
 
-To run the model interactively, in this directory, run the following command
+To run the model interactively:
 
+1. Install Mesa in editable mode from the repository root:
+
+pip install -e .
+
+2. Navigate to the example directory:
+
+cd mesa/examples/basic/schelling
+
+3. Start the interactive visualization:
 ```
     $ solara run app.py
 ```


### PR DESCRIPTION

Improves the "How to Run" section of the Schelling example README
by including the `pip install -e .` step required when running
examples from a local clone of the Mesa repository.

This helps prevent `ModuleNotFoundError: No module named 'mesa'`
when running the example locally.