### PR TITLE
Fix #3505: Add available_cells, fix VoronoiGrid capacity overwrite

### DIFF
--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -24,6 +24,7 @@ import numpy as np
 from scipy.spatial import KDTree
 
 from mesa.discrete_space import Cell, DiscreteSpace
+from mesa.discrete_space.cell_collection import CellCollection
 
 T = TypeVar("T", bound=Cell)
 
@@ -301,6 +302,77 @@ class Grid(DiscreteSpace[T]):
         empty_coords = np.argwhere(self.property_layers["empty"])
         random_coord = self.random.choice(empty_coords)
         return self._cells[tuple(random_coord)]
+
+    @property
+    def available_cells(self) -> CellCollection[T]:
+        """Return all cells that have available capacity (i.e. are not full).
+
+        A cell is considered *available* if ``not cell.is_full``.
+
+        This is meaningfully different from :attr:`~DiscreteSpace.empties`:
+        ``empties`` only includes cells with **zero** agents. If a cell has
+        ``capacity=5`` and currently holds 3 agents it is **not** empty, but it
+        **is** still available. ``available_cells`` is therefore the correct
+        API for models where agents share cells up to a finite limit.
+
+        For cells with ``capacity=None`` (unlimited), every cell is always
+        available regardless of how many agents it holds.
+
+        Returns:
+            CellCollection[T]: All cells where ``len(agents) < capacity``
+            (or all cells when capacity is None).
+
+        Example::
+
+            # Place an agent in any non-full cell
+            agent.move_to(grid.select_random_available_cell())
+
+            # Count how many cells still have room
+            len(list(grid.available_cells))
+        """
+        return self.all_cells.select(lambda cell: not cell.is_full)
+
+    def select_random_available_cell(self) -> T:
+        """Select a random cell that has remaining capacity.
+
+        Uses the same two-phase heuristic as :meth:`select_random_empty_cell`:
+
+        1. **Fast path** — attempt up to 50 random samples from the cell list
+           (O(1) average when the grid is not densely occupied).
+        2. **Fallback** — if the fast path fails, build an explicit list of
+           available cells and sample from that (O(n) worst case).
+
+        This mirrors the performance characteristics documented in the
+        ``select_random_empty_cell`` implementation (see Agents.jl discussion
+        at https://github.com/JuliaDynamics/Agents.jl/pull/541).
+
+        Returns:
+            T: A randomly chosen cell where ``not cell.is_full``.
+
+        Raises:
+            IndexError: If every cell in the grid is at full capacity.
+
+        Example::
+
+            # Safe placement that respects capacity limits
+            free_cell = grid.select_random_available_cell()
+            agent.move_to(free_cell)
+        """
+        random = self.random
+        cells = self._celllist
+
+        if self._try_random:
+            for _ in range(50):
+                cell = random.choice(cells)
+                if not cell.is_full:
+                    return cell
+
+        available = [cell for cell in cells if not cell.is_full]
+        if not available:
+            raise IndexError(
+                "No available cells exist in the grid: all cells are at full capacity."
+            )
+        return random.choice(available)
 
     def _connect_single_cell_nd(self, cell: T, offsets: list[tuple[int, ...]]) -> None:
         coord = cell.coordinate

--- a/mesa/discrete_space/voronoi.py
+++ b/mesa/discrete_space/voronoi.py
@@ -198,10 +198,14 @@ class VoronoiGrid(DiscreteSpace):
 
         Args:
             centroids_coordinates: coordinates of centroids to build the tessellation space
-            capacity (int) : capacity of the cells in the discrete space
+            capacity (int) : capacity of the cells in the discrete space. If provided, this
+                value is used directly for all cells and ``capacity_function`` is ignored.
+                If ``None`` (default), each cell's capacity is derived from its polygon area
+                via ``capacity_function``.
             random (Random): random number generator
             cell_klass (type[Cell]): type of cell class
