### PR TITLE
docs: add clear run instructions for boid_flockers example

### DIFF
--- a/mesa/examples/basic/boid_flockers/Readme.md
+++ b/mesa/examples/basic/boid_flockers/Readme.md
@@ -8,11 +8,18 @@ This model tests Mesa's continuous space feature, and uses numpy arrays to repre
 
 ## How to Run
 
-To run the model interactively, in this directory, run the following command
+1. Go to the example directory:
 
-```
-    $ solara run app.py
-```
+cd mesa/examples/basic/boid_flockers
+
+2. Install Mesa and dependencies:
+
+pip install mesa[rec]
+
+3. Run the model:
+
+solara run app.py
+
 
 
 ## Files


### PR DESCRIPTION
This PR adds clear "How to Run" instructions to the README of the boid_flockers example.

Changes
- Added step-by-step instructions to run the model
- Included dependency installation commands
- Added solara run app.py command

Motivation
Some Mesa examples lack clear instructions for beginners to run them locally.
This update helps new users easily install dependencies and start the example without confusion.
