### PR TITLE
Fix benchmark workflow permissions for fork PRs

### DIFF
--- a/.github/workflows/benchmarks-comment.yml
+++ b/.github/workflows/benchmarks-comment.yml
@@ -1,0 +1,37 @@
+name: Comment benchmark results
+
+on:
+  workflow_run:
+    workflows: ["Performance benchmarks"]
+    types:
+      - completed
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark results
+        uses: actions/download-artifact@v8
+        with:
+          name: benchmark-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = parseInt(fs.readFileSync('pr_number.txt', 'utf8').trim());
+            const output = fs.readFileSync('benchmark_output.txt', 'utf8');
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Performance benchmarks:\n\n' + output
+            });

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,19 +9,17 @@ on:
       - '**.py'
       - '.github/workflows/benchmarks.yml'
 
+permissions:
+  contents: read
+
 jobs:
   run-benchmarks:
-    permissions:
-      contents: read
     if: >
       github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'trigger-benchmarks') ||
       github.event.action == 'opened' ||
       github.event.action == 'ready_for_review'
     runs-on: ubuntu-latest
-    outputs:
-      output: ${{steps.compare_timings.outputs.timing_comparison}}
     steps:
-      # Python and dependency setup
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -32,7 +30,8 @@ jobs:
         run: pip install uv
       - name: Install dependencies
         run: uv pip install --system numpy pandas tqdm tabulate matplotlib solara networkx scipy
-      # Benchmarks on the mesa main branch
+
+      # Benchmarks on main
       - name: Checkout main branch
         uses: actions/checkout@v6
         with:
@@ -43,7 +42,8 @@ jobs:
       - name: Run benchmarks on main branch
         working-directory: benchmarks
         run: python global_benchmark.py
-      # Upload benchmarks, checkout PR branch, download benchmarks
+
+      # Upload main benchmarks, then checkout PR
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7
         with:
@@ -51,7 +51,6 @@ jobs:
           path: benchmarks/timings_1.pickle
       - name: Checkout PR branch
         uses: actions/checkout@v6
-        if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -65,35 +64,22 @@ jobs:
         with:
           name: timings-main
           path: benchmarks
-      # Run benchmarks on the PR branch
+
+      # Run benchmarks on PR and compare
       - name: Run benchmarks on PR branch
         working-directory: benchmarks
         run: python global_benchmark.py
-      # Run compare script and create comment
-      - name: Run compare timings and encode output
+      - name: Run compare timings
         working-directory: benchmarks
-        id: compare_timings
-        run: |
-          TIMING_COMPARISON=$(python compare_timings.py | base64 -w 0)  # Base64 encode the output
-          echo "timing_comparison=$TIMING_COMPARISON" >> $GITHUB_OUTPUT
-  comment_pr:
-    permissions:
-      pull-requests: write
-      issues: write
-    runs-on: ubuntu-latest
-    needs: run-benchmarks
-    env:
-      TIMING_COMPARISON: ${{needs.run-benchmarks.outputs.output}}
-    steps:
-      - name: Comment PR
-        uses: actions/github-script@v8
+        run: python compare_timings.py > benchmark_output.txt
+
+      # Save PR number and results for the comment workflow
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > benchmarks/pr_number.txt
+      - name: Upload benchmark comparison
+        uses: actions/upload-artifact@v7
         with:
-          script: |
-            const output = Buffer.from(process.env.TIMING_COMPARISON, 'base64').toString('utf-8');
-            const issue_number = context.issue.number;
-            github.rest.issues.createComment({
-              issue_number: issue_number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Performance benchmarks:\n\n' + output
-            });
+          name: benchmark-results
+          path: |
+            benchmarks/benchmark_output.txt
+            benchmarks/pr_number.txt


### PR DESCRIPTION
### Summary
Fixes the 403 "Resource not accessible by integration" error when the benchmark workflow tries to comment on PRs from forks.

### Bug / Issue
After switching the benchmark workflow from `pull_request_target` to `pull_request`, the comment step fails with a 403 for fork PRs. The `pull_request` event restricts the `GITHUB_TOKEN` to read-only for forks, regardless of declared `permissions`. Splitting into two jobs within the same workflow doesn't help (both jobs share the same restricted token.)

### Implementation
Split the single workflow into two files:

1. **`benchmarks.yml`:** Runs on `pull_request` with read-only permissions. Executes the benchmarks on both main and the PR branch, then uploads the comparison output and PR number as artifacts.
2. **`benchmarks-comment.yml`:** Triggers on `workflow_run` completion. Since `workflow_run` always runs in the base repo context, it has write permissions. Downloads the artifacts and posts the comment.

This follows [GitHub's recommended pattern](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) for workflows that need write access on fork PRs.

As a side benefit, the base64 encoding workaround for passing the comparison output is no longer needed — results are passed as plain text through artifacts.

### Testing
- Verified on a fork PR that the benchmark job completes and uploads artifacts: https://github.com/EwoutH/mesa/pull/26
- Verified that the `workflow_run` job picks up the artifacts and posts the comment successfully.

### Additional Notes
- The `workflow_run` job only runs when the benchmark workflow succeeds (`conclusion == 'success'`).
- If we ever want to move back to a single-workflow approach, `pull_request_target` would work but requires careful handling of the checkout step to avoid running untrusted code with elevated permissions.