### PR TITLE
docs: add quick installation section to getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,4 +1,27 @@
 # Getting started
+
+## Quick Installation
+
+To install Mesa, simply run:
+
+```bash
+pip install mesa
+```
+
+You can verify the installation by running:
+
+```bash
+python -c "import mesa; print(mesa.__version__)"
+```
+
+For development installation (from source):
+
+```bash
+git clone https://github.com/mesa/mesa.git
+cd mesa
+pip install -e .
+```
+
 Mesa is a modular framework for building, analyzing and visualizing agent-based models.
 
 **Agent-based models** are computer simulations involving multiple entities (the agents) acting and interacting with one another based on their programmed behavior. Agents can be used to represent living cells, animals, individual humans, even entire organizations or abstract entities. Sometimes, we may have an understanding of how the individual components of a system behave, and want to see what system-level behaviors and effects emerge from their interaction. Other times, we may have a good idea of how the system overall behaves, and want to figure out what individual behaviors explain it. Or we may want to see how to get agents to cooperate or compete most effectively. Or we may just want to build a cool toy with colorful little dots moving around.


### PR DESCRIPTION
This PR adds a quick installation section to the getting started guide (closes #3515).

## Changes
- Added **Quick Installation** section after the title
- Includes `pip install mesa` command
- Includes verification step
- Includes development installation from source