### PR TITLE
Refactor _add_agent in ContinuousSpace

### DIFF
--- a/mesa/experimental/continuous_space/continuous_space.py
+++ b/mesa/experimental/continuous_space/continuous_space.py
@@ -113,18 +113,18 @@ class ContinuousSpace:
         index = self._n_agents
         self._n_agents += 1
 
-        if self._agent_positions.shape[0] <= index:
-            # we are out of space
-            fraction = 0.2  # we add 20%  Fixme
-            n = round(fraction * self._n_agents, None)
-            self._agent_positions = np.vstack(
-                [
-                    self._agent_positions,
-                    np.empty(
-                        (n, self.dimensions.shape[0]),
-                    ),
-                ]
+        current_capacity = self._agent_positions.shape[0]
+        if current_capacity <= index:
+            # expand using pre-allocation with a growth factor
+            growth_factor = 0.2
+            n = max(int(current_capacity * growth_factor), 20)
+            new_capacity = current_capacity + n
+
+            new_positions = np.empty(
+                (new_capacity, self.dimensions.shape[0]), dtype=float
             )
+            new_positions[:current_capacity] = self._agent_positions
+            self._agent_positions = new_positions
 
         agent._mesa_index = index
         self._index_to_agent[index] = agent


### PR DESCRIPTION
> [!IMPORTANT]
> For enhancements and new features, include the issue/discussion where a maintainer approved this work before opening a PR. Unapproved feature/enhancement PRs may be closed.

### Pre-PR Checklist
- [x] I linked an issue/discussion where a maintainer approved this enhancement/feature for implementation.

### Approval Link
#3548 

### Summary
This PR optimizes the memory reallocation strategy inside `ContinuousSpace._add_agent` by replacing the existing `np.vstack` call with a faster array pre-allocation and slice assignment approach.

### Motive
See #3548 

### Implementation
Replaced `np.vstack` with a pre-allocation strategy and slice assignment

### Usage Examples
It remains same as this is an internal refactor


### Additional Notes
Closes #3548 


---

## GSoC contributor checklist

### Context & motivation
This is my prerequisite effort to make continuous space and continuous space agent faster or optimise wherever there is scope before we start working on stacked spaces.


### What I learned
See #2585 and #3458 for background



### Learning repo
<!-- Link to your fork of GSoC-learning-space, and to any specific models relevant to this PR -->
🔗 My learning repo: https://github.com/codebreaker32/GSoC-learning-space
🔗 Relevant model(s): NA

### Readiness checks
- [x] This PR addresses an agreed-upon problem (linked issue or discussion with maintainer approval), **or** is a small/trivial fix
- [x] I have read the [contributing guide](https://github.com/mesa/mesa/blob/main/CONTRIBUTING.md) and [deprecation policy](https://github.com/mesa/mesa/blob/main/CONTRIBUTING.md#deprecation-policy)
- [x] I have performed a self-review: I reviewed my own PR as if I were a reviewer and left comments on anything that needs explanation
- [ ] Another GSoC contributor has reviewed this PR: @<!-- tag reviewer here -->
- [x] Tests pass locally (`pytest --cov=mesa tests/`)
- [x] Code is formatted (`ruff check . --fix`)
- [x] If applicable: documentation, examples, and/or migration guide are updated
