### PR TITLE
docs: standardize run instructions across Mesa examples

### DIFF
--- a/mesa/examples/advanced/alliance_formation/Readme.md
+++ b/mesa/examples/advanced/alliance_formation/Readme.md
@@ -36,8 +36,13 @@ An example of the bilateral shapley value in another model:
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
+

--- a/mesa/examples/advanced/epstein_civil_violence/Readme.md
+++ b/mesa/examples/advanced/epstein_civil_violence/Readme.md
@@ -8,11 +8,16 @@ The model generates mass uprising as self-reinforcing processes: if enough agent
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
+
 
 
 ## Files

--- a/mesa/examples/advanced/pd_grid/Readme.md
+++ b/mesa/examples/advanced/pd_grid/Readme.md
@@ -17,11 +17,15 @@ The Demographic Prisoner's Dilemma demonstrates how simple rules can lead to the
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
 
 ## Files
 

--- a/mesa/examples/advanced/sugarscape_g1mt/Readme.md
+++ b/mesa/examples/advanced/sugarscape_g1mt/Readme.md
@@ -43,11 +43,15 @@ The model demonstrates several Mesa concepts and features:
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
 
 
 ## Files

--- a/mesa/examples/advanced/wolf_sheep/Readme.md
+++ b/mesa/examples/advanced/wolf_sheep/Readme.md
@@ -16,12 +16,15 @@ The model is tests and demonstrates several Mesa concepts and features:
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
-
+Open the displayed local URL in your browser.
 
 ## Files
 

--- a/mesa/examples/basic/boid_flockers/Readme.md
+++ b/mesa/examples/basic/boid_flockers/Readme.md
@@ -8,11 +8,15 @@ This model tests Mesa's continuous space feature, and uses numpy arrays to repre
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
 
 
 ## Files

--- a/mesa/examples/basic/boltzmann_wealth_model/Readme.md
+++ b/mesa/examples/basic/boltzmann_wealth_model/Readme.md
@@ -8,11 +8,15 @@ As the model runs, the distribution of wealth among agents goes from being perfe
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
 
 ## Files
 

--- a/mesa/examples/basic/conways_game_of_life/Readme.md
+++ b/mesa/examples/basic/conways_game_of_life/Readme.md
@@ -9,11 +9,15 @@ The "game" is a zero-player game, meaning that its evolution is determined by it
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
 
 
 

--- a/mesa/examples/basic/schelling/Readme.md
+++ b/mesa/examples/basic/schelling/Readme.md
@@ -8,11 +8,15 @@ By default, the number of similar neighbors the agents need to be happy is set t
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
 
 
 ## Files

--- a/mesa/examples/basic/virus_on_network/Readme.md
+++ b/mesa/examples/basic/virus_on_network/Readme.md
@@ -17,11 +17,15 @@ JavaScript library used in this example to render the network: [d3.js](https://d
 
 ## How to Run
 
-Assuming Mesa is already installed, run the example with:
+Install Mesa with recommended dependencies:
+
+pip install "mesa[rec]"
+
+Then run the example:
 
 solara run app.py
 
-Then open the displayed local URL in your browser.
+Open the displayed local URL in your browser.
 
 
 ## Files


### PR DESCRIPTION
This PR standardizes the **"How to Run" instructions** across multiple Mesa example READMEs.

## Changes

* Removed installation steps from individual examples.
* Simplified run instructions to assume **Mesa is already installed**.
* Updated examples to use a consistent command:
         solara run app.py

Following maintainer feedback, this consolidates the documentation updates into a single PR and ensures consistent run instructions across examples.
