### PR TITLE
fixed:_get_interval and added the tests

### DIFF
--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -260,11 +260,16 @@ class EventGenerator:
         return self._current_event.time
 
     def _get_interval(self) -> float | int:
-        """Get the next interval value."""
+        """Return the next interval value from the schedule.
+
+        Raises:
+            ValueError: If a callable interval returns a negative value or zero.
+            
+        """
         if callable(self.schedule.interval):
             interval = self.schedule.interval(self.model)
-            if interval < 0:
-                raise ValueError(f"Interval must be > 0, got {interval}")
+            if interval <= 0:
+                raise ValueError(f"Interval must be strictly > 0, got {interval}")
             return interval
         return self.schedule.interval
 

--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -264,7 +264,7 @@ class EventGenerator:
 
         Raises:
             ValueError: If a callable interval returns a negative value or zero.
-            
+
         """
         if callable(self.schedule.interval):
             interval = self.schedule.interval(self.model)

--- a/tests/time/test_events.py
+++ b/tests/time/test_events.py
@@ -613,6 +613,23 @@ class TestEventGeneratorExecution:
         with pytest.raises(ValueError):
             model.run_for(3)
 
+    def test_callable_interval_zero_raises_in_get_interval(self, setup):
+        """Test if callable interval raises ValueError immediately in _get_interval."""
+        model, fn = setup
+        gen = EventGenerator(model, fn, Schedule(start=1, interval=lambda m: 0))
+
+        with pytest.raises(ValueError):
+            gen._get_interval()
+
+    def test_callable_interval_zero_raises(self, setup):
+        """Test if callable interval raises exception if return is zero."""
+        model, fn = setup
+        gen = EventGenerator(model, fn, Schedule(start=1, interval=lambda m: 0))
+        gen.start()
+
+        with pytest.raises(ValueError):
+            model.run_for(3)
+
     def test_functools_partial(self, setup):
         """Test using functools.partial for arguments."""
         model, fn = setup


### PR DESCRIPTION
> [!NOTE]
> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.

### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
Fixes inconsistent interval validation in `EventGenerator` for callable schedules.  
Previously, callable intervals could return `0` without error, while fixed numeric intervals already rejected `<= 0`.  
This could lead to repeated rescheduling at the same simulation timestamp and a potential infinite loop in event processing.

### Bug / Issue
Closes #3702 

`Schedule.__post_init__` enforces `interval > 0` for non-callable values, but `EventGenerator._get_interval()` only partially validated callable results.  
Expected behavior: callable and non-callable intervals should follow the same rule (`> 0`).  
Actual behavior: a callable returning `0` was accepted.

### Implementation
- Updated `EventGenerator._get_interval()` in `mesa/time/events.py`:
  - validation now raises `ValueError` when callable interval returns `<= 0`
  - error message clarifies interval must be strictly greater than zero
- Updated docstring for `_get_interval()` to document raised `ValueError`.

### Testing
Added regression tests in `tests/time/test_events.py`:
- `test_callable_interval_zero_raises_in_get_interval`
  - directly verifies `_get_interval()` raises `ValueError` for callable returning `0`
- `test_callable_interval_zero_raises`
  - verifies runtime path raises `ValueError` during model execution/rescheduling

These complement the existing negative-interval test.

### Additional Notes
- Scope is intentionally minimal and limited to validation consistency for callable intervals.
- This change prevents zero-interval rescheduling from creating a potential infinite same-timestamp event loop.
