### PR TITLE
Fix typos and grammar in first model tutorial

### DIFF
--- a/docs/tutorials/0_first_model.ipynb
+++ b/docs/tutorials/0_first_model.ipynb
@@ -35,7 +35,7 @@
     "This is a simulated agent-based economy. In an agent-based economy, the behavior of an individual economic agent, such as a consumer or producer, is studied in a market environment.\n",
     "This model is drawn from the field econophysics, specifically a paper prepared by Drăgulescu et al. for additional information on the modeling assumptions used in this model. [Drăgulescu, 2002].\n",
     "\n",
-    "The assumption that govern this model are:\n",
+    "The assumptions that govern this model are:\n",
     "\n",
     "1. There are some number of agents.\n",
     "2. All agents begin with 1 unit of money.\n",
@@ -102,7 +102,7 @@
     "\n",
     " This tutorial is written in [Jupyter](http://jupyter.org) to facilitate the explanation portions. \n",
     "\n",
-    "Start Jupyter form the command line:\n",
+    "Start Jupyter from the command line:\n",
     "\n",
     "```bash\n",
     "jupyter lab\n",
@@ -260,7 +260,7 @@
     "\n",
     "    def step(self):\n",
     "        \"\"\"Advance the model by one step.\"\"\"\n",
-    "        # This function psuedo-randomly reorders the list of agent objects and\n",
+    "        # This function pseudo-randomly reorders the list of agent objects\n",
     "        # then iterates through calling the function passed in as the parameter\n",
     "        self.agents.shuffle_do(\"say_hi\")"
    ]


### PR DESCRIPTION
This PR fixes a few minor typos and grammar issues in the Boltzmann Wealth Model tutorial.

Changes include:
- Corrected "form" → "from"
- Corrected "psuedo-randomly" → "pseudo-randomly"
- Corrected grammar: "assumption" → "assumptions"

These are small documentation improvements to make the tutorial clearer for new users.