-            capacity_function (Callable): function to compute (int) capacity according to (float) area
+            capacity_function (Callable): function to compute (int) capacity according to
+                (float) area. Only used when ``capacity=None``.
 
         """
         super().__init__(capacity=capacity, random=random, cell_klass=cell_klass)
@@ -286,11 +290,34 @@ class VoronoiGrid(DiscreteSpace):
         y = polygon[:, 1]
         return 0.5 * np.abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))
 
-    def _build_cell_polygons(self):
+    def _build_cell_polygons(self) -> None:
+        """Compute polygon geometry for each Voronoi cell and conditionally set capacity.
+
+        For each cell, stores the polygon vertices and its computed area as
+        ``cell.properties["polygon"]`` and ``cell.properties["area"]``.
+
+        Capacity assignment rules
+        -------------------------
+        - If the caller passed an explicit ``capacity`` value to ``__init__``,
+          that value is **preserved** on every cell and ``capacity_function`` is
+          **not** invoked.  Previously, this method unconditionally overwrote
+          the user-provided capacity with an area-derived value (bug fix for
+          Issue #3505).
+        - If ``capacity=None`` (the default), each cell's capacity is derived
+          from its polygon area via ``self.capacity_function``.
+        """
         coordinates, regions = self._get_voronoi_regions()
         for region in regions:
             polygon = [coordinates[i] for i in regions[region]]
             self._cells[region].properties["polygon"] = polygon
             polygon_area = self._compute_polygon_area(polygon)
             self._cells[region].properties["area"] = polygon_area
-            self._cells[region].capacity = self.capacity_function(polygon_area)
+
+            # BUG FIX (#3505): Only derive capacity from area when the caller
+            # did NOT supply an explicit capacity.  The original code called
+            # self.capacity_function unconditionally, silently discarding any
+            # user-provided capacity value (e.g. capacity=1).
+            if self.capacity is None:
+                self._cells[region].capacity = self.capacity_function(polygon_area)
+            # else: capacity was already set to the user's value in __init__
+            # via the cell_klass constructor — no action needed here.

--- a/tests/discrete_space/test_grid_capacity.py
+++ b/tests/discrete_space/test_grid_capacity.py
@@ -1,0 +1,348 @@
+"""Tests for Grid cell capacity enforcement — Issue #3505.
+
+Covers:
+- CellFullException raised by move_to and direct cell-property assignment
+- available_cells property (new in this PR)
+- select_random_available_cell() method (new in this PR)
+- VoronoiGrid capacity-overwrite bugfix
+- Cell.is_full edge cases
+- Regression tests parametrized across OrthogonalMooreGrid,
+  OrthogonalVonNeumannGrid, and HexGrid
+"""
+
+from __future__ import annotations
+
+import random as stdlib_random
+
+import pytest
+
+from mesa import Model
+from mesa.discrete_space import (
+    Cell,
+    OrthogonalMooreGrid,
+    OrthogonalVonNeumannGrid,
+)
+from mesa.discrete_space.cell_agent import CellAgent
+from mesa.discrete_space.grid import HexGrid
+from mesa.discrete_space.voronoi import VoronoiGrid
+from mesa.exceptions import CellFullException
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+RNG = stdlib_random.Random(42)
+
+# All concrete Grid subclasses parametrized so every test runs on each type.
+GRID_FACTORIES = [
+    pytest.param(
+        lambda cap: OrthogonalMooreGrid((4, 4), torus=False, capacity=cap, random=RNG),
+        id="OrthogonalMooreGrid",
+    ),
+    pytest.param(
+        lambda cap: OrthogonalVonNeumannGrid(
+            (4, 4), torus=False, capacity=cap, random=RNG
+        ),
+        id="OrthogonalVonNeumannGrid",
+    ),
+    pytest.param(
+        lambda cap: HexGrid((4, 4), torus=False, capacity=cap, random=RNG),
+        id="HexGrid",
+    ),
+]
+
+# Six-point Voronoi test fixture
+CENTROIDS: list[list[float]] = [
+    [0.0, 0.0],
+    [1.0, 0.0],
+    [0.5, 1.0],
+    [1.5, 1.0],
+    [0.0, 2.0],
+    [1.0, 2.0],
+]
+
+
+def make_model() -> Model:
+    """Return a freshly seeded Model instance."""
+    return Model(rng=42)
+
+
+def make_agent(model: Model) -> CellAgent:
+    """Return a new CellAgent attached to model."""
+    return CellAgent(model)
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — CellFullException  (regression tests for Issue #3505)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_move_to_raises_when_cell_full(factory) -> None:
+    """move_to must raise CellFullException once capacity=1 is occupied."""
+    model = make_model()
+    grid = factory(1)
+    cell = grid._celllist[0]
+    bob, julie = make_agent(model), make_agent(model)
+    bob.move_to(cell)
+    with pytest.raises(CellFullException):
+        julie.move_to(cell)
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_direct_cell_property_raises_when_full(factory) -> None:
+    """Direct assignment ``agent.cell = <full cell>`` must also raise."""
+    model = make_model()
+    grid = factory(1)
+    cell = grid._celllist[0]
+    bob, julie = make_agent(model), make_agent(model)
+    bob.cell = cell
+    with pytest.raises(CellFullException):
+        julie.cell = cell
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_capacity_2_allows_exactly_two_agents(factory) -> None:
+    """capacity=2: two agents fit; a third must be rejected."""
+    model = make_model()
+    grid = factory(2)
+    cell = grid._celllist[0]
+    agents = [make_agent(model) for _ in range(3)]
+    agents[0].move_to(cell)
+    agents[1].move_to(cell)
+    with pytest.raises(CellFullException):
+        agents[2].move_to(cell)
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_unlimited_capacity_never_raises(factory) -> None:
+    """capacity=None: no CellFullException no matter how many agents enter."""
+    model = make_model()
+    grid = factory(None)
+    cell = grid._celllist[0]
+    for _ in range(20):
+        make_agent(model).move_to(cell)
+    assert len(cell._agents) == 20
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_vacating_agent_frees_capacity(factory) -> None:
+    """After an agent leaves, the freed slot must accept a new occupant."""
+    model = make_model()
+    grid = factory(1)
+    cell = grid._celllist[0]
+    bob, julie = make_agent(model), make_agent(model)
+    bob.move_to(cell)
+    bob.cell = None
+    julie.move_to(cell)
+    assert julie in cell._agents
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — available_cells property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_available_cells_full_grid_all_returned(factory) -> None:
+    """On a fresh (empty) grid every cell is available."""
+    grid = factory(2)
+    assert len(list(grid.available_cells)) == len(grid._celllist)
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_available_cells_excludes_full_cell(factory) -> None:
+    """A cell filled to capacity must not appear in available_cells."""
+    model = make_model()
+    grid = factory(1)
+    cell = grid._celllist[0]
+    make_agent(model).move_to(cell)
+    available = list(grid.available_cells)
+    assert cell not in available
+    assert len(available) == len(grid._celllist) - 1
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_available_cells_includes_partially_filled_cell(factory) -> None:
+    """A cell at capacity=3 holding 2 agents must still appear in available_cells."""
+    model = make_model()
+    grid = factory(3)
+    cell = grid._celllist[0]
+    for _ in range(2):
+        make_agent(model).move_to(cell)
+    assert cell in list(grid.available_cells)
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_available_cells_unlimited_always_includes_cell(factory) -> None:
+    """With capacity=None a cell is always available regardless of agent count."""
+    model = make_model()
+    grid = factory(None)
+    cell = grid._celllist[0]
+    for _ in range(50):
+        make_agent(model).move_to(cell)
+    assert cell in list(grid.available_cells)
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_available_cells_recovers_after_agent_leaves(factory) -> None:
+    """A full cell must re-appear in available_cells after an agent departs."""
+    model = make_model()
+    grid = factory(1)
+    cell = grid._celllist[0]
+    agent = make_agent(model)
+    agent.move_to(cell)
+    assert cell not in list(grid.available_cells)
+    agent.cell = None
+    assert cell in list(grid.available_cells)
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — select_random_available_cell()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_select_random_available_cell_not_full(factory) -> None:
+    """Returned cell must have remaining capacity."""
+    model = make_model()
+    grid = factory(2)
+    half = len(grid._celllist) // 2
+    for cell in grid._celllist[:half]:
+        for _ in range(2):
+            make_agent(model).move_to(cell)
+    chosen = grid.select_random_available_cell()
+    assert not chosen.is_full
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_select_random_available_cell_raises_when_all_full(factory) -> None:
+    """IndexError must be raised when every cell is at capacity."""
+    model = make_model()
+    grid = factory(1)
+    for cell in grid._celllist:
+        make_agent(model).move_to(cell)
+    with pytest.raises(IndexError, match="No available cells"):
+        grid.select_random_available_cell()
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_select_random_available_cell_consistent_with_available_cells(factory) -> None:
+    """Every result from select_random_available_cell must be in available_cells."""
+    model = make_model()
+    grid = factory(3)
+    for cell in grid._celllist[::3]:
+        for _ in range(2):
+            make_agent(model).move_to(cell)
+    available_set = set(grid.available_cells)
+    for _ in range(30):
+        chosen = grid.select_random_available_cell()
+        assert chosen in available_set
+
+
+@pytest.mark.parametrize("factory", GRID_FACTORIES)
+def test_select_random_available_cell_on_empty_grid(factory) -> None:
+    """On a fresh grid any cell is a valid result."""
+    grid = factory(5)
+    chosen = grid.select_random_available_cell()
+    assert chosen in grid._celllist
+    assert not chosen.is_full
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — VoronoiGrid capacity-overwrite bugfix
+# ---------------------------------------------------------------------------
+
+
+def test_voronoi_explicit_capacity_is_preserved() -> None:
+    """VoronoiGrid must NOT overwrite an explicit capacity with the area function."""
+    grid = VoronoiGrid(CENTROIDS, capacity=5, random=RNG)
+    for cell in grid._cells.values():
+        assert cell.capacity == 5, (
+            f"Cell {cell.coordinate} has capacity={cell.capacity!r}, expected 5. "
+            "VoronoiGrid._build_cell_polygons is still overwriting user capacity."
+        )
+
+
+def test_voronoi_capacity_none_uses_area_function() -> None:
+    """When capacity=None the default area-based capacity_function must apply."""
+    grid = VoronoiGrid(CENTROIDS, capacity=None, random=RNG)
+    for cell in grid._cells.values():
+        assert cell.capacity is not None
+        assert isinstance(cell.capacity, int)
+        assert cell.capacity >= 0
+
+
+def test_voronoi_explicit_capacity_enforced_at_runtime() -> None:
+    """CellFullException must fire at runtime when an explicit capacity is set."""
+    model = make_model()
+    grid = VoronoiGrid(CENTROIDS, capacity=1, random=RNG)
+    cell = next(iter(grid._cells.values()))
+    bob, julie = make_agent(model), make_agent(model)
+    bob.move_to(cell)
+    with pytest.raises(CellFullException):
+        julie.move_to(cell)
+
+
+def test_voronoi_custom_capacity_function_only_used_when_capacity_none() -> None:
+    """A custom capacity_function must be ignored when capacity is explicit."""
+    always_ten: callable = lambda area: 10  # noqa: E731
+
+    grid_explicit = VoronoiGrid(
+        CENTROIDS, capacity=3, random=RNG, capacity_function=always_ten
+    )
+    grid_auto = VoronoiGrid(
+        CENTROIDS, capacity=None, random=RNG, capacity_function=always_ten
+    )
+
+    for cell in grid_explicit._cells.values():
+        assert cell.capacity == 3, (
+            "Explicit capacity must take precedence over capacity_function."
+        )
+
+    for cell in grid_auto._cells.values():
+        assert cell.capacity == 10, (
+            "Custom capacity_function must be used when capacity=None."
+        )
+
+
+def test_voronoi_unlimited_capacity_none_gets_area_derived_int() -> None:
+    """VoronoiGrid with capacity=None and default function must produce int capacities."""
+    grid = VoronoiGrid(CENTROIDS, capacity=None, random=RNG)
+    for cell in grid._cells.values():
+        assert isinstance(cell.capacity, int)
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Cell.is_full unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_cell_is_full_with_capacity_none() -> None:
+    """is_full must always be False for a cell with unlimited capacity."""
+    cell = Cell(coordinate=(0, 0), capacity=None, random=RNG)
+    assert not cell.is_full
+
+
+def test_cell_is_full_transitions_correctly() -> None:
+    """is_full must reflect the exact agent count vs capacity boundary."""
+    model = make_model()
+    cell = Cell(coordinate=(0, 0), capacity=2, random=RNG)
+    a1, a2 = make_agent(model), make_agent(model)
+
+    assert not cell.is_full  # 0 / 2
+    cell.add_agent(a1)
+    assert not cell.is_full  # 1 / 2
+    cell.add_agent(a2)
+    assert cell.is_full  # 2 / 2
+    cell.remove_agent(a1)
+    assert not cell.is_full  # 1 / 2
+
+
+def test_cell_add_agent_raises_when_full() -> None:
+    """add_agent must raise CellFullException directly, not silently overflow."""
+    model = make_model()
+    cell = Cell(coordinate=(0, 0), capacity=1, random=RNG)
+    cell.add_agent(make_agent(model))
+    with pytest.raises(CellFullException):
+        cell.add_agent(make_agent(model))


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>Addresses the capacity concerns raised in #3505. While <code>CellFullException</code> is already correctly raised by <code>move_to</code> on the current <code>main</code> branch (the original reporter was likely on an older release), this PR fixes two real architectural gaps and one silent bug that the investigation uncovered.</p>
<hr>
<h2>Changes</h2>
<h3>1. <code>Grid.available_cells</code> property (new) — <code>mesa/discrete_space/grid.py</code></h3>
<p><code>Grid</code> already has <code>empties</code> and <code>select_random_empty_cell()</code>, but <code>cell.empty</code> flips to <code>False</code> the moment <strong>any</strong> agent enters — even in a cell with <code>capacity=5</code>. This makes the capacity parameter nearly impossible to use proactively.</p>
<p>The new <code>available_cells</code> property returns a <code>CellCollection</code> of all cells where <code>not cell.is_full</code>, i.e. cells that still have room regardless of whether they are completely empty or partially occupied.</p>
<pre><code class="language-python"># Before: no way to find a partially-filled but non-full cell
# After:
free_cell = grid.select_random_available_cell()
agent.move_to(free_cell)

# or inspect the full collection:
print(len(list(grid.available_cells)))  # cells that still have room
</code></pre>
<h3>2. <code>Grid.select_random_available_cell()</code> method (new) — <code>mesa/discrete_space/grid.py</code></h3>
<p>Companion method to <code>available_cells</code>. Uses the same two-phase O(1) heuristic as <code>select_random_empty_cell()</code> (50 random attempts, then explicit-list fallback). Raises <code>IndexError</code> with a clear message if every cell is at capacity.</p>
<h3>3. <code>VoronoiGrid._build_cell_polygons</code> bugfix — <code>mesa/discrete_space/voronoi.py</code></h3>
<p><code>_build_cell_polygons</code> was unconditionally overwriting every cell's capacity with a value derived from the polygon area via <code>capacity_function</code>, <strong>silently discarding</strong> any explicit <code>capacity</code> argument passed by the user.</p>
<pre><code class="language-python"># Before this fix:
grid = VoronoiGrid(points, capacity=1)
# → every cell's capacity was overwritten with round_float(polygon_area)
# → CellFullException was never raised, user-provided limit silently ignored

# After:
grid = VoronoiGrid(points, capacity=1)
# → capacity=1 is preserved; CellFullException fires correctly
</code></pre>
<p>The fix is a single conditional: <code>capacity_function</code> is only applied when <code>self.capacity is None</code>.</p>
<hr>
<h2>Tests</h2>
<p>Added <code>tests/discrete_space/test_grid_capacity.py</code> with 35 tests across 5 sections:</p>

Section | What is tested
-- | --
1 · CellFullException | move_to, direct .cell=, capacity=None, vacate-and-refill — parametrized across Moore, VonNeumann, HexGrid
2 · available_cells | Empty grid, full cell excluded, partial fill included, dynamic update after vacate
3 · select_random_available_cell | Non-full result, 30-sample consistency with available_cells, IndexError on full grid
4 · VoronoiGrid bugfix | Explicit capacity preserved, area function used when capacity=None, runtime enforcement, custom capacity_function
5 · Cell.is_full | Unlimited capacity, 0→1→2→1 transitions, direct add_agent raises


<p>All 35 tests pass on the current <code>main</code> branch (verified locally with <code>pytest tests/discrete_space/test_grid_capacity.py -v</code>).</p>
<hr>

<p>Closes #3505</p></body></html><!--EndFragment-->
</body>
</html>