### PR TITLE
perf:lazy KDTree rebuild + tests

### DIFF
--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -105,7 +105,7 @@ class Network(DiscreteSpace[Cell]):
             self._kdtree = KDTree(positions)
         else:
             self._kdtree = None
-        self._kdtree_dirty = False  #set to false after rebuilding  every time
+        self._kdtree_dirty = False  # set to false after rebuilding  every time
 
     def _connect_cells(self) -> None:
         for cell in self.all_cells:
@@ -134,8 +134,7 @@ class Network(DiscreteSpace[Cell]):
         Raises:
             ValueError: If network is not spatial
         """
-        
-        #build the kd-tree once if the _kdtree_dirty flag is true 
+        # build the kd-tree once if the _kdtree_dirty flag is true
 
         if self._kdtree_dirty:
             self._rebuild_kdtree()

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -105,7 +105,7 @@ class Network(DiscreteSpace[Cell]):
             self._kdtree = KDTree(positions)
         else:
             self._kdtree = None
-        self._kdtree_dirty = False  #set to false after rebuilding  everytime
+        self._kdtree_dirty = False  #set to false after rebuilding  every time
 
     def _connect_cells(self) -> None:
         for cell in self.all_cells:

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -68,6 +68,7 @@ class Network(DiscreteSpace[Cell]):
             )
 
         self._kdtree_cells = []
+        self._kdtree_dirty = False  # True when KDTree needs a rebuild.
         positions_for_tree = []
 
         # Create cells and gather KD-Tree data simultaneously
@@ -104,6 +105,7 @@ class Network(DiscreteSpace[Cell]):
             self._kdtree = KDTree(positions)
         else:
             self._kdtree = None
+        self._kdtree_dirty = False  #set to false after rebuilding  everytime
 
     def _connect_cells(self) -> None:
         for cell in self.all_cells:
@@ -118,6 +120,11 @@ class Network(DiscreteSpace[Cell]):
 
         Only works for spatial networks (networks with node positions).
 
+        Note:
+            The KD-Tree index is rebuilt lazily. If cells were added or removed
+            since the previous spatial query, this method rebuilds the KD-Tree
+            before performing the nearest-neighbor lookup.
+
         Args:
             position: Physical position [x, y]
 
@@ -127,6 +134,12 @@ class Network(DiscreteSpace[Cell]):
         Raises:
             ValueError: If network is not spatial
         """
+        
+        #build the kd-tree once if the _kdtree_dirty flag is true 
+
+        if self._kdtree_dirty:
+            self._rebuild_kdtree()
+
         if getattr(self, "_kdtree", None) is None:
             raise ValueError("No nodes with positions found in network")
 
@@ -140,17 +153,16 @@ class Network(DiscreteSpace[Cell]):
 
         if cell._position is not None:
             self._kdtree_cells.append(cell)
-            self._rebuild_kdtree()
+            self._kdtree_dirty = True
 
     def remove_cell(self, cell: Cell):
         """Remove a cell from the space."""
         super().remove_cell(cell)
         self.G.remove_node(cell.coordinate)
-        self._rebuild_kdtree()
 
-        if cell._position is not None:
+        if cell._position is not None and cell in self._kdtree_cells:
             self._kdtree_cells.remove(cell)
-            self._rebuild_kdtree()
+            self._kdtree_dirty = True
 
     def add_connection(self, cell1: Cell, cell2: Cell):
         """Add a connection between the two cells."""

--- a/tests/discrete_space/test_spatial_lookups.py
+++ b/tests/discrete_space/test_spatial_lookups.py
@@ -2,6 +2,7 @@
 
 import math
 import random
+from unittest.mock import patch
 
 import networkx as nx
 import numpy as np
@@ -122,6 +123,78 @@ def test_network_lookups():
     )
     assert net_layout._cells[0].position is not None
     assert net_layout.find_nearest_cell([0, 0]) is not None
