### PR TITLE
Enhancement #3541: Add Grid.available_cells and select_random_availab…

### DIFF
--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -331,7 +331,7 @@ class Grid(DiscreteSpace[T]):
         Example::
 
             # Place an agent in any non-full cell
-            agent.move_to(grid.select_random_not_full_cell())
+            agent.move_to(grid.select_random_cell_with_capacity())
 
             # Count how many cells still have room
             len(list(grid.available_cells))

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1426,7 +1426,7 @@ def test_select_random_available_cell_not_full(factory) -> None:
     for cell in grid._celllist[:half]:
         for _ in range(2):
             make_agent(model).move_to(cell)
-    chosen = grid.select_random_not_full_cell()
+    chosen = grid.select_random_cell_with_capacity()
     assert not chosen.is_full
 
 
@@ -1438,7 +1438,7 @@ def test_select_random_available_cell_raises_when_all_full(factory) -> None:
     for cell in grid._celllist:
         make_agent(model).move_to(cell)
     with pytest.raises(IndexError, match="No available cells"):
-        grid.select_random_not_full_cell()
+        grid.select_random_cell_with_capacity()
 
 
 @pytest.mark.parametrize("factory", GRID_FACTORIES)
@@ -1451,7 +1451,7 @@ def test_select_random_available_cell_consistent_with_available_cells(factory) -
             make_agent(model).move_to(cell)
     available_set = set(grid.cells_with_capacity)
     for _ in range(30):
-        chosen = grid.select_random_not_full_cell()
+        chosen = grid.select_random_cell_with_capacity()
         assert chosen in available_set
 
 


### PR DESCRIPTION
## Summary

Closes #3541

Adds two new methods to `Grid` that make the `capacity` parameter 
usable proactively. The existing `empties` / `select_random_empty_cell()` 
API only tracks cells with zero agents. Once any agent enters a cell, 
`cell.empty` is `False` — even if `capacity=5` and 4 slots remain.

## Changes — `mesa/discrete_space/grid.py`

### `Grid.available_cells` (new property)
Returns a `CellCollection` of all cells where `not cell.is_full`.

### `Grid.select_random_available_cell()` (new method)
Uses the same two-phase O(1) heuristic as `select_random_empty_cell()`.
Raises `IndexError` with a clear message if all cells are at capacity.
```python
# Place agent in any non-full cell
agent.move_to(grid.select_random_available_cell())

# Count cells that still have room
len(list(grid.available_cells))
```

## Tests — `tests/discrete_space/test_grid_capacity.py`

27 tests parametrized across `OrthogonalMooreGrid`, 
`OrthogonalVonNeumannGrid`, and `HexGrid`:

| Section | Coverage |
|---|---|
| CellFullException | `move_to`, `.cell=`, `capacity=None`, vacate-and-refill |
| `available_cells` | Empty grid, full excluded, partial fill, dynamic update |
| `select_random_available_cell` | Non-full result, 30-sample consistency, `IndexError` |
| `Cell.is_full` | Unlimited, 0→1→2→1 transitions, direct `add_agent` |



---

## GSoC contributor checklist

### Context & motivation
While experimenting with different grid types and capacity settings I kept
running into the same limitation: `grid.empties` and `select_random_empty_cell()`
become useless the moment any agent steps into a cell — even when capacity is
explicitly set to 5 or 10. There was no built-in way to ask the grid "give me
a cell that still has free slots", which felt like a fundamental missing piece
for any model where agents share cells up to a limit. I opened issue #3541 and
implemented the fix in this PR.

### What I learned
`cell.empty` and `cell.is_full` answer two completely different questions, and
conflating them is a real source of bugs in capacity-bounded models. My first
implementation mirrored the `empty` property layer with a `full` layer — it
looked clean but profiling showed it added measurable overhead in move-heavy
models (numpy writes on every `add_agent` / `remove_agent` call). Dropping
the persistent layer and computing `not_full_cells` lazily on demand was both
simpler to reason about and faster. Good reminder that less state is often better.

### Learning repo
🔗 My learning repo: https://github.com/DipayanDasgupta/GSoC-learning-space
🔗 Relevant model(s): https://github.com/DipayanDasgupta/GSoC-learning-space/tree/main/models/boltzmann_wealth

### Readiness checks
- [done] This PR addresses an agreed-upon problem (linked issue #3541, maintainer-approved)
- [done] I have read the contributing guide and deprecation policy
- [] I have performed a self-review (comments posted in Files changed tab)
- [done ] Another GSoC contributor has reviewed this PR: @codebreaker32
- [done] Tests pass locally (`pytest tests/discrete_space/`)
- [doone] Code is formatted (`ruff check . --fix`)
- [done] Docstrings included inline; no separate docs needed for this internal API