### PR TITLE
Improve readability of DataCollector lambdas in Schelling example

### DIFF
--- a/mesa/examples/basic/schelling/model.py
+++ b/mesa/examples/basic/schelling/model.py
@@ -61,7 +61,11 @@ class Schelling(Model):
                 ),
                 "population": lambda m: len(m.agents),
                 "minority_pct": lambda m: (
-                    (sum(1 for agent in m.agents if agent.type == 1) / len(m.agents)) * 100
+                    (
+                        sum(1 for agent in m.agents if agent.type == 1)
+                        / len(m.agents)
+                        * 100
+                    )
                     if len(m.agents) > 0
                     else 0
                 ),


### PR DESCRIPTION
Simplifies DataCollector lambda expressions in the Schelling example
to improve readability and use more idiomatic Python.

No functional changes.