+
+
+def test_network_lazy_rebuild_deferred_until_query():
+    
+    """KDTree rebuild should be deferred until nearest-cell query."""
+
+    G = nx.Graph()  # noqa: N806
+    G.add_nodes_from([0, 1])
+    net = Network(G, layout={0: (0, 0), 1: (10, 0)}, random=random.Random(42))
+
+    with patch.object(net, "_rebuild_kdtree", wraps=net._rebuild_kdtree) as rebuild_spy:
+        new_cell = Cell(
+            coordinate=99, position=np.array([100, 100]), random=random.Random(42)
+        )
+        net.add_cell(new_cell)
+
+        assert net._kdtree_dirty is True
+        assert rebuild_spy.call_count == 0
+
+        found = net.find_nearest_cell([101, 101])
+        assert found.coordinate == 99
+        assert rebuild_spy.call_count == 1
+        assert net._kdtree_dirty is False
+
+
+def test_network_lazy_rebuild_batches_mutations_to_single_rebuild():
+
+    """Multiple mutations should trigger a single rebuild at first query."""
+
+    G = nx.Graph()  # noqa: N806
+    G.add_nodes_from([0, 1])
+    net = Network(G, layout={0: (0, 0), 1: (10, 0)}, random=random.Random(42))
+
+    with patch.object(net, "_rebuild_kdtree", wraps=net._rebuild_kdtree) as rebuild_spy:
+        cell_a = Cell(
+            coordinate=99, position=np.array([100, 100]), random=random.Random(42)
+        )
+        cell_b = Cell(
+            coordinate=100, position=np.array([200, 200]), random=random.Random(42)
+        )
+        net.add_cell(cell_a)
+        net.add_cell(cell_b)
+        net.remove_cell(cell_a)
+
+        assert net._kdtree_dirty is True
+        assert rebuild_spy.call_count == 0
+
+        found = net.find_nearest_cell([201, 201])
+        assert found.coordinate == 100
+        assert rebuild_spy.call_count == 1
+        assert net._kdtree_dirty is False
+
+
+def test_network_non_spatial_cell_mutation_does_not_dirty_kdtree():
+
+    """Mutating non-spatial cells should not mark KDTree dirty."""
+
+    G = nx.Graph()  # noqa: N806
+    G.add_nodes_from([0, 1])
+    net = Network(G, layout={0: (0, 0), 1: (10, 0)}, random=random.Random(42))
+
+    with patch.object(net, "_rebuild_kdtree", wraps=net._rebuild_kdtree) as rebuild_spy:
+        non_spatial = Cell(coordinate=999, position=None, random=random.Random(42))
+        net.add_cell(non_spatial)
+        net.remove_cell(non_spatial)
+
+        assert net._kdtree_dirty is False
+        assert rebuild_spy.call_count == 0
+
+        # Query should not trigger rebuild because no spatial mutation happened.
+        _ = net.find_nearest_cell([1, 0])
+        assert rebuild_spy.call_count == 0
 
 
 def test_all_spaces():

--- a/tests/discrete_space/test_spatial_lookups.py
+++ b/tests/discrete_space/test_spatial_lookups.py
@@ -126,9 +126,7 @@ def test_network_lookups():
 
 
 def test_network_lazy_rebuild_deferred_until_query():
-    
     """KDTree rebuild should be deferred until nearest-cell query."""
-
     G = nx.Graph()  # noqa: N806
     G.add_nodes_from([0, 1])
     net = Network(G, layout={0: (0, 0), 1: (10, 0)}, random=random.Random(42))
@@ -149,9 +147,7 @@ def test_network_lazy_rebuild_deferred_until_query():
 
 
 def test_network_lazy_rebuild_batches_mutations_to_single_rebuild():
-
     """Multiple mutations should trigger a single rebuild at first query."""
-
     G = nx.Graph()  # noqa: N806
     G.add_nodes_from([0, 1])
     net = Network(G, layout={0: (0, 0), 1: (10, 0)}, random=random.Random(42))
@@ -177,9 +173,7 @@ def test_network_lazy_rebuild_batches_mutations_to_single_rebuild():
 
 
 def test_network_non_spatial_cell_mutation_does_not_dirty_kdtree():
-
     """Mutating non-spatial cells should not mark KDTree dirty."""
-
     G = nx.Graph()  # noqa: N806
     G.add_nodes_from([0, 1])
     net = Network(G, layout={0: (0, 0), 1: (10, 0)}, random=random.Random(42))


### PR DESCRIPTION
### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
Primary: fixes stale/redundant rebuild behavior in `remove_cell` .
Secondary: lazy rebuild is the implementation strategy to avoid repeated unnecessary rebuilds.

Fixes a stale/redundant KDTree rebuild issue in `NetworkGrid` where `remove_cell()` could trigger an eager rebuild on outdated `_kdtree_cells` data. As part of the fix, `KDTree` rebuilds are now deferred (lazy) until `find_nearest_cell()` is actually called, eliminating redundant work during bulk mutations.

### Bug / Issue
#3700 In the previous implementation,` add_cell()` and `remove_cell()` both triggered eager `KDTree` rebuilds. In `remove_cell()`, this could result in a rebuild on stale or already-modified `_kdtree_cells` data, causing a double/redundant rebuild. 
### Implementation
1.Added `self._kdtree_dirty` = False flag in `__init__`.
2.`_rebuild_kdtree()` now resets `_kdtree_dirty = False ` after every rebuild.
3.`remove_cell()`: Removes from `_kdtree_cells` and sets `_kdtree_dirty = True`. Eager rebuild removed, eliminating the previous stale/redundant rebuild on already-modified `_kdtree_cells` data.
4.`add_cell()`: For spatial cells, appends to `_kdtree_cells`  and sets `_kdtree_dirty = True` .
5.`find_nearest_cell()` checks the dirty flag and triggers a rebuild on demand before querying.

### Testing
`tests/discrete_space/test_spatial_lookups.py`
Three new tests added using `unittest.mock.patch.object(..., wraps=...)` to spy on `_rebuild_kdtree` call count:

`test_network_lazy_rebuild_deferred_until_query`  verifies no rebuild occurs during mutation-only phase; rebuild triggered only on first`find_nearest_cell(` call.
`test_network_lazy_rebuild_batches_mutations_to_single_rebuild`  verifies multiple mutations result in exactly one rebuild on query, not one per mutation.
`test_network_non_spatial_cell_mutation_does_not_dirty_kdtree ` verifies that adding/removing non-spatial cells does not set the dirty flag or trigger any rebuild
### Additional Notes
This change is purely a fix to rebuild timing. No public API changes. Graph topology updates remain eager and unaffected. The lazy rebuild is an internal optimization that emerges naturally from fixing the stale rebuild path in `remove_cell()`.
