### PR TITLE
add rescale helper to scenario 

### DIFF
--- a/mesa/experimental/scenarios/scenario.py
+++ b/mesa/experimental/scenarios/scenario.py
@@ -21,8 +21,7 @@ def rescale_samples(
     *,
     inplace: bool = False,
 ) -> np.ndarray:
-    """
-    Rescale samples from the unit interval [0, 1] to parameter ranges.
+    """Rescale samples from the unit interval [0, 1] to parameter ranges.
 
     Parameters
     ----------
@@ -35,17 +34,16 @@ def rescale_samples(
         If False (default), a new array containing the rescaled samples
         is returned.
 
-    Returns
+    Returns:
     -------
     ndarray (n, d)
         Rescaled samples.
 
-    Notes
+    Notes:
     -----
     The rescaling is performed using NumPy broadcasting. If ``inplace=True``,
     the original ``samples`` array is overwritten.
     """
-
     samples = np.asarray(samples)
     ranges = np.asarray(ranges)
 

--- a/tests/experimental/test_scenarios.py
+++ b/tests/experimental/test_scenarios.py
@@ -309,7 +309,7 @@ def test_rescale_bounds_mapping():
 
     expected = np.array([[5, 2]])
     assert np.allclose(scaled, expected)
-    
+
 
 def test_rescale_inplace():
     """Check that inplace=True modifies the original array."""


### PR DESCRIPTION
### Approval Link
https://github.com/mesa/mesa/discussions/3483#discussioncomment-16131083

### Summary
Add a small `rescale(samples, ranges)` helper for mapping samples from [0,1] to user defined parameter ranges.

Discussed in #3483 

### Motive
When generating experiments via Scenario.from_ndarray, users often sample parameters on [0,1] and then need to transform them into meaningful parameter ranges. This helper provides that transformation in a small, vectorized utility.

### Implementation
Adds a vectorized rescale function in scenario.py. Includes basic validation and tests covering scaling correctness, dimension mismatches, and edge cases.

### Usage Examples
````python
samples = qmc.LatinHypercube(d=3).random(100)

ranges = np.array([
    [0, 10],
    [5, 20],
    [-1, 1]
])

scaled = rescale(samples, ranges)

scenarios = Scenario.from_ndarray(scaled, ["a", "b", "c"], rng=42)
````
---

## GSoC contributor checklist

### Context & motivation
In #3483 , @quaquel suggested adding a small helper to rescale QMC samples from [0,1] to parameter ranges. Since I was already participating in that discussion around the experiment workflow and scenarios, I picked this up and implemented the helper so sampled parameters can be directly passed into `Scenario.from_ndarray`.

### What I learned
Most of the learning here actually came from the discussion rather than the implementation. Reading through the design ideas around scenarios, sampling, and experiment execution helped me understand how these pieces are expected to fit together in the new workflow.

### Readiness checks
- [x] This PR addresses an agreed-upon problem
- [x] I have read the [contributing guide](https://github.com/mesa/mesa/blob/main/CONTRIBUTING.md) and [deprecation policy](https://github.com/mesa/mesa/blob/main/CONTRIBUTING.md#deprecation-policy)
- [x] I have performed a self-review: I reviewed my own PR as if I were a reviewer and left comments on anything that needs explanation
- [ ] Another GSoC contributor has reviewed this PR: @<!-- tag reviewer here -->
- [x] Tests pass locally (`pytest --cov=mesa tests/`)
- [x] Code is formatted (`ruff check . --fix`)
- [x] If applicable: documentation, examples, and/or migration guide are updated