### PR TITLE
docs: auto-detect mesa version in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 #
 # Mesa documentation build configuration file, created by


### PR DESCRIPTION
Closes #3507

## What this PR does
- Replaces hardcoded version (`"0.5"`) in docs/conf.py with 
  automatic version detection using 'importlib.metadata'
- The docs will now always display the correct installed version 
  of Mesa, so users can confirm they are reading the right version
