### PR TITLE
avoid temporary list allocation in EventList.__len__

### DIFF
--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -471,7 +471,7 @@ class EventList:
         return event in self._events
 
     def __len__(self) -> int:  # noqa
-        return len([e for e in self._events if not e.CANCELED])
+        return sum(1 for e in self._events if not e.CANCELED)
 
     def __repr__(self) -> str:
         """Return a string representation of the event list."""


### PR DESCRIPTION
### Summary
This is a small micro optimization that avoids unnecessary memory allocation in a frequently used method without changing the public API. Replaced list comprehension in EventList.__len__ with a generator expression to avoid creating a temporary list during length calculation.

### Implementation
````python
sum(1 for e in self._events if not e.CANCELED)
````
instead of 
````python
len([e for e in self._events if not e.CANCELED])
````
### Additional Notes
This is a minor change meant purely for performance

